### PR TITLE
fix(web): format number for export availability display

### DIFF
--- a/web/src/components/planner/PlannerFactoryExports.vue
+++ b/web/src/components/planner/PlannerFactoryExports.vue
@@ -45,7 +45,7 @@
                 class="ml-2"
                 color="green"
               >
-                <b>{{ getDifference(factory, surplus.productId) }}</b>&nbsp;available for export
+                <b>{{ formatNumber(getDifference(factory, surplus.productId)) }}</b>&nbsp;available for export
               </v-chip>
             </span>
             <span


### PR DESCRIPTION
fixes #83 

<HR>

This pull request includes a change to the `PlannerFactoryExports.vue` file to improve the display of numerical differences by formatting the numbers.