### PR TITLE
Add Factory tabs

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="overflow: hidden">
 
 <head>
     <meta charset="UTF-8" />

--- a/web/src/components.d.ts
+++ b/web/src/components.d.ts
@@ -33,7 +33,8 @@ declare module 'vue' {
     RecipeSearchItem: typeof import('./components/recipes/RecipeSearchItem.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
-    Sharing: typeof import('./components/Sharing.vue')['default']
+    ShareButton: typeof import('./components/ShareButton.vue')['default']
+    TabNavigation: typeof import('./components/TabNavigation.vue')['default']
     Todo: typeof import('./components/graph/Todo.vue')['default']
   }
 }

--- a/web/src/components/Navigation.vue
+++ b/web/src/components/Navigation.vue
@@ -20,7 +20,6 @@
       />
     </v-tabs>
     <ko-fi />
-    <sharing />
     <join-discord text="Discord" />
   </v-toolbar>
 </template>

--- a/web/src/components/Navigation.vue
+++ b/web/src/components/Navigation.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script setup lang="ts">
-  const tab = null
+  const tab = ref(null)
   const items = [
     { title: 'Planner', icon: 'fas fa-ruler-triangle', href: '/' },
     { title: 'Graph (WIP)', icon: 'fas fa-project-diagram', href: '/graph' },

--- a/web/src/components/ShareButton.vue
+++ b/web/src/components/ShareButton.vue
@@ -1,14 +1,11 @@
 <template>
   <v-btn
-    class="ml-2"
-    color="blue"
-    :disabled="creating"
+    color="blue rounded"
+    icon="fas fa-share-alt"
+    size="small"
     variant="flat"
     @click="createShareLink"
-  >
-    <i class="fas fa-share-alt" /><span class="ml-2">Share Plan</span>
-  </v-btn>
-
+  />
   <v-snackbar v-model="toast" color="success" top>
     Link copied to clipboard!
   </v-snackbar>

--- a/web/src/components/ShareButton.vue
+++ b/web/src/components/ShareButton.vue
@@ -15,27 +15,27 @@
   import { config } from '@/config/config'
   import { storeToRefs } from 'pinia'
   import { useAppStore } from '@/stores/app-store'
-  import { Factory } from '@/interfaces/planner/FactoryInterface'
+  import { FactoryTab } from '@/interfaces/planner/FactoryInterface'
   import { ShareDataCreationResponse } from '@/interfaces/ShareDataInterface'
 
   // Get user auth stuff from the app store
   const appStore = useAppStore()
-  const { token, factories } = storeToRefs(appStore)
+  const { token, currentFactoryTab } = storeToRefs(appStore)
 
   const apiUrl = config.apiUrl
   const toast = ref(false)
   const creating = ref(false)
 
   const createShareLink = async () => {
-    if (!factories.value || factories.value.length === 0) {
+    if (!currentFactoryTab.value.factories || currentFactoryTab.value.factories.length === 0) {
       alert('No factory data to share!')
       return
     }
 
-    await handleCreation(factories.value)
+    await handleCreation(currentFactoryTab.value)
   }
 
-  const handleCreation = async (factoryData: Factory[]) => {
+  const handleCreation = async (factoryTabData: FactoryTab) => {
     creating.value = true
     try {
       const response = await fetch(`${apiUrl}/share`, {
@@ -44,7 +44,7 @@
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token.value}`,
         },
-        body: JSON.stringify(factoryData),
+        body: JSON.stringify(factoryTabData),
       })
       if (response.ok) {
         const data: ShareDataCreationResponse = await response.json()

--- a/web/src/components/ShareButton.vue
+++ b/web/src/components/ShareButton.vue
@@ -1,6 +1,7 @@
 <template>
   <v-btn
     color="blue rounded"
+    :disabled="creating"
     icon="fas fa-share-alt"
     size="small"
     variant="flat"

--- a/web/src/components/TabNavigation.vue
+++ b/web/src/components/TabNavigation.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-toolbar class="border-t-md" dark density="compact">
+    <div class="border-t-md d-flex bg-grey-darken-3 align-center" density="compact">
       <v-tabs
         v-model="appStore.currentFactoryTabIndex"
         color="deep-orange"
@@ -15,56 +15,34 @@
 
       </v-tabs>
       <v-btn
+        color="grey-darken-3"
         icon="fas fa-plus"
         size="x-small"
+        variant="flat"
         @click="appStore.addTab()"
       />
-    </v-toolbar>
+    </div>
 
-    <v-toolbar class="bg-grey-darken-2 px-2" dark density="compact">
-      <template #prepend>
-        <v-text-field
-          v-if="isEditingName"
-          density="compact"
-          hide-details
-          :value="appStore.currentFactoryTab.name"
-          variant="outlined"
-          width="300"
-        />
-        <span v-else>{{ appStore.currentFactoryTab.name }}</span>
+    <div class="bg-grey-darken-2 py-1 px-2 d-flex align-center justify-space-between" dark density="compact">
+      <input
+        v-model.lazy="appStore.currentFactoryTab.name"
+        class="pa-1 rounded tab-name"
+        @keyup.enter="onEnterTabName"
+      >
+
+      <div class="d-flex align-center h-100 ga-2">
+        <ShareButton />
         <v-btn
-          v-if="isEditingName"
-          class="ml-2"
-          color="green rounded"
-          icon=" fas fa-check"
+          v-if="appStore.factoryTabs.length > 1"
+          color="red rounded"
+          icon="fas fa-trash"
           size="small"
           variant="flat"
-          @click="isEditingName = !isEditingName"
+          @click="appStore.removeCurrentTab()"
         />
-        <v-btn
-          v-else
-          class="ml-2"
-          color="grey-darken-2"
-          icon="fas fa-pen"
-          size="x-small"
-          variant="flat"
-          @click="isEditingName = !isEditingName"
-        />
-      </template>
-
-      <ShareButton />
-      <v-btn
-        v-if="appStore.factoryTabs.length > 1"
-        class="ml-2"
-        color="red rounded"
-        icon="fas fa-trash"
-        size="small"
-        variant="flat"
-        @click="onClickRemoveTab"
-      />
-    </v-toolbar>
+      </div>
+    </div>
   </div>
-
 </template>
 
 <script setup lang="ts">
@@ -72,10 +50,18 @@
 
   const appStore = useAppStore()
 
-  const isEditingName = ref(false)
-
-  const onClickRemoveTab = () => {
-    appStore.removeTab(appStore.currentFactoryTab.id)
+  const onEnterTabName = (event: KeyboardEvent) => {
+    (event.target as HTMLInputElement).blur()
   }
-
 </script>
+
+<style lang="scss" scoped>
+.tab-name {
+  transition: background-color 0.3s;
+
+  &:hover {
+    cursor: pointer;
+    background-color: #535353;
+  }
+}
+</style>

--- a/web/src/components/TabNavigation.vue
+++ b/web/src/components/TabNavigation.vue
@@ -1,0 +1,76 @@
+<template>
+  <div>
+    <v-toolbar class="border-t-md" dark density="compact">
+      <v-tabs
+        v-model="tab"
+        color="deep-orange"
+      >
+        <v-tab
+          v-for="item in items"
+          :key="item.name"
+          class="text-none"
+          :text="item.name"
+          :value="item"
+        />
+
+      </v-tabs>
+      <v-btn
+        icon="fas fa-plus"
+        size="x-small"
+      />
+    </v-toolbar>
+
+    <v-toolbar class="bg-grey-darken-2 px-2" dark density="compact">
+      <template #prepend>
+        <v-text-field
+          v-if="isEditingName"
+          density="compact"
+          hide-details
+          :value="tab.name"
+          variant="outlined"
+          width="300"
+        />
+        <span v-else>{{ tab.name }}</span>
+        <v-btn
+          v-if="isEditingName"
+          class="ml-2"
+          color="green rounded"
+          icon=" fas fa-check"
+          size="small"
+          variant="flat"
+          @click="isEditingName = !isEditingName"
+        />
+        <v-btn
+          v-else
+          class="ml-2"
+          color="grey-darken-2"
+          icon="fas fa-pen"
+          size="x-small"
+          variant="flat"
+          @click="isEditingName = !isEditingName"
+        />
+      </template>
+
+      <ShareButton />
+      <v-btn
+        class="ml-2"
+        color="red rounded"
+        icon="fas fa-trash"
+        size="small"
+        variant="flat"
+      />
+    </v-toolbar>
+  </div>
+
+</template>
+
+<script setup lang="ts">
+  const isEditingName = ref(false)
+
+  const items = [
+    { id: 1, name: 'Default', factory: {} },
+    { id: 2, name: 'factory 1', factory: {} },
+  ]
+
+  const tab = ref(items[0])
+</script>

--- a/web/src/components/TabNavigation.vue
+++ b/web/src/components/TabNavigation.vue
@@ -2,21 +2,22 @@
   <div>
     <v-toolbar class="border-t-md" dark density="compact">
       <v-tabs
-        v-model="tab"
+        v-model="appStore.currentFactoryTabIndex"
         color="deep-orange"
       >
         <v-tab
-          v-for="item in items"
+          v-for="(item, index) in appStore.factoryTabs"
           :key="item.name"
           class="text-none"
           :text="item.name"
-          :value="item"
+          :value="index"
         />
 
       </v-tabs>
       <v-btn
         icon="fas fa-plus"
         size="x-small"
+        @click="appStore.addTab()"
       />
     </v-toolbar>
 
@@ -26,11 +27,11 @@
           v-if="isEditingName"
           density="compact"
           hide-details
-          :value="tab.name"
+          :value="appStore.currentFactoryTab.name"
           variant="outlined"
           width="300"
         />
-        <span v-else>{{ tab.name }}</span>
+        <span v-else>{{ appStore.currentFactoryTab.name }}</span>
         <v-btn
           v-if="isEditingName"
           class="ml-2"
@@ -53,11 +54,13 @@
 
       <ShareButton />
       <v-btn
+        v-if="appStore.factoryTabs.length > 1"
         class="ml-2"
         color="red rounded"
         icon="fas fa-trash"
         size="small"
         variant="flat"
+        @click="onClickRemoveTab"
       />
     </v-toolbar>
   </div>
@@ -65,12 +68,14 @@
 </template>
 
 <script setup lang="ts">
+  import { useAppStore } from '@/stores/app-store'
+
+  const appStore = useAppStore()
+
   const isEditingName = ref(false)
 
-  const items = [
-    { id: 1, name: 'Default', factory: {} },
-    { id: 2, name: 'factory 1', factory: {} },
-  ]
+  const onClickRemoveTab = () => {
+    appStore.removeTab(appStore.currentFactoryTab.id)
+  }
 
-  const tab = ref(items[0])
 </script>

--- a/web/src/components/graph/Graph.vue
+++ b/web/src/components/graph/Graph.vue
@@ -75,6 +75,10 @@
     console.log('Initial nodes:', nodes.value)
     console.log('Initial edges:', edges.value)
   })
+
+  watch(factories, () => {
+    initializeGraph()
+  })
 </script>
 
 <style>
@@ -87,7 +91,7 @@
 .notice {
   width: 1000px;
   position: absolute;
-  top: 12vh;
+  top: 16vh;
   left: calc(50% - 500px);
   z-index: 100;
 }

--- a/web/src/components/planner/Planner.vue
+++ b/web/src/components/planner/Planner.vue
@@ -462,7 +462,7 @@
 <style scoped lang="scss">
 .planner-container {
   width: 100%;
-  height: calc(100vh - 64px);
+  height: calc(100vh - 64px - 98px);
 
   @media screen and (min-width: 2000px) {
     margin-left: 10vw;
@@ -474,7 +474,6 @@
   }
 
   .two-pane-container {
-    height: calc(100vh - 112px);
     margin: 0;
   }
 
@@ -487,7 +486,7 @@
 
   .main-content {
     width: 100%;
-    max-height: calc(100vh - 64px);
+    max-height: calc(100vh - 64px - 98px);
     overflow-y: auto;
 
     @media screen and (min-width: 2000px) {

--- a/web/src/interfaces/ShareDataInterface.ts
+++ b/web/src/interfaces/ShareDataInterface.ts
@@ -1,4 +1,4 @@
-import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { FactoryTab } from '@/interfaces/planner/FactoryInterface'
 
 export interface ShareDataCreationResponse {
   status: string;
@@ -6,5 +6,5 @@ export interface ShareDataCreationResponse {
 }
 
 export interface ShareDataReturnResponse {
-  data: Factory[]
+  data: FactoryTab
 }

--- a/web/src/interfaces/planner/FactoryInterface.ts
+++ b/web/src/interfaces/planner/FactoryInterface.ts
@@ -101,3 +101,9 @@ export interface Factory {
   hasProblem: boolean
   displayOrder: number;
 }
+
+export interface FactoryTab {
+  id: string;
+  name: string;
+  factories: Factory[];
+}

--- a/web/src/layouts/default.vue
+++ b/web/src/layouts/default.vue
@@ -15,7 +15,7 @@
   const route = useRoute()
 
   const showTabNavigation = computed(() => {
-    return route.path === '/'
+    return route.path === '/' || route.path === '/graph'
   })
 
   const authRef = ref(null)

--- a/web/src/layouts/default.vue
+++ b/web/src/layouts/default.vue
@@ -2,6 +2,7 @@
   <v-app>
     <navigation @click="closeAuthTray" />
     <auth ref="authRef" />
+    <tab-navigation v-if="showTabNavigation" />
     <v-main @click="closeAuthTray">
       <router-view />
     </v-main>
@@ -9,6 +10,14 @@
 </template>
 
 <script setup lang="ts">
+  import { useRoute } from 'vue-router'
+
+  const route = useRoute()
+
+  const showTabNavigation = computed(() => {
+    return route.path === '/'
+  })
+
   const authRef = ref(null)
 
   const closeAuthTray = () => {

--- a/web/src/pages/share/[id].vue
+++ b/web/src/pages/share/[id].vue
@@ -1,26 +1,11 @@
 <template>
-  <h1 v-if="loading" class="text-center">Loading share data...</h1>
-  <v-dialog v-model="dialog" max-width="500" persistent>
-    <v-card>
-      <v-card-title class="headline">Load data?</v-card-title>
-      <v-card-text>
-        <p class="mb-2"><b>Careful!</b> You are about to load data from a share link. This will overwrite your current plan data!</p>
-        <p class="mb-2">If you wish to save your factory data before you load this, dismiss this prompt, create your own share link and save that link first.</p>
-        <p>Do you wish to continue loading the data?</p>
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer />
-        <v-btn color="red" @click="cancelLoad">No</v-btn>
-        <v-btn color="green" @click="continueWithLoad">Yes</v-btn>
-      </v-card-actions>
-    </v-card>
-  </v-dialog>
+  <h1 class="text-center">Loading share data...</h1>
 </template>
 <script setup lang="ts">
   import { ref } from 'vue'
   import { DataInterface } from '@/interfaces/DataInterface'
   import { useGameDataStore } from '@/stores/game-data-store'
-  import { Factory } from '@/interfaces/planner/FactoryInterface'
+  import { FactoryTab } from '@/interfaces/planner/FactoryInterface'
   import { config } from '@/config/config'
   import { ShareDataReturnResponse } from '@/interfaces/ShareDataInterface'
   import { useAppStore } from '@/stores/app-store'
@@ -36,9 +21,7 @@
   const appStore = useAppStore()
   const route = useRoute()
 
-  const dialog = ref(false)
-  const loading = ref(true)
-  const loadedFactoryData = ref() // The data from the share link
+  const loadedFactoryData = ref<FactoryTab>() // The data from the share link
 
   // On page load, check if there is a share ID in the URL and load the data if there is
   onMounted(() => {
@@ -47,22 +30,18 @@
 
   const loadShareData = async () => {
     const shareId = (route.params as { id: string }).id
+    if (!shareId) return
 
-    if (shareId) {
-      loadedFactoryData.value = await getDataFromShare(shareId)
-      loading.value = false
+    loadedFactoryData.value = await getDataFromShare(shareId)
 
-      console.log('appStore', appStore.factories)
-
-      if (appStore.factories.length > 0) {
-        dialog.value = true
-      } else {
-        continueWithLoad()
-      }
+    if (loadedFactoryData.value) {
+      appStore.addTab(loadedFactoryData.value)
     }
+
+    router.push('/')
   }
 
-  const getDataFromShare = async (shareId: string): Promise<Factory[] | undefined> => {
+  const getDataFromShare = async (shareId: string): Promise<FactoryTab | undefined> => {
     const apiUrl = config.apiUrl
 
     // Make an API call to get the game data from the share ID
@@ -76,9 +55,8 @@
       const data: ShareDataReturnResponse = await response.json()
       if (response.ok) {
         console.log('Data:', data)
-        loading.value = false
 
-        if (data.data.length === 0) {
+        if (!data.data) {
           alert('Failed to load share link, it contained invalid data.')
           return
         }
@@ -93,19 +71,5 @@
         alert(`Failed to load share link. Please report this error to GitHub! "${error.message}"`)
       }
     }
-
-    return []
   }
-
-  const continueWithLoad = () => {
-    appStore.setFactories(loadedFactoryData.value)
-
-    // Redirect user to the index
-    router.push('/')
-  }
-
-  const cancelLoad = () => {
-    router.push('/')
-  }
-
 </script>

--- a/web/src/pages/share/[id].vue
+++ b/web/src/pages/share/[id].vue
@@ -30,12 +30,13 @@
 
   const loadShareData = async () => {
     const shareId = (route.params as { id: string }).id
-    if (!shareId) return
 
-    loadedFactoryData.value = await getDataFromShare(shareId)
+    if (shareId) {
+      loadedFactoryData.value = await getDataFromShare(shareId)
 
-    if (loadedFactoryData.value) {
-      appStore.addTab(loadedFactoryData.value)
+      if (loadedFactoryData.value) {
+        appStore.addTab(loadedFactoryData.value)
+      }
     }
 
     router.push('/')

--- a/web/src/stores/app-store.ts
+++ b/web/src/stores/app-store.ts
@@ -1,32 +1,45 @@
 // Utilities
 import { defineStore } from 'pinia'
-import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { Factory, FactoryTab } from '@/interfaces/planner/FactoryInterface'
 import { ref, watch } from 'vue'
 
 export const useAppStore = defineStore('app', () => {
   // Define state using Composition API
-  const factories = ref<Factory[]>(JSON.parse(localStorage.getItem('factories') ?? '[]') as Factory[])
+  const factoryTabs = ref<FactoryTab[]>(JSON.parse(localStorage.getItem('factoryTabs') ?? '[]') as FactoryTab[])
+
+  if (factoryTabs.value.length === 0) {
+    factoryTabs.value = [
+      {
+        id: 'default',
+        name: 'Default',
+        // Fill the tabs from the legacy factories array if present so no data gets lost
+        factories: JSON.parse(localStorage.getItem('factories') ?? '[]'),
+      },
+    ]
+  }
+
+  const currentFactoryTabIndex = ref(0)
+  const currentFactoryTab = computed(() => factoryTabs.value[currentFactoryTabIndex.value])
+
+  const factories = computed({
+    get () {
+      return currentFactoryTab.value.factories
+    },
+    set (value) {
+      currentFactoryTab.value.factories = value
+    },
+  })
+
   const loggedInUser = ref<string>(localStorage.getItem('loggedInUser') ?? '')
   const token = ref<string>(localStorage.getItem('token') ?? '')
   const lastSave = ref<Date>(new Date(localStorage.getItem('lastSave') ?? ''))
   const lastEdit = ref<Date>(new Date(localStorage.getItem('lastEdit') ?? ''))
 
   // Watch the factories array for changes
-  watch(factories, () => {
-    localStorage.setItem('factories', JSON.stringify(factories.value))
+  watch(factoryTabs, () => {
+    localStorage.setItem('factoryTabs', JSON.stringify(factoryTabs.value))
     setLastEdit() // Update last edit time whenever the data changes, from any source.
   }, { deep: true })
-
-  // Getters
-  const getFactory = (id: number) => {
-    return factories.value.find(factory => factory.id === id)
-  }
-  const getFactories = () => {
-    return factories.value
-  }
-  const getLastEdit = () => {
-    return lastEdit.value
-  }
 
   // Define actions
   const addFactory = (factory: Factory) => {
@@ -80,16 +93,39 @@ export const useAppStore = defineStore('app', () => {
     localStorage.setItem('lastSave', lastSave.value.toISOString())
   }
 
+  const addTab = () => {
+    factoryTabs.value.push({
+      id: crypto.randomUUID(),
+      name: 'New Tab',
+      factories: [],
+    })
+
+    currentFactoryTabIndex.value = factoryTabs.value.length - 1
+  }
+
+  const removeTab = (id: string) => {
+    if (factoryTabs.value.length === 1) return
+
+    const index = factoryTabs.value.findIndex(tab => tab.id === id)
+    if (index !== -1) {
+      factoryTabs.value.splice(index, 1)
+
+      if (currentFactoryTabIndex.value === index) {
+        currentFactoryTabIndex.value = index - 1
+      }
+    }
+  }
+
   // Return state, actions, and getters
   return {
+    currentFactoryTab,
+    currentFactoryTabIndex,
+    factoryTabs,
     factories,
     loggedInUser,
     token,
     lastSave,
     lastEdit,
-    getFactory,
-    getFactories,
-    getLastEdit,
     addFactory,
     removeFactory,
     updateFactory,
@@ -98,5 +134,7 @@ export const useAppStore = defineStore('app', () => {
     setLastSave,
     setLastEdit,
     setFactories,
+    addTab,
+    removeTab,
   }
 })

--- a/web/src/stores/app-store.ts
+++ b/web/src/stores/app-store.ts
@@ -10,7 +10,7 @@ export const useAppStore = defineStore('app', () => {
   if (factoryTabs.value.length === 0) {
     factoryTabs.value = [
       {
-        id: 'default',
+        id: crypto.randomUUID(),
         name: 'Default',
         // Fill the tabs from the legacy factories array if present so no data gets lost
         factories: JSON.parse(localStorage.getItem('factories') ?? '[]'),

--- a/web/src/stores/app-store.ts
+++ b/web/src/stores/app-store.ts
@@ -41,6 +41,17 @@ export const useAppStore = defineStore('app', () => {
     setLastEdit() // Update last edit time whenever the data changes, from any source.
   }, { deep: true })
 
+  // Getters
+  const getFactory = (id: number) => {
+    return factories.value.find(factory => factory.id === id)
+  }
+  const getFactories = () => {
+    return factories.value
+  }
+  const getLastEdit = () => {
+    return lastEdit.value
+  }
+
   // Define actions
   const addFactory = (factory: Factory) => {
     factories.value.push(factory)
@@ -128,6 +139,9 @@ export const useAppStore = defineStore('app', () => {
     token,
     lastSave,
     lastEdit,
+    getFactory,
+    getFactories,
+    getLastEdit,
     addFactory,
     removeFactory,
     updateFactory,

--- a/web/src/stores/app-store.ts
+++ b/web/src/stores/app-store.ts
@@ -93,11 +93,15 @@ export const useAppStore = defineStore('app', () => {
     localStorage.setItem('lastSave', lastSave.value.toISOString())
   }
 
-  const addTab = () => {
+  const addTab = ({
+    id = crypto.randomUUID(),
+    name = 'New Tab',
+    factories = [],
+  } = {} as Partial<FactoryTab>) => {
     factoryTabs.value.push({
-      id: crypto.randomUUID(),
-      name: 'New Tab',
-      factories: [],
+      id,
+      name,
+      factories,
     })
 
     currentFactoryTabIndex.value = factoryTabs.value.length - 1

--- a/web/src/stores/app-store.ts
+++ b/web/src/stores/app-store.ts
@@ -103,17 +103,15 @@ export const useAppStore = defineStore('app', () => {
     currentFactoryTabIndex.value = factoryTabs.value.length - 1
   }
 
-  const removeTab = (id: string) => {
+  const removeCurrentTab = async () => {
     if (factoryTabs.value.length === 1) return
 
-    const index = factoryTabs.value.findIndex(tab => tab.id === id)
-    if (index !== -1) {
-      factoryTabs.value.splice(index, 1)
-
-      if (currentFactoryTabIndex.value === index) {
-        currentFactoryTabIndex.value = index - 1
-      }
+    if (factories.value.length && !window.confirm('Are you sure you want to delete this tab? This will delete all factories in it.')) {
+      return
     }
+
+    factoryTabs.value.splice(currentFactoryTabIndex.value, 1)
+    currentFactoryTabIndex.value = Math.min(currentFactoryTabIndex.value, factoryTabs.value.length - 1)
   }
 
   // Return state, actions, and getters
@@ -135,6 +133,6 @@ export const useAppStore = defineStore('app', () => {
     setLastEdit,
     setFactories,
     addTab,
-    removeTab,
+    removeCurrentTab,
   }
 })


### PR DESCRIPTION
Closes #109 

I did not add the Icon picker as the PR got a little big already

Here are my key changes:
* When opening the site the user starts with one "Default" tab
* There should be no data loss to users when this version gets deployed as the "factories" localStorage entry is used as fallback when there is no new "factoryTabs" entry
* You can add, delete, share and rename tabs
* Each tab contains its own set of factories
* When opening a share link, it gets added as a new tab
 -> share links that were created before this change will break, should I fix this?


Does it make sense to explain this functionality in the welcome modal? I'll let you decide

Please make sure to test this well before deploying, as this may break persistent data for users!