### PR TITLE
filtering out issues that are created with a label

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: New issue, add Needs Triage label
-      if: github.event.action == 'opened'
+      if: github.event.action == 'opened' && join(github.event.labels) == ''
       uses: actions/github-script@v7
       with:
         script: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/issue-management.yml` file. The change updates the condition for adding the "Needs Triage" label to new issues.