### PR TITLE
feat(workflow): Remove 'Needs Triage' label from issues after adding P1 label

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -45,6 +45,12 @@ jobs:
                 milestone: milestone.number
               });
             }
+            await github.rest.issues.removeLabel({
+              issue_number: issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Needs Triage'
+            });
           }
 
     - name: P1 Label removed, remove "High Priority" milestone


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/issue-management.yml` file to improve the issue management workflow by removing the 'Needs Triage' label from issues.