### PR TITLE
fix: Enabling parsing tests

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Build Parsing
         run: pnpm build
 
+      - name: Test Parsing
+        run: pnpm test
+
   build-backend:
     name: Build Backend
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/builds.yml` file. The change adds a new step to test the parsing after the build step in the workflow.