### PR TITLE
Power updates to use correct underclocking formula

### DIFF
--- a/web/src/utils/factory-management/buildings.ts
+++ b/web/src/utils/factory-management/buildings.ts
@@ -24,6 +24,7 @@ export const calculateBuildingRequirements = (factory: Factory, gameData: DataIn
       const buildingCount = product.amount / productInRecipe.perMin
       // When calculating the building power cost, we need to apply a special formular when overclocking or underclocking. 
       // Initially we will handle underclocking, which requires us to only run the formula on the fractional part of the building count 
+      // See the official wiki for details: https://satisfactory.wiki.gg/wiki/Clock_speed
       const wholeBuildingCount = Math.floor(buildingCount);
       const fractionalBuildingCount = buildingCount - wholeBuildingCount;
 

--- a/web/src/utils/factory-management/buildings.ts
+++ b/web/src/utils/factory-management/buildings.ts
@@ -22,7 +22,7 @@ export const calculateBuildingRequirements = (factory: Factory, gameData: DataIn
 
       const buildingData = recipe.building
       const buildingCount = product.amount / productInRecipe.perMin
-      // When calculating the building power cost, we need to apply a special formular when overclocking or underclocking. 
+      // When calculating the building power cost, we need to apply a special formula when overclocking or underclocking.
       // Initially we will handle underclocking, which requires us to only run the formula on the fractional part of the building count 
       // See the official wiki for details: https://satisfactory.wiki.gg/wiki/Clock_speed
       const wholeBuildingCount = Math.floor(buildingCount);

--- a/web/src/utils/factory-management/buildings.ts
+++ b/web/src/utils/factory-management/buildings.ts
@@ -22,12 +22,16 @@ export const calculateBuildingRequirements = (factory: Factory, gameData: DataIn
 
       const buildingData = recipe.building
       const buildingCount = product.amount / productInRecipe.perMin
+      // When calculating the building power cost, we need to apply a special formular when overclocking or underclocking. 
+      // Initially we will handle underclocking, which requires us to only run the formula on the fractional part of the building count 
+      const wholeBuildingCount = Math.floor(buildingCount);
+      const fractionalBuildingCount = buildingCount - wholeBuildingCount;
 
       product.buildingRequirements = {
         name: buildingData.name,
         amount: buildingCount,
         powerPerBuilding: buildingData.power,
-        totalPower: buildingData.power * buildingCount,
+        totalPower: (buildingData.power * wholeBuildingCount) + (buildingData.power * Math.pow(fractionalBuildingCount, 1.321928)), // Power usage = initial power usage x (clock speed / 100)1.321928
       }
     } else {
       product.buildingRequirements = {} as BuildingRequirement

--- a/web/src/utils/factory-setups/simple-plan.spec.ts
+++ b/web/src/utils/factory-setups/simple-plan.spec.ts
@@ -71,7 +71,7 @@ describe('Simple factory plan', () => {
     expect(factory.usingRawResourcesOnly).toBe(true)
   })
   it('should have the correct total power', () => {
-    expect(factory.totalPower).toBe(13.333333333333334)
+    expect(factory.totalPower).toBe(12.936138367958613)
   })
   it('should have a single dependency', () => {
     const ironPlateFac = findFacByName('Iron Plates', factories)

--- a/web/src/utils/factory-setups/simple-plan.spec.ts
+++ b/web/src/utils/factory-setups/simple-plan.spec.ts
@@ -61,7 +61,7 @@ describe('Simple factory plan', () => {
         name: 'smeltermk1',
         amount: 3.3333333333333335, // I hate this so much
         powerPerBuilding: 4, // Should be a number really
-        totalPower: 13.333333333333334,
+        totalPower: 12.936138367958613,
       },
     })
   })

--- a/web/src/utils/factory-setups/simple-plan.spec.ts
+++ b/web/src/utils/factory-setups/simple-plan.spec.ts
@@ -60,7 +60,7 @@ describe('Simple factory plan', () => {
       smeltermk1: {
         name: 'smeltermk1',
         amount: 3.3333333333333335, // I hate this so much
-        powerPerBuilding: 4, // Should be a number really
+        powerPerBuilding: 4,
         totalPower: 12.936138367958613,
       },
     })


### PR DESCRIPTION
fixes #154

Keeping this PR a bit smaller. This corrects power to match other calculators for basic machines, fixing the under-clocking issues that existed (e.g. not Quantum encoders/ particle accelerators, etc)