### PR TITLE
Correcting Power Shard display name

### DIFF
--- a/parsing/gameData.json
+++ b/parsing/gameData.json
@@ -190,7 +190,7 @@
                 "isFicsmas": false
             },
             "CrystalShard": {
-                "name": "Synthetic Power Shard",
+                "name": "Power Shard",
                 "stackSize": 100,
                 "isFluid": false,
                 "isFicsmas": false

--- a/parsing/src/processor.ts
+++ b/parsing/src/processor.ts
@@ -220,6 +220,13 @@ function getItems(data: any[]): PartDataInterface {
                     isFluid: false,
                     isFicsmas: false,
                 };                
+            } else if (entry.ClassName === "Desc_CrystalShard_C") {
+                parts["CrystalShard"] = {
+                    name: "Power Shard",
+                    stackSize: 100, //SS_MEDIUM
+                    isFluid: false,
+                    isFicsmas: false,
+                };                
             }
 
             // Ensures it's a recipe, we only care about items that are produced within a recipe.
@@ -257,6 +264,11 @@ function getItems(data: any[]): PartDataInterface {
                 if (isCollectable(entry.mIngredients)) {
                     collectables[partName] = friendlyName;
                 } else {
+                    if (partName === "CrystalShard") {
+                        console.log("friendlyName:", friendlyName);
+                        console.log("entry:", entry);
+                        console.log("displayName:", entry.mDisplayName);    
+                    }
                     parts[partName] = {
                         name: friendlyName,
                         stackSize,


### PR DESCRIPTION
fixes #152 

This pull request includes changes to the handling and naming of the "CrystalShard" item in the `parsing` module. The most important changes involve renaming the item and adding specific handling logic for it in the data processing function.