### PR TITLE
Fix to nuclear waste

### DIFF
--- a/parsing/gameData.json
+++ b/parsing/gameData.json
@@ -8154,7 +8154,7 @@
                 {
                     "part": "PlutoniumWaste",
                     "amount": 1,
-                    "perMin": 10
+                    "perMin": 1
                 }
             ],
             "building": {

--- a/parsing/gameData.json
+++ b/parsing/gameData.json
@@ -10146,7 +10146,7 @@
                 {
                     "part": "NuclearWaste",
                     "amount": 1,
-                    "perMin": 50
+                    "perMin": 10
                 }
             ],
             "building": {

--- a/parsing/src/recipes.ts
+++ b/parsing/src/recipes.ts
@@ -151,7 +151,7 @@ function getRecipes(
         id: "NuclearWaste",
         displayName: "Uranium Waste",
         ingredients: [{ part: 'NuclearFuelRod', amount: 1, perMin: 0.2 }, { part: 'Water', amount: 1200, perMin: 240 }],
-        products: [{ part: "NuclearWaste", amount: 1, perMin: 50 }],
+        products: [{ part: "NuclearWaste", amount: 1, perMin: 10 }],
         building: { name: "nuclearpowerplant", power: 0 },
         isAlternate: false,
         isFicsmas: false

--- a/parsing/src/recipes.ts
+++ b/parsing/src/recipes.ts
@@ -160,7 +160,7 @@ function getRecipes(
         id: "PlutoniumWaste",
         displayName: "Plutonium Waste",
         ingredients: [{ part: 'PlutoniumFuelRod', amount: 1, perMin: 0.1 }, { part: 'Water', amount: 2400, perMin: 240 }],
-        products: [{ part: "PlutoniumWaste", amount: 1, perMin: 10 }],
+        products: [{ part: "PlutoniumWaste", amount: 1, perMin: 1 }],
         building: { name: "nuclearpowerplant", power: 0 },
         isAlternate: false,
         isFicsmas: false

--- a/web/public/gameData_v1.0-21.json
+++ b/web/public/gameData_v1.0-21.json
@@ -8154,7 +8154,7 @@
                 {
                     "part": "PlutoniumWaste",
                     "amount": 1,
-                    "perMin": 10
+                    "perMin": 1
                 }
             ],
             "building": {
@@ -10146,7 +10146,7 @@
                 {
                     "part": "NuclearWaste",
                     "amount": 1,
-                    "perMin": 50
+                    "perMin": 10
                 }
             ],
             "building": {

--- a/web/src/config/config.ts
+++ b/web/src/config/config.ts
@@ -1,4 +1,4 @@
 export const config = {
   apiUrl: import.meta.env.VITE_ENV === 'dev' ? 'http://localhost:3001' : 'https://api.satisfactory-factories.app',
-  dataVersion: '1.0-20',
+  dataVersion: '1.0-21',
 }


### PR DESCRIPTION
fixes #158

Incorrectly transferred the recipes for [Uranium Waste](https://satisfactory.wiki.gg/wiki/Uranium_Fuel_Rod) and [Plutonium Waste](https://satisfactory.wiki.gg/wiki/Plutonium_Fuel_Rod). This fixes that. 

<HR>

This pull request includes several changes to the `parsing` and `web` directories to update the processing and display of nuclear and plutonium waste production rates. The most important changes include modifying the production rates in the data files and updating the configuration to reflect the new data version.