### PR TITLE
Fixes bug to show details for part with no ingredients

### DIFF
--- a/web/src/components/planner/PlannerFactoryProducts.vue
+++ b/web/src/components/planner/PlannerFactoryProducts.vue
@@ -125,7 +125,7 @@
         </v-chip>
       </v-row>
       <v-row
-        v-if="Object.keys(product.requirements).length > 0"
+        v-if="Object.keys(product.requirements).length > 0 || product.buildingRequirements.amount > 0 || product.buildingRequirements.totalPower > 0"
         class="my-2 px-2 text-body-1 d-flex align-center"
       >
         <p class="mr-2">Requires:</p>


### PR DESCRIPTION
fixes #171 

Previously logic was only looking if there were ingredients before showing/hiding the row, but some parts (in phase 5), do not have ingredients - just power and a product.

<HR>

This pull request includes an important change to the `PlannerFactoryProducts.vue` file to improve the display logic for product requirements.