### PR TITLE
Fixes quantum power calculation

### DIFF
--- a/parsing/gameData.json
+++ b/parsing/gameData.json
@@ -1189,7 +1189,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -1320,7 +1320,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -6613,7 +6613,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -7395,7 +7395,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -9400,7 +9400,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -9476,7 +9476,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false

--- a/parsing/gameData.json
+++ b/parsing/gameData.json
@@ -1189,7 +1189,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -1320,7 +1322,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -6613,7 +6617,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -7395,7 +7401,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -9400,7 +9408,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -9476,7 +9486,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false

--- a/parsing/src/recipes.ts
+++ b/parsing/src/recipes.ts
@@ -119,7 +119,7 @@ function getRecipes(
                 lowPower = Number(recipe.mVariablePowerConsumptionConstant);
                 highPower = Number(recipe.mVariablePowerConsumptionFactor);
                 // calculate the average power
-                if (lowPower && highPower) {
+                if (lowPower != null && highPower != null) {
                     powerPerBuilding = (lowPower + highPower) / 2;
                 }
             }

--- a/parsing/src/recipes.ts
+++ b/parsing/src/recipes.ts
@@ -130,7 +130,7 @@ function getRecipes(
                 power: powerPerBuilding || 0, // Use calculated power or 0
             };
             // keeping this in a separate conditional prevents a ton of properties with null values from being added to the building object
-            if (lowPower && highPower) {
+            if (lowPower !== null && highPower !== null) {
                 building.minPower = lowPower;
                 building.maxPower = highPower;
             }

--- a/parsing/src/recipes.ts
+++ b/parsing/src/recipes.ts
@@ -119,7 +119,7 @@ function getRecipes(
                 lowPower = Number(recipe.mVariablePowerConsumptionConstant);
                 highPower = Number(recipe.mVariablePowerConsumptionFactor);
                 // calculate the average power: Note that because low power can be 0, (and often is), we can't use truthy checks to validate these values
-                if (lowPower != null && highPower != null) {
+                if (lowPower !== null && highPower !== null) {
                     powerPerBuilding = (lowPower + highPower) / 2;
                 }
             }

--- a/parsing/src/recipes.ts
+++ b/parsing/src/recipes.ts
@@ -118,7 +118,7 @@ function getRecipes(
                 // get the power from the recipe instead of the building
                 lowPower = Number(recipe.mVariablePowerConsumptionConstant);
                 highPower = Number(recipe.mVariablePowerConsumptionFactor);
-                // calculate the average power
+                // calculate the average power: Note that because low power can be 0, (and often is), we can't use truthy checks to validate these values
                 if (lowPower != null && highPower != null) {
                     powerPerBuilding = (lowPower + highPower) / 2;
                 }

--- a/parsing/tests/parsing.spec.ts
+++ b/parsing/tests/parsing.spec.ts
@@ -197,5 +197,43 @@ describe('common', () => {
             expect(recipe.building.maxPower).toBe(1000);
             expect(recipe.isAlternate).toBe(false);
         });
+
+        it('validate a recipe with variable power with a Quantum encoder (Neural-Quantum Processor)', () => {
+            //arrange
+            let recipe : Recipe = results.recipes.find((item: { id: string; }) => item.id === 'TemporalProcessor');
+
+            //act
+
+            //assert
+            expect(recipe).toBeDefined();
+            expect(recipe.displayName).toBe('Neural-Quantum Processor');
+            expect(recipe.ingredients.length).toBe(4);
+            expect(recipe.ingredients[0].part).toBe('TimeCrystal');
+            expect(recipe.ingredients[0].amount).toBe(5);
+            expect(recipe.ingredients[0].perMin).toBe(15);
+            expect(recipe.ingredients[1].part).toBe('ComputerSuper');
+            expect(recipe.ingredients[1].amount).toBe(1);
+            expect(recipe.ingredients[1].perMin).toBe(3);
+            expect(recipe.ingredients[2].part).toBe('FicsiteMesh');
+            expect(recipe.ingredients[2].amount).toBe(15);
+            expect(recipe.ingredients[2].perMin).toBe(45);
+            expect(recipe.ingredients[3].part).toBe('QuantumEnergy');
+            expect(recipe.ingredients[3].amount).toBe(25);
+            expect(recipe.ingredients[3].perMin).toBe(75);
+            expect(recipe.products.length).toBe(2);
+            expect(recipe.products[0].part).toBe('TemporalProcessor');
+            expect(recipe.products[0].amount).toBe(1);
+            expect(recipe.products[0].perMin).toBe(3);
+            expect(recipe.products[0].isByProduct).toBe(false);
+            expect(recipe.products[1].part).toBe('DarkEnergy');
+            expect(recipe.products[1].amount).toBe(25);
+            expect(recipe.products[1].perMin).toBe(75);
+            expect(recipe.products[1].isByProduct).toBe(true);
+            expect(recipe.building.name).toBe('quantumencoder');
+            expect(recipe.building.power).toBe(1000);
+            expect(recipe.building.minPower).toBe(0);
+            expect(recipe.building.maxPower).toBe(2000);
+            expect(recipe.isAlternate).toBe(false);
+        });
     })
 })

--- a/web/public/gameData_v1.0-22.json
+++ b/web/public/gameData_v1.0-22.json
@@ -1189,7 +1189,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -1320,7 +1320,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -6613,7 +6613,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -7395,7 +7395,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -9400,7 +9400,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -9476,7 +9476,7 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 0.1
+                "power": 1000
             },
             "isAlternate": false,
             "isFicsmas": false

--- a/web/public/gameData_v1.0-22.json
+++ b/web/public/gameData_v1.0-22.json
@@ -1189,7 +1189,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -1320,7 +1322,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -6613,7 +6617,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -7395,7 +7401,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -9400,7 +9408,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false
@@ -9476,7 +9486,9 @@
             ],
             "building": {
                 "name": "quantumencoder",
-                "power": 1000
+                "power": 1000,
+                "minPower": 0,
+                "maxPower": 2000
             },
             "isAlternate": false,
             "isFicsmas": false

--- a/web/src/config/config.ts
+++ b/web/src/config/config.ts
@@ -1,4 +1,4 @@
 export const config = {
   apiUrl: import.meta.env.VITE_ENV === 'dev' ? 'http://localhost:3001' : 'https://api.satisfactory-factories.app',
-  dataVersion: '1.0-21',
+  dataVersion: '1.0-22',
 }


### PR DESCRIPTION
The recipe for Neural-Quantum Processor has a minimum power of 0 and a max power of 2000. The Average should be 1000, but it wasn't. Because of this conditional. 
```
if (lowPower && highPower) {
  powerPerBuilding = (lowPower + highPower) / 2;
}
```

Now this is checking to make sure the low and high value is truthy - e.g. not false, 0, "", null, undefined or NaN. See the problem there? I didn't initially... but because the low value is 0 - it was basically considered null, and didn't calculate the average for this recipe. Here is the new code:
```
if (lowPower != null && highPower != null) {
  powerPerBuilding = (lowPower + highPower) / 2;
}
```