### PR TITLE
Added Summary/Statistics panel #101

### DIFF
--- a/web/src/components.d.ts
+++ b/web/src/components.d.ts
@@ -36,6 +36,8 @@ declare module 'vue' {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     ShareButton: typeof import('./components/ShareButton.vue')['default']
+    Statistics: typeof import('./components/planner/Statistics.vue')['default']
+    Summary: typeof import('./components/planner/Summary.vue')['default']
     TabNavigation: typeof import('./components/TabNavigation.vue')['default']
     Templates: typeof import('./components/Templates.vue')['default']
     Todo: typeof import('./components/graph/Todo.vue')['default']

--- a/web/src/components/planner/Planner.vue
+++ b/web/src/components/planner/Planner.vue
@@ -54,6 +54,8 @@
           :help-text="helpText"
           :world-raw-resources="worldRawResources"
         />
+        <statistics v-if="factories.length !== 0" :help-text="helpText" :factories="factories"/>
+        <Summary v-if="factories.length !== 0" :help-text="helpText" :factories="factories"/>
         <planner-factory
           v-for="(factory) in factories"
           :key="factory.id"

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -172,7 +172,7 @@
   import { defineProps, inject } from 'vue'
   import { Factory, FactoryDependencyMetrics, FactoryItem } from '@/interfaces/planner/FactoryInterface'
   import { DataInterface } from '@/interfaces/DataInterface'
-  import { getPartDisplayName } from '@/utils/helpers'
+  import { getPartDisplayName, hasMetricsForPart, differenceClass } from '@/utils/helpers'
   import { formatNumber } from '@/utils/numberFormatter'
 
   const findFactory = inject('findFactory') as (id: string | number) => Factory
@@ -199,17 +199,6 @@
 
   const confirmDelete = (message = 'Are you sure you want to delete this factory?') => {
     return confirm(message)
-  }
-
-  const differenceClass = (difference: number) => {
-    return {
-      'text-green': difference > 0,
-      'text-red': difference < 0,
-    }
-  }
-
-  const hasMetricsForPart = (factory: Factory, part: string) => {
-    return factory.dependencies.metrics && factory.dependencies.metrics[part]
   }
 
   const hasExports = (factory: Factory) => {

--- a/web/src/components/planner/Statistics.vue
+++ b/web/src/components/planner/Statistics.vue
@@ -1,0 +1,273 @@
+<template>
+    <v-row>
+      <v-col>
+        <v-card class="factory-card">
+          <v-row class="header">
+            <v-col class="text-h4 flex-grow-1" cols="8">
+              <i class="fas fa-list" /><span class="ml-3">World Statistics</span>
+            </v-col>
+            <v-col class="text-right" cols="4">
+              <v-btn
+                v-show="!hidden"
+                color="primary"
+                prepend-icon="fas fa-eye-slash"
+                variant="outlined"
+                @click="toggleVisibility"
+                >Hide
+              </v-btn>
+              <v-btn
+                v-show="hidden"
+                color="primary"
+                prepend-icon="fas fa-eye"
+                variant="outlined"
+                @click="toggleVisibility"
+                >Show
+              </v-btn>
+            </v-col>
+          </v-row>
+          <v-card-text v-show="!hidden" class="text-body-1">
+            <!-- Raw Resources Area -->
+            <h1 class="text-h5 mb-4">
+              <i class="fas fa-globe" />
+              <span class="ml-3">Raw Resources</span>
+            </h1>
+            <p v-show="helpText" class="mb-4">
+              <i class="fas fa-info-circle" /> Shows the amount of raw resources
+              consumed by all your factories.
+            </p>
+            <span v-for="(resource, id) in allFactoryRawResources" :key="id">
+              <v-chip class="sf-chip blue" variant="tonal">
+                <game-asset :subject="resource.id.toString()" type="item" />
+                <span class="ml-2">
+                  <b>{{ getPartDisplayName(resource.id.toString()) }}</b
+                  >: {{ formatNumber(resource.totalAmount) }}/min
+                </span>
+              </v-chip>
+            </span>
+            <v-divider class="my-4 mx-n4" color="white" thickness="5px" />
+  
+            <!-- Building Summary Area -->
+            <h1 class="text-h5 mb-4">
+              <i class="fas fa-building" />
+              <span class="ml-3">Building Summary</span>
+            </h1>
+            <p v-show="helpText" class="mb-4">
+              <i class="fas fa-info-circle" /> Shows the amount buildings of each
+              type in all your factories.
+            </p>
+            <span v-for="(building, type) in totalBuildingsByType" :key="type">
+              <v-chip class="sf-chip orange" variant="tonal">
+                <game-asset :subject="building.name" type="building" />
+                <span class="ml-1">
+                  <b>{{ getBuildingDisplayName(building.name) ?? "UNKNOWN" }}</b
+                  >: {{ formatNumber(building.totalAmount) ?? 0 }}x
+                </span>
+              </v-chip>
+            </span>
+            <v-divider class="my-4 mx-n4" color="white" thickness="5px" />
+  
+            <!-- Produced Items Area -->
+            <h1 class="text-h5 mb-4">
+              <i class="fas fa-conveyor-belt-alt" />
+              <span class="ml-3">Produced Items</span>
+            </h1>
+            <p v-show="helpText" class="mb-4">
+              <i class="fas fa-info-circle" /> Shows all the items produced by all
+              your factories.
+            </p>
+            <v-chip
+              v-for="(product, id) in allFactoryProducts"
+              :key="id"
+              class="sf-chip"
+            >
+              <span class="mr-2">
+                <game-asset :subject="id" type="item" />
+              </span>
+              <span>
+                <b>{{ product.name }}</b
+                >: {{ formatNumber(product.totalAmount) }}/min
+              </span>
+            </v-chip>
+            <v-divider class="my-4 mx-n4" color="white" thickness="5px" />
+  
+            <!-- Excess Product Area -->
+            <h1 class="text-h5 mb-4">
+              <i class="fas fa-warehouse" />
+              <span class="ml-3">Product Surplus & Deficit</span>
+            </h1>
+            <p v-show="helpText" class="mb-4">
+              <i class="fas fa-info-circle" /> Shows the amount of surplus or
+              deficit of items you have in your factory. These are items that
+              either need to be produced more (in red), or items that can be
+              stored or sunk (in green)!
+            </p>
+            <v-chip
+              v-for="(product, partId) in factoryProductDifferences"
+              :key="partId"
+              class="sf-chip"
+              :class="{
+                'text-green': product.totalDifference > 0,
+                'text-red': product.totalDifference < 0,
+              }"
+            >
+              <game-asset :subject="partId" type="item" />
+              <span class="ml-2">
+                <b>{{ product.name }}</b
+                >: {{ formatNumber(product.totalDifference) }}/min
+              </span>
+            </v-chip>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </template>
+  
+  <script setup lang="ts">
+  import { ref, watch, computed } from "vue";
+  import {
+    Factory,
+    BuildingRequirement,
+  } from "@/interfaces/planner/FactoryInterface";
+  import { formatNumber } from "@/utils/numberFormatter";
+  import {
+    getPartDisplayName,
+    hasMetricsForPart,
+    differenceClass,
+  } from "@/utils/helpers";
+  
+  const props = defineProps<{
+    factories: Factory[];
+    helpText: boolean;
+  }>();
+  
+  // Initialize the 'hidden' ref based on the value in localStorage
+  const hidden = ref<boolean>(
+    localStorage.getItem("statisticsHidden") === "true"
+  );
+  
+  // Watch the 'hidden' ref and update localStorage whenever it changes
+  watch(hidden, (newValue) => {
+    localStorage.setItem("statisticsHidden", newValue.toString());
+  });
+  
+  // Function to toggle visibility
+  const toggleVisibility = () => {
+    hidden.value = !hidden.value;
+  };
+  
+  const getBuildingDisplayName = inject("getBuildingDisplayName") as (
+    part: string
+  ) => string;
+  
+  // This function calculates total number of buildings for each type of building and creates a new record to store that info in
+  const totalBuildingsByType = computed(() => {
+    const buildings: Record<
+      string,
+      {
+        name: string;
+        totalAmount: number;
+        powerPerBuilding: number;
+        totalPower: number;
+      }
+    > = {}; // Explicitly define the type
+    props.factories.forEach((factory) => {
+      Object.entries(factory.buildingRequirements).forEach(
+        ([key, requirement]) => {
+          if (!buildings[key]) {
+            // Initialize the building entry
+            buildings[key] = {
+              name: requirement.name,
+              totalAmount: 0,
+              powerPerBuilding: requirement.powerPerBuilding,
+              totalPower: 0,
+            };
+          }
+  
+          // Accumulate the total amount and total power
+          buildings[key].totalAmount += requirement.amount;
+          buildings[key].totalPower += requirement.totalPower;
+        }
+      );
+    });
+  
+    return buildings;
+  });
+  
+  // This function calculates total number of products produced
+  const allFactoryProducts = computed(() => {
+    const products: Record<
+      string,
+      { name: string; totalAmount: number; totalDifference: number }
+    > = {};
+  
+    props.factories.forEach((factory) => {
+      factory.products.forEach((product) => {
+        if (!products[product.id]) {
+          products[product.id] = {
+            name: getPartDisplayName(product.id) ?? product.id,
+            totalAmount: 0,
+            totalDifference: 0,
+          };
+        }
+  
+        // Accumulate the product amount
+        products[product.id].totalAmount += product.amount;
+  
+        // Add the difference if metrics exist
+        if (hasMetricsForPart(factory, product.id)) {
+          const difference =
+            factory.dependencies.metrics[product.id]?.difference ?? 0;
+          products[product.id].totalDifference += difference;
+        }
+      });
+    });
+  
+    return products;
+  });
+  
+  // This function calculates total number of raw resources required for all the factories combined
+  const allFactoryRawResources = computed(() => {
+    const rawResources: Record<string, { id: string; totalAmount: number }> = {};
+  
+    props.factories.forEach((factory) => {
+      Object.values(factory.rawResources).forEach((resource) => {
+        if (!rawResources[resource.id]) {
+          // Initialize the raw resource entry
+          rawResources[resource.id] = {
+            id: resource.id,
+            totalAmount: 0,
+          };
+        }
+  
+        // Accumulate the resource amount
+        rawResources[resource.id].totalAmount += resource.amount;
+      });
+    });
+  
+    return rawResources;
+  });
+  
+  // This function calculates total number of products produced and gets the difference between demand and supply (to see if we have a surplus of products or not)
+  const factoryProductDifferences = computed(() => {
+    const differences: Record<string, { name: string; totalDifference: number }> =
+      {};
+  
+    props.factories.forEach((factory) => {
+      Object.entries(factory.dependencies.metrics).forEach(([partId, metric]) => {
+        if (metric.difference !== 0) {
+          if (!differences[partId]) {
+            differences[partId] = {
+              name: getPartDisplayName(partId) ?? partId,
+              totalDifference: 0,
+            };
+          }
+          // Accumulate the difference
+          differences[partId].totalDifference += metric.difference;
+        }
+      });
+    });
+  
+    return differences;
+  });
+  </script>
+  

--- a/web/src/components/planner/Statistics.vue
+++ b/web/src/components/planner/Statistics.vue
@@ -126,13 +126,11 @@
   import { ref, watch, computed } from "vue";
   import {
     Factory,
-    BuildingRequirement,
   } from "@/interfaces/planner/FactoryInterface";
   import { formatNumber } from "@/utils/numberFormatter";
   import {
     getPartDisplayName,
     hasMetricsForPart,
-    differenceClass,
   } from "@/utils/helpers";
   
   const props = defineProps<{

--- a/web/src/components/planner/Summary.vue
+++ b/web/src/components/planner/Summary.vue
@@ -1,0 +1,241 @@
+<template>
+    <v-row>
+      <v-col>
+        <v-card class="factory-card">
+          <v-row class="header">
+            <v-col class="text-h4 flex-grow-1" cols="8">
+              <i class="fas fa-list" /><span class="ml-3">Factories Summary</span>
+            </v-col>
+            <v-col class="text-right" cols="4">
+              <v-btn
+                v-show="!hidden"
+                color="primary"
+                prepend-icon="fas fa-eye-slash"
+                variant="outlined"
+                @click="toggleVisibility"
+                >Hide
+              </v-btn>
+              <v-btn
+                v-show="hidden"
+                color="primary"
+                prepend-icon="fas fa-eye"
+                variant="outlined"
+                @click="toggleVisibility"
+                >Show
+              </v-btn>
+            </v-col>
+          </v-row>
+          <v-card-text v-show="!hidden" class="text-body-1">
+            <p v-show="helpText" class="mb-4">
+              <i class="fas fa-info-circle" /> Showing an overview of each factory
+              with the name, machines and their production.
+            </p>
+  
+            <v-table>
+              <thead>
+                <tr>
+                  <th class="text-left">Factory Name</th>
+                  <th class="text-left">Machines</th>
+                  <th class="text-left">Producing</th>
+                  <th class="text-left">Importing</th>
+                  <th class="text-left">Exporting</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="factory in factories"
+                  :class="factoryClass(factory)"
+                  class="header"
+                >
+                  <td class="header">{{ factory.name }}</td>
+                  <td class="header">
+                    <span
+                      v-for="([_, buildingData], buildingIndex) in Object.entries(
+                        factory.buildingRequirements
+                      )"
+                      :key="buildingIndex"
+                      style="display: inline"
+                    >
+                      <v-chip class="sf-chip orange" variant="tonal">
+                        <game-asset
+                          :subject="buildingData.name"
+                          type="building"
+                        />
+                        <span class="ml-1">
+                          <b>{{
+                            getBuildingDisplayName(buildingData.name) ?? "UNKNOWN"
+                          }}</b
+                          >: {{ formatNumber(buildingData.amount) ?? 0 }}x
+                        </span>
+                      </v-chip>
+                    </span>
+                  </td>
+                  <td class="header">
+                    <v-chip
+                      v-for="part in factory.products"
+                      :key="`${factory.id}-${part.id}`"
+                      class="sf-chip"
+                    >
+                      <span class="mr-2">
+                        <game-asset
+                          v-if="part.id"
+                          :subject="part.id"
+                          type="item"
+                        />
+                      </span>
+                      <span>
+                        <b>{{ getPartDisplayName(part.id) }}</b
+                        >: {{ formatNumber(part.amount) }}/min
+                      </span>
+                      <span
+                        v-if="
+                          hasMetricsForPart(factory, part.id) &&
+                          factory.dependencies.metrics[part.id].difference !== 0
+                        "
+                        class="ml-2"
+                        :class="
+                          differenceClass(
+                            factory.dependencies.metrics[part.id].difference
+                          )
+                        "
+                        >({{
+                          formatNumber(
+                            factory.dependencies.metrics[part.id].difference
+                          )
+                        }}/min)</span
+                      >
+                    </v-chip>
+                  </td>
+                  <td class="header">
+                    <v-chip
+                      v-for="(
+                        totalAmount, outputPart
+                      ) in calculateTotalDependencies(factory.inputs)"
+                      :key="`${factory.id}-${outputPart}`"
+                      class="sf-chip ml-2"
+                    >
+                      <game-asset
+                        v-if="outputPart"
+                        height="32"
+                        :subject="outputPart"
+                        type="item"
+                        width="32"
+                      />
+                      <span class="ml-2">
+                        <b>{{ getPartDisplayName(outputPart) }}:</b>
+                        {{ formatNumber(totalAmount) }}/min
+                      </span>
+                    </v-chip>
+                  </td>
+                  <td class="header">
+                    <v-chip
+                      v-for="(
+                        totalAmount, part
+                      ) in calculateTotalDependencyRequests(
+                        factory.dependencies.requests
+                      )"
+                      :key="part"
+                      class="sf-chip ml-2"
+                    >
+                      <game-asset
+                        v-if="part"
+                        height="32"
+                        :subject="part"
+                        type="item"
+                        width="32"
+                      />
+                      <span class="ml-2">
+                        <b>{{ getPartDisplayName(part) }}:</b>
+                        {{ formatNumber(totalAmount) }}/min
+                      </span>
+                    </v-chip>
+                  </td>
+                </tr>
+              </tbody>
+            </v-table>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </template>
+  
+  <script setup lang="ts">
+  import { ref, watch } from "vue";
+  import {
+    Factory,
+    FactoryInput,
+    FactoryDependencyRequest,
+  } from "@/interfaces/planner/FactoryInterface";
+  import {
+    getPartDisplayName,
+    hasMetricsForPart,
+    differenceClass,
+  } from "@/utils/helpers";
+  import { formatNumber } from "@/utils/numberFormatter";
+  defineProps<{
+    factories: Factory[];
+    helpText: boolean;
+  }>();
+  
+  // Initialize the 'hidden' ref based on the value in localStorage
+  const hidden = ref<boolean>(localStorage.getItem("summaryHidden") === "true");
+  
+  watch(hidden, (newValue) => {
+    localStorage.setItem("summaryHidden", newValue.toString());
+  });
+  
+  const toggleVisibility = () => {
+    hidden.value = !hidden.value;
+  };
+  
+  const getBuildingDisplayName = inject("getBuildingDisplayName") as (
+    part: string
+  ) => string;
+  
+  const factoryClass = (factory: Factory) => {
+    return {
+      "factory-card": true,
+      problem: factory.hasProblem,
+    };
+  };
+  
+  // This function finds out which items are being imported into the factory and their quantity
+  const calculateTotalDependencies = (inputs: FactoryInput[]) => {
+    const totals: Record<string, number> = {};
+  
+    inputs.forEach((input) => {
+      const { outputPart, amount } = input;
+      if (outputPart) {
+        if (!totals[outputPart]) {
+          totals[outputPart] = 0;
+        }
+        totals[outputPart] += amount;
+      }
+    });
+  
+    return totals;
+  };
+  
+  // This function finds out which items are being exported from the factory and their quantity
+  const calculateTotalDependencyRequests = (
+    requests: Record<string, FactoryDependencyRequest[]>
+  ) => {
+    const totals: Record<string, number> = {};
+  
+    Object.values(requests).forEach((dependencyRequests) => {
+      dependencyRequests.forEach((request) => {
+        const { part, amount } = request;
+  
+        if (part) {
+          if (!totals[part]) {
+            totals[part] = 0;
+          }
+          totals[part] += amount;
+        }
+      });
+    });
+  
+    return totals;
+  };
+  </script>
+  

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -1,4 +1,5 @@
 import { useGameDataStore } from '@/stores/game-data-store'
+import { Factory } from "@/interfaces/planner/FactoryInterface";
 
 const gameDataStore = useGameDataStore()
 const gameData = gameDataStore.getGameData()
@@ -15,3 +16,13 @@ export const getPartDisplayName = (part: string | number | null): string => {
     gameData.items.parts[part]?.name ||
     `UNKNOWN PART ${part}!`
 }
+export const hasMetricsForPart = (factory: Factory, part: string) => {
+  return factory.dependencies.metrics && factory.dependencies.metrics[part];
+};
+
+export const differenceClass = (difference: number) => {
+  return {
+    "text-green": difference > 0,
+    "text-red": difference < 0,
+  };
+};


### PR DESCRIPTION
Creates two different Summary/Stats views. This time more cleanly.

1) World Statistics
This provides the user an overall view of total production, number of machines, consumption of raw resources etc.

![image](https://github.com/user-attachments/assets/1b3431fb-982b-4cda-8f1c-1c6083debf99)


2) Factories Summary
This provides the user with a table for quick information about all their factories. Including importing and exporting products.

![image](https://github.com/user-attachments/assets/9f965114-253e-4246-aba3-bbb907bd3a03)

Note: Does not handle electricity or power consumption currently. Could be a useful feature to add down the line.
Also I made a separate pull request before because I accidentally committed pnpm-lock file. My bad! Hope this ones better
