### PR TITLE
fix(web): Fixing Raw Resource Import message

### DIFF
--- a/web/src/components/planner/PlannerFactoryImports.vue
+++ b/web/src/components/planner/PlannerFactoryImports.vue
@@ -129,9 +129,6 @@
             @click="deleteInput(inputIndex, factory)"
           />
         </div>
-        <span v-if="ableToImport(factory) === 'noFacs'" class="ml-2">(Add another Factory with Exports!)</span>
-        <span v-if="ableToImport(factory) === 'rawOnly'" class="ml-2">(This factory is only using raw resources and requires no imports.)</span>
-        <span v-if="ableToImport(factory) === 'noImportFacs'" class="ml-2">(There are no factories that have exports able to supply this factory.)</span>
       </div>
       <div class="input-row d-flex align-center">
         <v-btn
@@ -144,6 +141,9 @@
           @click="addEmptyInput(factory)"
         >Add Import
         </v-btn>
+        <span v-if="ableToImport(factory) === 'noFacs'" class="ml-2">(Add another Factory with Exports!)</span>
+        <span v-if="ableToImport(factory) === 'rawOnly'" class="ml-2">(This factory is only using raw resources and requires no imports.)</span>
+        <span v-if="ableToImport(factory) === 'noImportFacs'" class="ml-2">(There are no factories that have exports able to supply this factory.)</span>
       </div>
     </div>
     <p v-else class="text-body-1">Awaiting product selection.</p>


### PR DESCRIPTION
Moving this message back outside the loop, as it is supposed to go here

![image](https://github.com/user-attachments/assets/471fd1ae-c429-46c0-b300-4884e0bc5ed9)

Should be fixed now

Closes #211 