### PR TITLE
Fix sharing process for iOS users

### DIFF
--- a/web/src/components/ShareButton.vue
+++ b/web/src/components/ShareButton.vue
@@ -40,7 +40,17 @@
 
   const handleCreation = async (factoryTabData: FactoryTab) => {
     creating.value = true
-    const token = await authStore.getToken()
+    let token: string
+    try {
+      token = await authStore.getToken()
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error('Error:', error)
+        alert('Your session has expired, please log in and try sharing again.')
+      }
+      return
+    }
+
     try {
       const response = await fetch(`${apiUrl}/share`, {
         method: 'POST',
@@ -57,6 +67,10 @@
         creating.value = false
       } else if (response.status === 429) {
         alert('You are being rate limited. Stop spamming that button! Please wait some time before trying again.')
+      } else if (response.status === 500) {
+        alert('A server error has occurred trying to create the share link. Please report this on Discord!')
+      } else if (response.status === 502) {
+        alert('The backend server is offline! Please report this with some urgency on Discord!')
       } else {
         console.error('Creating share link failed:', response.body)
         alert(`Failed to create share link. Please report this error on our GitHub site 'https://github.com/satisfactory-factories/application'! "${response.body}"`)

--- a/web/src/components/ShareButton.vue
+++ b/web/src/components/ShareButton.vue
@@ -76,11 +76,8 @@
     try {
       token = await authStore.getToken()
     } catch (error) {
-      if (error instanceof Error) {
-        console.error('Error:', error)
-        alert('Your session has expired, please log in and try sharing again.')
-      }
-      return
+      // Do nothing
+      token = ''
     }
 
     try {

--- a/web/src/components/ShareButton.vue
+++ b/web/src/components/ShareButton.vue
@@ -40,7 +40,7 @@
 
   const handleCreation = async (factoryTabData: FactoryTab) => {
     creating.value = true
-    const token = authStore.getToken()
+    const token = await authStore.getToken()
     try {
       const response = await fetch(`${apiUrl}/share`, {
         method: 'POST',

--- a/web/src/components/ShareButton.vue
+++ b/web/src/components/ShareButton.vue
@@ -46,6 +46,7 @@
     } catch (error) {
       if (error instanceof Error) {
         console.error('Error:', error)
+        creating.value = false
         alert('Your session has expired, please log in and try sharing again.')
       }
       return

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -56,7 +56,7 @@
             <v-btn
               class="mr-2"
               color="orange rounded"
-              icon="fa fa-copy"
+              icon="fas fa-copy"
               size="small"
               title="Copy Factory"
               variant="outlined"

--- a/web/src/stores/auth-store.ts
+++ b/web/src/stores/auth-store.ts
@@ -20,15 +20,15 @@ export const useAuthStore = (fetchOverride?: typeof fetch) => {
     }
   }
 
-  const getToken = async (invalidateSession = true) => {
+  const getToken = async () => {
     // This is a hack to get round the need of dependency injection for the store, using localStorage as a middleman.
     // It's not ideal, but it works for now.
     const token = localStorage.getItem('token') ?? ''
-    await validateToken(invalidateSession, token) // Will fail if it throws an error
+    await validateToken(token) // Will fail if it throws an error
     return token ?? ''
   }
 
-  const validateToken = async (invalidateSession = true, token?: string): Promise<boolean | string> => {
+  const validateToken = async (token?: string): Promise<boolean | string> => {
     if (!token) {
       console.error('validateToken: No token provided!')
       throw new InvalidTokenError('No token provided')
@@ -55,11 +55,8 @@ export const useAuthStore = (fetchOverride?: typeof fetch) => {
       return true
     } else if (response.status === 401) {
       console.warn('validateToken: Token invalid!')
-
-      if (invalidateSession) {
-        eventBus.emit('sessionExpired')
-        handleLogout()
-      }
+      eventBus.emit('sessionExpired')
+      handleLogout()
       throw new InvalidTokenError()
     } else if (response.status === 500 || response.status === 502) {
       console.error('validateToken: Backend is offline!')


### PR DESCRIPTION
iOS has a very annoying issue where all browsers upon it do not allow the `navigator.clipboard` API without a user interaction attached.

In the event the user agent doesn't support clipboard API, the user is shown a simple dialog with a button to copy the link directly.

<img width="1362" alt="Screenshot 2024-11-27 at 13 51 04" src="https://github.com/user-attachments/assets/6f22436b-1d46-44e7-9e94-13939c494f79">
