### PR TITLE
feat(web): Added ability to mark factories as out of sync with the game so the user can check them

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" style="overflow: hidden">
-
+<html lang="en">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,9 +1,5 @@
 <template>
-  <v-app>
-    <v-main>
-      <router-view />
-    </v-main>
-  </v-app>
+  <router-view />
 </template>
 
 <script lang="ts" setup>

--- a/web/src/assets/styles/global.scss
+++ b/web/src/assets/styles/global.scss
@@ -114,7 +114,7 @@
   }
 
   &.needsSync {
-    border: 2px solid #ff8800 !important;
+    border: 2px solid rgb(167, 86, 0) !important;
 
     .header {
       background-color: rgba(255, 136, 0, 0.16);

--- a/web/src/assets/styles/global.scss
+++ b/web/src/assets/styles/global.scss
@@ -13,6 +13,15 @@
     padding: 12px 10px !important;
   }
 
+  &.x-small {
+    padding: 0 8px !important;
+    font-size: 12px !important;
+  }
+
+  &.no-margin {
+    margin: 0 !important;
+  }
+
   &.blue {
     color: rgb(33, 150, 243) !important;
     border-color: rgb(0, 93, 167) !important;
@@ -26,6 +35,11 @@
   &.yellow {
     color: #fbc02d !important;
     border-color: rgb(172, 153, 2) !important
+  }
+
+  &.green {
+    color: #4caf50 !important;
+    border-color: #4caf50 !important;
   }
 }
 
@@ -96,6 +110,22 @@
 
     .header {
       background-color: rgba(140, 9, 21, 0.4);
+    }
+  }
+
+  &.needsSync {
+    border: 2px solid #ff8800 !important;
+
+    .header {
+      background-color: rgba(255, 136, 0, 0.16);
+    }
+  }
+
+  &.inSync {
+    border: 2px solid #4caf50 !important;
+
+    .header {
+      background-color: rgba(76, 175, 80, 0.16);
     }
   }
 }

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -14,19 +14,19 @@
             </div>
             <div class="d-flex align-center">
               <div v-if="factory.inSync">
-                <v-chip class="sf-chip small green no-margin" @click="changeSync(factory)">
+                <v-chip class="sf-chip small green no-margin" @click="setSync(factory)">
                   <i class="fas fa-check-square" />
                   <span class="ml-2">In sync with game</span>
                 </v-chip>
               </div>
               <div v-if="factory.inSync === false">
-                <v-chip class="sf-chip small orange no-margin" @click="changeSync(factory)">
+                <v-chip class="sf-chip small orange no-margin" @click="setSync(factory)">
                   <i class="fas fa-times-square" />
-                  <span class="ml-2">Needs updating in game</span>
+                  <span class="ml-2">Out of sync with game</span>
                 </v-chip>
               </div>
               <div v-if="factory.inSync === null">
-                <v-chip class="border border-gray border-dashed" @click="changeSync(factory)">
+                <v-chip class="border border-gray border-dashed" :disabled="!factory.products[0]?.id" @click="setSync(factory)">
                   <i class="fas fa-question" />
                   <span class="ml-2">Mark as in sync with game</span>
                 </v-chip>
@@ -37,7 +37,8 @@
                     <i class="fas fa-info-circle" />
                   </div>
                 </template>
-                <span>Game Sync is when you have implemented the factory into your game.<br> When it drops out of sync, there are changes that you need to implement.</span>
+                <span>Game Sync is when you have implemented the factory inside the game.<br> When it drops out of sync, there are changes that you need to implement.<br> When a factory's products are changed, the factory will be out of sync, or if you set it manually.
+                </span>
               </v-tooltip>
             </div>
           </v-col>
@@ -350,8 +351,18 @@
     return factory.dependencies?.metrics[part] ?? {}
   }
 
-  const changeSync = (factory: Factory) => {
+  const setSync = (factory: Factory) => {
     factory.inSync = !factory.inSync
+
+    // Record what the sync'ed state is
+    if (factory.inSync) {
+      factory.syncState = {}
+
+      // Get the current products of the factory and set them
+      factory.products.forEach(product => {
+        factory.syncState[product.id] = product.amount
+      })
+    }
   }
 
   provide('fixProduction', fixProduction)

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -3,13 +3,35 @@
     <v-col>
       <v-card :id="factory.id" :class="factoryClass(factory)">
         <v-row class="header">
-          <v-col class="text-h5 text-md-h4 flex-grow-1" cols="auto" md="8">
-            <i class="fas fa-industry" />
-            <input
-              v-model="factory.name"
-              class="ml-3 pl-0 factory-name"
-              placeholder="Factory Name"
-            >
+          <v-col class="flex-grow-1" cols="auto" md="8">
+            <div class="text-h6 text-md-h5">
+              <i class="fas fa-industry" />
+              <input
+                v-model="factory.name"
+                class="ml-3 pl-0 factory-name"
+                placeholder="Factory Name"
+              >
+            </div>
+            <div>
+              <div v-if="factory.inSync" class="d-inline">
+                <v-chip class="sf-chip small green no-margin" @click="changeSync(factory)">
+                  <i class="fas fa-check-square" />
+                  <span class="ml-2">In sync with game</span>
+                </v-chip>
+              </div>
+              <div v-if="factory.inSync === false" class="d-inline">
+                <v-chip class="sf-chip small orange no-margin" @click="changeSync(factory)">
+                  <i class="fas fa-times-square" />
+                  <span class="ml-2">Needs updating in game</span>
+                </v-chip>
+              </div>
+              <div v-if="factory.inSync === null" class="d-inline">
+                <v-chip class="border border-gray border-dashed" @click="changeSync(factory)">
+                  <i class="fas fa-question" />
+                  <span class="ml-2">Mark as in sync with game</span>
+                </v-chip>
+              </div>
+            </div>
           </v-col>
           <v-col class="text-right pt-0 pt-md-3" cols="auto" md="4">
             <factory-debug :is-compact="smAndDown" :subject="factory" subject-type="Factory" />
@@ -249,6 +271,7 @@
     return {
       'factory-card': true,
       problem: factory.hasProblem,
+      needsSync: factory.inSync !== null ? !factory.inSync : false,
     }
   }
 
@@ -317,6 +340,10 @@
     }
 
     return factory.dependencies?.metrics[part] ?? {}
+  }
+
+  const changeSync = (factory: Factory) => {
+    factory.inSync = !factory.inSync
   }
 
   provide('fixProduction', fixProduction)

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -271,7 +271,7 @@
     return {
       'factory-card': true,
       problem: factory.hasProblem,
-      needsSync: factory.inSync !== null ? !factory.inSync : false,
+      needsSync: !factory.hasProblem && factory.inSync !== null ? !factory.inSync : false,
     }
   }
 

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -12,25 +12,33 @@
                 placeholder="Factory Name"
               >
             </div>
-            <div>
-              <div v-if="factory.inSync" class="d-inline">
+            <div class="d-flex align-center">
+              <div v-if="factory.inSync">
                 <v-chip class="sf-chip small green no-margin" @click="changeSync(factory)">
                   <i class="fas fa-check-square" />
                   <span class="ml-2">In sync with game</span>
                 </v-chip>
               </div>
-              <div v-if="factory.inSync === false" class="d-inline">
+              <div v-if="factory.inSync === false">
                 <v-chip class="sf-chip small orange no-margin" @click="changeSync(factory)">
                   <i class="fas fa-times-square" />
                   <span class="ml-2">Needs updating in game</span>
                 </v-chip>
               </div>
-              <div v-if="factory.inSync === null" class="d-inline">
+              <div v-if="factory.inSync === null">
                 <v-chip class="border border-gray border-dashed" @click="changeSync(factory)">
                   <i class="fas fa-question" />
                   <span class="ml-2">Mark as in sync with game</span>
                 </v-chip>
               </div>
+              <v-tooltip right>
+                <template #activator="{ props }">
+                  <div class="ml-2 text-grey" v-bind="props">
+                    <i class="fas fa-info-circle" />
+                  </div>
+                </template>
+                <span>Game Sync is when you have implemented the factory into your game.<br> When it drops out of sync, there are changes that you need to implement.</span>
+              </v-tooltip>
             </div>
           </v-col>
           <v-col class="text-right pt-0 pt-md-3" cols="auto" md="4">

--- a/web/src/components/planner/PlannerFactoryList.vue
+++ b/web/src/components/planner/PlannerFactoryList.vue
@@ -13,7 +13,7 @@
               <i class="fas fa-industry mr-2" />
               <span>{{ truncateFactoryName(element.name) }}</span>
             </v-col>
-            <v-tooltip left>
+            <v-tooltip right>
               <template #activator="{ props }">
                 <v-col
                   class="pa-0 align-content-center text-center"

--- a/web/src/components/planner/PlannerFactoryList.vue
+++ b/web/src/components/planner/PlannerFactoryList.vue
@@ -3,18 +3,32 @@
     <template #item="{ element }">
       <div :key="element.id" class="mb-1 rounded" :class="factoryClass(element)">
         <v-card
-          class="w-100 header list"
+          class="w-100 header list px-0 rounded-0 "
+          style="box-shadow: none !important;"
           @click="navigateToFactory(element.id)"
         >
-          <v-card-title class="py-3">
-            <v-row>
-              <v-col align-self="end" class="text-body-1">
-                <i class="fas fa-bars text-grey-darken-1" />
-                <i class="fas fa-industry ml-2" />
-                <span class="ml-2">{{ truncateFactoryName(element.name) }}</span>
-              </v-col>
-            </v-row>
-          </v-card-title>
+          <v-row class="d-flex ma-0">
+            <v-col class="text-body-1 align-content-center pa-2" cols="11">
+              <i class="fas fa-bars text-grey-darken-1 mr-2" />
+              <i class="fas fa-industry mr-2" />
+              <span>{{ truncateFactoryName(element.name) }}</span>
+            </v-col>
+            <v-col
+              class="pa-0 align-content-center text-center pa-2"
+              :class="syncStateClass(element)"
+              cols="1"
+            >
+              <div v-if="element.inSync" class="d-inline">
+                <i class="fas fa-check" />
+              </div>
+              <div v-if="element.inSync === false" class="d-inline">
+                <i class="fas fa-times" />
+              </div>
+              <div v-if="element.inSync === null" class="d-inline">
+                <i class="fas fa-question" />
+              </div>
+            </v-col>
+          </v-row>
         </v-card>
       </div>
     </template>
@@ -56,6 +70,7 @@
     return {
       'factory-card': true,
       problem: factory.hasProblem,
+      needsSync: factory.inSync === false,
     }
   }
 
@@ -69,6 +84,14 @@
 
   const onDragEnd = () => {
     emit('updateFactories', factoriesCopy.value)
+  }
+
+  const syncStateClass = (factory: Factory) => {
+    return {
+      'bg-green': factory.inSync,
+      'bg-orange': factory.inSync === false,
+      'bg-grey': factory.inSync === null,
+    }
   }
 </script>
 

--- a/web/src/components/planner/PlannerFactoryList.vue
+++ b/web/src/components/planner/PlannerFactoryList.vue
@@ -13,21 +13,34 @@
               <i class="fas fa-industry mr-2" />
               <span>{{ truncateFactoryName(element.name) }}</span>
             </v-col>
-            <v-col
-              class="pa-0 align-content-center text-center pa-2"
-              :class="syncStateClass(element)"
-              cols="1"
-            >
-              <div v-if="element.inSync" class="d-inline">
-                <i class="fas fa-check" />
-              </div>
-              <div v-if="element.inSync === false" class="d-inline">
-                <i class="fas fa-times" />
-              </div>
-              <div v-if="element.inSync === null" class="d-inline">
-                <i class="fas fa-question" />
-              </div>
-            </v-col>
+            <v-tooltip left>
+              <template #activator="{ props }">
+                <v-col
+                  class="pa-0 align-content-center text-center"
+                  :class="syncStateClass(element)"
+                  cols="1"
+                  v-bind="props"
+                >
+                  <div v-if="element.inSync" class="d-inline">
+                    <i class="fas fa-check" />
+                  </div>
+                  <div v-if="element.inSync === false" class="d-inline">
+                    <i class="fas fa-times" />
+                  </div>
+                  <div v-if="element.inSync === null" class="d-inline">
+                    <i class="fas fa-question" />
+                  </div>
+                </v-col>
+              </template>
+              <span>
+                {{ element.inSync === true
+                  ? 'In sync with game'
+                  : element.inSync === false
+                    ? 'Out of sync with game'
+                    : 'Game sync unknown'
+                }}
+              </span>
+            </v-tooltip>
           </v-row>
         </v-card>
       </div>
@@ -70,7 +83,7 @@
     return {
       'factory-card': true,
       problem: factory.hasProblem,
-      needsSync: factory.inSync === false,
+      needsSync: !factory.hasProblem && factory.inSync === false,
     }
   }
 
@@ -88,9 +101,9 @@
 
   const syncStateClass = (factory: Factory) => {
     return {
-      'bg-green': factory.inSync,
-      'bg-orange': factory.inSync === false,
-      'bg-grey': factory.inSync === null,
+      'bg-green-darken-2': factory.inSync,
+      'bg-orange-darken-2': factory.inSync === false,
+      'bg-grey-darken-2': factory.inSync === null,
     }
   }
 </script>

--- a/web/src/interfaces/planner/FactoryInterface.ts
+++ b/web/src/interfaces/planner/FactoryInterface.ts
@@ -105,6 +105,7 @@ export interface Factory {
   hidden: boolean; // Whether to hide the card or not
   hasProblem: boolean
   inSync: boolean | null;
+  syncState: { [key: string]: number };
   displayOrder: number;
 }
 

--- a/web/src/interfaces/planner/FactoryInterface.ts
+++ b/web/src/interfaces/planner/FactoryInterface.ts
@@ -104,6 +104,7 @@ export interface Factory {
   usingRawResourcesOnly: boolean;
   hidden: boolean; // Whether to hide the card or not
   hasProblem: boolean
+  inSync: boolean | null;
   displayOrder: number;
 }
 

--- a/web/src/stores/app-store.ts
+++ b/web/src/stores/app-store.ts
@@ -68,6 +68,10 @@ export const useAppStore = defineStore('app', () => {
       if (factory.inSync === undefined) {
         factory.inSync = null
       }
+
+      if (factory.syncState === undefined) {
+        factory.syncState = {}
+      }
     })
 
     return factories.value

--- a/web/src/stores/app-store.ts
+++ b/web/src/stores/app-store.ts
@@ -58,10 +58,15 @@ export const useAppStore = defineStore('app', () => {
   // ==== FACTORY MANAGEMENT
   // This function is needed to ensure that data fixes are applied as we migrate things and change things around.
   const getFactories = () => {
-    // Patch for old data pre #116
     factories.value.forEach(factory => {
+      // Patch for old data pre #116
       if (!factory.exports) {
         factory.exports = {}
+      }
+
+      // Patch for #222
+      if (factory.inSync === undefined) {
+        factory.inSync = null
       }
     })
 

--- a/web/src/utils/factory-management/factory.ts
+++ b/web/src/utils/factory-management/factory.ts
@@ -61,6 +61,7 @@ export const newFactory = (name = 'A new factory'): Factory => {
     usingRawResourcesOnly: false,
     hidden: false,
     hasProblem: false,
+    inSync: null,
     displayOrder: -1, // this will get set by the planner
   }
 }

--- a/web/src/utils/factory-management/factory.ts
+++ b/web/src/utils/factory-management/factory.ts
@@ -10,6 +10,7 @@ import { configureExportCalculator } from '@/utils/factory-management/exportCalc
 import { calculateHasProblem } from '@/utils/factory-management/problems'
 import { DataInterface } from '@/interfaces/DataInterface'
 import eventBus from '@/utils/eventBus'
+import { calculateSyncState } from '@/utils/factory-management/syncState'
 
 export const findFac = (factoryId: string | number, factories: Factory[]): Factory => {
   // This should always be supplied, if not there's a major bug.
@@ -62,6 +63,7 @@ export const newFactory = (name = 'A new factory'): Factory => {
     hidden: false,
     hasProblem: false,
     inSync: null,
+    syncState: {},
     displayOrder: -1, // this will get set by the planner
   }
 }
@@ -83,6 +85,9 @@ export const calculateFactory = (
 
   // And calculate Byproducts
   calculateByProducts(factory, gameData)
+
+  // Calculate if there have been any changes the player needs to enact.
+  calculateSyncState(factory)
 
   // Calculate building requirements for each product based on the selected recipe and product amount.
   calculateBuildingRequirements(factory, gameData)

--- a/web/src/utils/factory-management/syncState.spec.ts
+++ b/web/src/utils/factory-management/syncState.spec.ts
@@ -18,27 +18,31 @@ describe('syncState', () => {
     mockFactory.syncState = {
       IronIngot: 100,
     }
+
+    mockFactory.inSync = true
   })
 
   describe('calculateSyncState', () => {
     it('should not make changes to a synced factory', () => {
-      mockFactory.inSync = true
-
       calculateSyncState(mockFactory)
       expect(mockFactory.inSync).toBe(true)
     })
-    it('should detect a desynced factory', () => {
+
+    it('should detect a de-synced factory', () => {
       mockFactory.syncState.IronIngot = 50
 
       calculateSyncState(mockFactory)
       expect(mockFactory.inSync).toBe(false)
     })
+
     it('should not affect a factory with no sync state', () => {
+      mockFactory.inSync = null
       mockFactory.syncState = {}
 
       calculateSyncState(mockFactory)
       expect(mockFactory.inSync).toBe(null)
     })
+
     it('should detect a desynced factory across multiple products', () => {
       addProductToFactory(mockFactory, {
         id: 'CopperIngot',
@@ -51,6 +55,7 @@ describe('syncState', () => {
       calculateSyncState(mockFactory)
       expect(mockFactory.inSync).toBe(false)
     })
+
     it('should maintain a synced factory across multiple products', () => {
       addProductToFactory(mockFactory, {
         id: 'CopperIngot',
@@ -65,11 +70,12 @@ describe('syncState', () => {
       expect(mockFactory.inSync).toBe(true)
     })
 
-    it('should do nothing when there are no products', () => {
+    it('should drop factory out of sync when there are no products', () => {
       mockFactory.products = []
       calculateSyncState(mockFactory)
-      expect(mockFactory.inSync).toBe(null)
+      expect(mockFactory.inSync).toBe(false)
     })
+
     it('should mark a factory as out of sync when there are no products', () => {
       mockFactory.products = []
       calculateSyncState(mockFactory)

--- a/web/src/utils/factory-management/syncState.spec.ts
+++ b/web/src/utils/factory-management/syncState.spec.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { newFactory } from '@/utils/factory-management/factory'
+import { addProductToFactory } from '@/utils/factory-management/products'
+import { calculateSyncState } from '@/utils/factory-management/syncState'
+
+describe('syncState', () => {
+  let mockFactory: Factory
+
+  beforeEach(() => {
+    mockFactory = newFactory('Iron Ingots')
+    addProductToFactory(mockFactory, {
+      id: 'IronIngot',
+      amount: 100,
+      recipe: 'IronIngot',
+    })
+
+    mockFactory.syncState = {
+      IronIngot: 100,
+    }
+  })
+
+  describe('calculateSyncState', () => {
+    it('should not make changes to a synced factory', () => {
+      mockFactory.inSync = true
+
+      calculateSyncState(mockFactory)
+      expect(mockFactory.inSync).toBe(true)
+    })
+    it('should detect a desynced factory', () => {
+      mockFactory.syncState.IronIngot = 50
+
+      calculateSyncState(mockFactory)
+      expect(mockFactory.inSync).toBe(false)
+    })
+    it('should not affect a factory with no sync state', () => {
+      mockFactory.syncState = {}
+
+      calculateSyncState(mockFactory)
+      expect(mockFactory.inSync).toBe(null)
+    })
+    it('should detect a desynced factory across multiple products', () => {
+      addProductToFactory(mockFactory, {
+        id: 'CopperIngot',
+        amount: 100,
+        recipe: 'CopperIngot',
+      })
+      mockFactory.syncState.IronIngot = 50
+      mockFactory.syncState.CopperIngot = 100
+
+      calculateSyncState(mockFactory)
+      expect(mockFactory.inSync).toBe(false)
+    })
+    it('should maintain a synced factory across multiple products', () => {
+      addProductToFactory(mockFactory, {
+        id: 'CopperIngot',
+        amount: 100,
+        recipe: 'CopperIngot',
+      })
+      mockFactory.inSync = true
+      mockFactory.syncState.IronIngot = 100
+      mockFactory.syncState.CopperIngot = 100
+
+      calculateSyncState(mockFactory)
+      expect(mockFactory.inSync).toBe(true)
+    })
+
+    it('should do nothing when there are no products', () => {
+      mockFactory.products = []
+      calculateSyncState(mockFactory)
+      expect(mockFactory.inSync).toBe(null)
+    })
+    it('should mark a factory as out of sync when there are no products', () => {
+      mockFactory.products = []
+      calculateSyncState(mockFactory)
+      expect(mockFactory.inSync).toBe(false)
+    })
+  })
+})

--- a/web/src/utils/factory-management/syncState.ts
+++ b/web/src/utils/factory-management/syncState.ts
@@ -1,0 +1,31 @@
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+
+export const calculateSyncState = (factory: Factory) => {
+  // If factory has not been marked as in any form of sync, skip.
+  if (factory.inSync === null) {
+    return
+  }
+
+  // Scan the products and determine if they are in sync with the syncState.
+  // If there are no products, mark the factory out of sync, if already in sync.
+  if (!factory.products.length) {
+    if (factory.inSync) {
+      factory.inSync = false
+    }
+  }
+
+  factory.products.forEach(product => {
+    // If the product has no syncState, skip.
+    if (!factory.syncState[product.id]) {
+      return
+    }
+
+    // If the product has a sync state, check if the state has differed from the new product data.
+    const syncState = factory.syncState[product.id]
+
+    // If the sync state does not match the product amount, mark the factory as out of sync.
+    if (syncState !== product.amount) {
+      factory.inSync = false
+    }
+  })
+}


### PR DESCRIPTION
Closes #222 

This PR enables the user to do the following:

- Mark a factory as "in sync with game" denoting that they have done what the plan says in game
- Mark a factory as "out of sync" as a todo for them to fix later
- When a factory is marked as In Sync, the values of the products are saved. When the products get updated, the factory falls out of sync which the user then needs to put it back in sync.
- This feature is optional, the factory is created as `inSync: null` and when they mark it as sync for the first time does it then start tracking the sync state.
- I've updated the Factory List to be 1) more compact and 2) integrate the sync status.

Video https://youtu.be/dA4O4CMNi1Q