### PR TITLE
fix(web): Prevent invalid imports and dependencies by scanning for them.

### DIFF
--- a/web/src/utils/factory-management/dependencies.ts
+++ b/web/src/utils/factory-management/dependencies.ts
@@ -56,7 +56,7 @@ export const scanForInvalidInputs = (factory: Factory, factories: Factory[]): vo
 
       // If the product does not exist, remove the dependency and the input.
       if (!product) {
-        console.warn(`Factory ${factory.id} does not have the product ${request.part} requested by ${dependantFactory.id}. Removing dependency and input.`)
+        console.warn(`Factory ${factory.name} (${factory.id}) does not have the product ${request.part} requested by ${dependantFactory.name} (${dependantFactory.id}). Removing dependency and input.`)
 
         // Filter out the dependency request(s) for the part from the erroneous factory.
         factory.dependencies.requests[requestedFactoryId] = factory.dependencies.requests[requestedFactoryId].filter(req => req.part !== request.part)

--- a/web/src/utils/factory-management/dependencies.ts
+++ b/web/src/utils/factory-management/dependencies.ts
@@ -1,4 +1,4 @@
-import { Factory, FactoryInput } from '@/interfaces/planner/FactoryInterface'
+import { Factory, FactoryDependencyRequest, FactoryInput } from '@/interfaces/planner/FactoryInterface'
 import { findFac } from '@/utils/factory-management/factory'
 
 // Adds dependencies between two factories.
@@ -29,6 +29,51 @@ export const addDependency = (
     requestingFactoryId: factory.id,
     part: input.outputPart,
     amount: input.amount,
+  })
+}
+
+// Scans for invalid dependency requests and removes the request and the input from the erroneous factory.
+export const scanForInvalidInputs = (factory: Factory, factories: Factory[]): void => {
+  // If there's no requests, nothing to do.
+  if (!factory.dependencies?.requests) {
+    return
+  }
+
+  // Scan all requests for the factory
+  Object.keys(factory.dependencies?.requests).forEach(requestedFactoryId => {
+    const requests: FactoryDependencyRequest[] = factory.dependencies.requests[requestedFactoryId]
+
+    const dependantFactory = findFac(requestedFactoryId, factories)
+    // If the factory doesn't exist, somehow this data corrupted, clean it up now.
+    if (!dependantFactory) {
+      console.error(`Requested factory ${requestedFactoryId} not found!`)
+      delete factory.dependencies.requests[requestedFactoryId]
+    }
+
+    requests.forEach(request => {
+      // Check if the product exists within the factory
+      const product = factory.products.find(prod => prod.id === request.part)
+
+      // If the product does not exist, remove the dependency and the input.
+      if (!product) {
+        console.warn(`Factory ${factory.id} does not have the product ${request.part} requested by ${dependantFactory.id}. Removing dependency and input.`)
+
+        // Filter out the dependency request(s) for the part from the erroneous factory.
+        factory.dependencies.requests[requestedFactoryId] = factory.dependencies.requests[requestedFactoryId].filter(req => req.part !== request.part)
+
+        // If all requests from the factory have been removed, also delete the key.
+        if (factory.dependencies.requests[requestedFactoryId].length === 0) {
+          delete factory.dependencies.requests[requestedFactoryId]
+        }
+
+        // Delete the input from the factory that caused the issue.
+        dependantFactory.inputs.forEach((input, index) => {
+          if (input.factoryId === factory.id && input.outputPart === request.part) {
+            dependantFactory.inputs.splice(index, 1)
+          }
+        })
+      }
+    })
   })
 }
 

--- a/web/src/utils/factory-management/factory.ts
+++ b/web/src/utils/factory-management/factory.ts
@@ -4,7 +4,11 @@ import { calculateByProducts, calculateInternalProducts, calculateProducts } fro
 import { calculateBuildingRequirements, calculateBuildingsAndPower } from '@/utils/factory-management/buildings'
 import { calculateRawSupply, calculateUsingRawResourcesOnly } from '@/utils/factory-management/supply'
 import { calculateFactorySatisfaction } from '@/utils/factory-management/satisfaction'
-import { calculateDependencyMetrics, constructDependencies } from '@/utils/factory-management/dependencies'
+import {
+  calculateDependencyMetrics,
+  constructDependencies,
+  scanForInvalidInputs,
+} from '@/utils/factory-management/dependencies'
 import { calculateExports } from '@/utils/factory-management/exports'
 import { configureExportCalculator } from '@/utils/factory-management/exportCalculator'
 import { calculateHasProblem } from '@/utils/factory-management/problems'
@@ -109,6 +113,11 @@ export const calculateFactory = (
 
   // Check all other factories to see if they are affected by this factory change.
   constructDependencies(allFactories)
+
+  // Check if we have any invalid inputs.
+  scanForInvalidInputs(factory, allFactories)
+
+  // Calculate the dependency metrics for the factory.
   allFactories.forEach(factory => {
     calculateDependencyMetrics(factory)
   })


### PR DESCRIPTION
Fixes #228 

This adds a new step to calculateFactory to scan for potentially invalid imports and dependencies. This should stop the "invisible problem" bug where if someone managed to have old imports and they weren't removed properly.