### PR TITLE
Add notes and tasks indicators to the factory list and headers #261

### DIFF
--- a/web/src/components.d.ts
+++ b/web/src/components.d.ts
@@ -28,7 +28,7 @@ declare module 'vue' {
     PlannerFactorySatisfaction: typeof import('./components/planner/PlannerFactorySatisfaction.vue')['default']
     PlannerFactorySatisfactionBuildings: typeof import('./components/planner/PlannerFactorySatisfactionBuildings.vue')['default']
     PlannerFactorySatisfactionItems: typeof import('./components/planner/PlannerFactorySatisfactionItems.vue')['default']
-    PlannerFactoryTodos: typeof import('./components/planner/PlannerFactoryTodos.vue')['default']
+    PlannerFactoryTasks: typeof import('./components/planner/PlannerFactoryTasks.vue')['default']
     PlannerGlobalActions: typeof import('./components/planner/PlannerGlobalActions.vue')['default']
     PlannerStatistics: typeof import('./components/planner/PlannerStatistics.vue')['default']
     RecipeItem: typeof import('./components/recipes/RecipeItem.vue')['default']

--- a/web/src/components/planner/Planner.vue
+++ b/web/src/components/planner/Planner.vue
@@ -277,7 +277,7 @@
     helpText.value = !helpText.value
   }
 
-  const navigateToFactory = (factoryId: number | string) => {
+  const navigateToFactory = (factoryId: number | string, subsection?: string) => {
     const facId = parseInt(factoryId.toString(), 10)
     const factory = findFac(facId, appStore.getFactories())
     if (!factory) {
@@ -290,7 +290,7 @@
     // Wait a bit for the factory to unhide fully. Hack but works well.
     setTimeout(() => {
       // Navigate to it
-      const factoryElement = document.getElementById(`${factoryId}`)
+      const factoryElement = document.getElementById(subsection ?? `${factoryId}`)
       if (factoryElement) {
         factoryElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
       }

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -12,7 +12,23 @@
                 placeholder="Factory Name"
               >
             </div>
+            <!-- chips bar -->
             <div class="d-flex align-center">
+              <!-- tasks chip -->
+              <div v-if="countIncompleteTasks(factory)" class="mr-2">
+                <v-chip class="sf-chip small yellow no-margin" @click="navigateToFactory(factory.id, `${factory.id}-todos`)">
+                  <i class="fas fa-tasks" />
+                  <span class="ml-2">{{ countIncompleteTasks(factory) }} todos</span>
+                </v-chip>
+              </div>
+              <!-- notes chip -->
+              <div v-if="factory.notes" class="mr-2">
+                <v-chip class="sf-chip small yellow no-margin" @click="navigateToFactory(factory.id, `${factory.id}-notes`)">
+                  <i class="fas fa-sticky-note" />
+                  <span class="ml-2">See notes</span>
+                </v-chip>
+              </div>
+              <!-- sync status chip -->
               <div v-if="factory.inSync">
                 <v-chip class="sf-chip small green no-margin" @click="setSync(factory)">
                   <i class="fas fa-check-square" />
@@ -31,6 +47,7 @@
                   <span class="ml-2">Mark as in sync with game</span>
                 </v-chip>
               </div>
+              <!-- sync status tooltip -->
               <v-tooltip right>
                 <template #activator="{ props }">
                   <div class="ml-2 text-grey" v-bind="props">
@@ -122,12 +139,14 @@
           <v-row>
             <v-col cols="12" md="6">
               <planner-factory-todos
+                :id="`${factory.id}-todos`"
                 :factory="factory"
                 :help-text="helpText"
               />
             </v-col>
             <v-col cols="12" md="6">
               <planner-factory-notes
+                :id="`${factory.id}-notes`"
                 :factory="factory"
                 :help-text="helpText"
               />
@@ -267,6 +286,7 @@
   import { Factory, FactoryDependencyMetrics, FactoryItem } from '@/interfaces/planner/FactoryInterface'
   import { DataInterface } from '@/interfaces/DataInterface'
   import { getPartDisplayName } from '@/utils/helpers'
+  import { countIncompleteTasks } from '@/utils/factory-management/factory'
   import { formatNumber } from '@/utils/numberFormatter'
   import { useDisplay } from 'vuetify'
 
@@ -275,7 +295,7 @@
   const copyFactory = inject('copyFactory') as (factory: Factory) => void
   const deleteFactory = inject('deleteFactory') as (factory: Factory) => void
   const moveFactory = inject('moveFactory') as (factory: Factory, direction: string) => void
-  const navigateToFactory = inject('navigateToFactory') as (id: string | number) => void
+  const navigateToFactory = inject('navigateToFactory') as (id: string | number, subsection?: string) => void
   const getProduct = inject('getProduct') as (factory: Factory, productId: string) => FactoryItem
 
   defineProps<{

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -16,9 +16,9 @@
             <div class="d-flex align-center">
               <!-- tasks chip -->
               <div v-if="countIncompleteTasks(factory)" class="mr-2">
-                <v-chip class="sf-chip small yellow no-margin" @click="navigateToFactory(factory.id, `${factory.id}-todos`)">
+                <v-chip class="sf-chip small yellow no-margin" @click="navigateToFactory(factory.id, `${factory.id}-tasks`)">
                   <i class="fas fa-tasks" />
-                  <span class="ml-2">{{ countIncompleteTasks(factory) }} todos</span>
+                  <span class="ml-2">{{ countIncompleteTasks(factory) }} tasks</span>
                 </v-chip>
               </div>
               <!-- notes chip -->
@@ -138,8 +138,8 @@
           <v-divider class="my-4 mx-n4" color="white" thickness="5px" />
           <v-row>
             <v-col cols="12" md="6">
-              <planner-factory-todos
-                :id="`${factory.id}-todos`"
+              <planner-factory-tasks
+                :id="`${factory.id}-tasks`"
                 :factory="factory"
                 :help-text="helpText"
               />

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -15,10 +15,10 @@
             <!-- chips bar -->
             <div class="d-flex align-center">
               <!-- tasks chip -->
-              <div v-if="countIncompleteTasks(factory)" class="mr-2">
+              <div v-if="countActiveTasks(factory)" class="mr-2">
                 <v-chip class="sf-chip small yellow no-margin" @click="navigateToFactory(factory.id, `${factory.id}-tasks`)">
                   <i class="fas fa-tasks" />
-                  <span class="ml-2">{{ countIncompleteTasks(factory) }} tasks</span>
+                  <span class="ml-2">Tasks: {{ countActiveTasks(factory) }}</span>
                 </v-chip>
               </div>
               <!-- notes chip -->
@@ -286,7 +286,7 @@
   import { Factory, FactoryDependencyMetrics, FactoryItem } from '@/interfaces/planner/FactoryInterface'
   import { DataInterface } from '@/interfaces/DataInterface'
   import { getPartDisplayName } from '@/utils/helpers'
-  import { countIncompleteTasks } from '@/utils/factory-management/factory'
+  import { countActiveTasks } from '@/utils/factory-management/factory'
   import { formatNumber } from '@/utils/numberFormatter'
   import { useDisplay } from 'vuetify'
 

--- a/web/src/components/planner/PlannerFactoryList.vue
+++ b/web/src/components/planner/PlannerFactoryList.vue
@@ -20,7 +20,7 @@
                   class="text-body-1 align-content-center text-center py-0 px-1 bg-orange-darken-2"
                   cols="auto"
                   v-bind="props"
-                  @click="navigateToFactory(element.id, `${element.id}-todos`)"
+                  @click="navigateToFactory(element.id, `${element.id}-tasks`)"
                   @click.stop
                 >
                   <i class="d-inline fas fa-tasks mr-1" />

--- a/web/src/components/planner/PlannerFactoryList.vue
+++ b/web/src/components/planner/PlannerFactoryList.vue
@@ -8,7 +8,7 @@
           @click="navigateToFactory(element.id)"
         >
           <v-row class="d-flex flex-nowrap ma-0">
-            <v-spacer class="text-body-1 align-content-center pa-2">
+            <v-spacer class="d-flex align-center text-body-1 pa-2">
               <i class="fas fa-bars text-grey-darken-1 mr-2" />
               <i class="fas fa-industry mr-2" />
               <span>{{ truncateFactoryName(element.name) }}</span>
@@ -16,25 +16,25 @@
             <v-tooltip right>
               <template #activator="{ props }">
                 <v-col
-                  v-if="countIncompleteTasks(element as Factory)"
-                  class="text-body-1 align-content-center text-center py-0 px-1 bg-orange-darken-2"
+                  v-if="countActiveTasks(element as Factory)"
+                  class="context-icon align-content-center text-center py-0 px-1"
                   cols="auto"
                   v-bind="props"
                   @click="navigateToFactory(element.id, `${element.id}-tasks`)"
                   @click.stop
                 >
                   <i class="d-inline fas fa-tasks mr-1" />
-                  <span>{{ countIncompleteTasks(element as Factory) }}</span>
+                  <span>{{ countActiveTasks(element as Factory) }}</span>
                 </v-col>
               </template>
-              <span>{{ countIncompleteTasks(element as Factory) }} tasks</span>
+              <span>Tasks: {{ countActiveTasks(element as Factory) }}</span>
             </v-tooltip>
             <v-tooltip right>
               <template #activator="{ props }">
                 <v-col
                   v-if="element.notes"
-                  class="text-body-1 align-content-center text-center py-0 px-1 bg-orange-darken-2"
-                  cols="1"
+                  class="context-icon align-content-center text-center py-0 px-1"
+                  cols="auto"
                   v-bind="props"
                   @click="navigateToFactory(element.id, `${element.id}-notes`)"
                   @click.stop
@@ -47,7 +47,7 @@
             <v-tooltip right>
               <template #activator="{ props }">
                 <v-col
-                  class="pa-0 align-content-center text-center"
+                  class="pa-0 ml-2 align-content-center text-center"
                   :class="syncStateClass(element)"
                   cols="1"
                   v-bind="props"
@@ -94,7 +94,7 @@
 <script setup lang="ts">
   import { defineEmits, defineProps, inject, ref, watch } from 'vue'
   import { Factory } from '@/interfaces/planner/FactoryInterface'
-  import { countIncompleteTasks } from '@/utils/factory-management/factory'
+  import { countActiveTasks } from '@/utils/factory-management/factory'
   import draggable from 'vuedraggable'
 
   const navigateToFactory = inject('navigateToFactory') as (id: number, subsection?: string) => void
@@ -149,6 +149,14 @@
     .header {
       border-bottom: 0 !important;
     }
+  }
+}
+
+.context-icon {
+  color: #757575;
+  transition: color 0.3s;
+  &:hover {
+    color: white;
   }
 }
 </style>

--- a/web/src/components/planner/PlannerFactoryList.vue
+++ b/web/src/components/planner/PlannerFactoryList.vue
@@ -7,12 +7,43 @@
           style="box-shadow: none !important;"
           @click="navigateToFactory(element.id)"
         >
-          <v-row class="d-flex ma-0">
-            <v-col class="text-body-1 align-content-center pa-2" cols="11">
+          <v-row class="d-flex flex-nowrap ma-0">
+            <v-spacer class="text-body-1 align-content-center pa-2">
               <i class="fas fa-bars text-grey-darken-1 mr-2" />
               <i class="fas fa-industry mr-2" />
               <span>{{ truncateFactoryName(element.name) }}</span>
-            </v-col>
+            </v-spacer>
+            <v-tooltip right>
+              <template #activator="{ props }">
+                <v-col
+                  v-if="countIncompleteTasks(element as Factory)"
+                  class="text-body-1 align-content-center text-center py-0 px-1 bg-orange-darken-2"
+                  cols="auto"
+                  v-bind="props"
+                  @click="navigateToFactory(element.id, `${element.id}-todos`)"
+                  @click.stop
+                >
+                  <i class="d-inline fas fa-tasks mr-1" />
+                  <span>{{ countIncompleteTasks(element as Factory) }}</span>
+                </v-col>
+              </template>
+              <span>{{ countIncompleteTasks(element as Factory) }} tasks</span>
+            </v-tooltip>
+            <v-tooltip right>
+              <template #activator="{ props }">
+                <v-col
+                  v-if="element.notes"
+                  class="text-body-1 align-content-center text-center py-0 px-1 bg-orange-darken-2"
+                  cols="1"
+                  v-bind="props"
+                  @click="navigateToFactory(element.id, `${element.id}-notes`)"
+                  @click.stop
+                >
+                  <i class="d-inline fas fa-sticky-note" />
+                </v-col>
+              </template>
+              <span>See notes</span>
+            </v-tooltip>
             <v-tooltip right>
               <template #activator="{ props }">
                 <v-col
@@ -63,9 +94,10 @@
 <script setup lang="ts">
   import { defineEmits, defineProps, inject, ref, watch } from 'vue'
   import { Factory } from '@/interfaces/planner/FactoryInterface'
+  import { countIncompleteTasks } from '@/utils/factory-management/factory'
   import draggable from 'vuedraggable'
 
-  const navigateToFactory = inject('navigateToFactory') as (id: number) => void
+  const navigateToFactory = inject('navigateToFactory') as (id: number, subsection?: string) => void
 
   // eslint-disable-next-line func-call-spacing
   const emit = defineEmits<{

--- a/web/src/components/planner/PlannerFactoryNotes.vue
+++ b/web/src/components/planner/PlannerFactoryNotes.vue
@@ -1,6 +1,9 @@
 <template>
   <v-card class="factory-card sub-card">
-    <v-card-title>Notes</v-card-title>
+    <v-card-title>
+      <i class="fas fa-sticky-note" />
+      <span class="ml-3">Notes</span>
+    </v-card-title>
     <v-card-text>
       <v-textarea
         v-model="factory.notes"

--- a/web/src/components/planner/PlannerFactoryTasks.vue
+++ b/web/src/components/planner/PlannerFactoryTasks.vue
@@ -2,7 +2,7 @@
   <v-card class="factory-card sub-card">
     <v-card-title>
       <i class="fas fa-tasks" />
-      <span class="ml-3">Todos</span>
+      <span class="ml-3">Tasks</span>
     </v-card-title>
     <v-card-text>
       <v-text-field

--- a/web/src/components/planner/PlannerFactoryTodos.vue
+++ b/web/src/components/planner/PlannerFactoryTodos.vue
@@ -1,6 +1,9 @@
 <template>
   <v-card class="factory-card sub-card">
-    <v-card-title>Todos</v-card-title>
+    <v-card-title>
+      <i class="fas fa-tasks" />
+      <span class="ml-3">Todos</span>
+    </v-card-title>
     <v-card-text>
       <v-text-field
         v-model="newTask"

--- a/web/src/utils/factory-management/factory.spec.ts
+++ b/web/src/utils/factory-management/factory.spec.ts
@@ -1,4 +1,4 @@
-import { newFactory } from '@/utils/factory-management/factory'
+import { countIncompleteTasks, newFactory } from '@/utils/factory-management/factory'
 import { describe, expect, it } from 'vitest'
 
 describe('Factory Management', () => {
@@ -8,6 +8,31 @@ describe('Factory Management', () => {
       expect(fac.id).toBeGreaterThan(0)
       expect(fac.name).toBe('My new factory')
       expect(fac.products.length).toBe(0)
+      expect(fac.tasks.length).toBe(0)
+    })
+  })
+
+  describe('countIncompleteTasks', () => {
+    it('should count the number of incomplete tasks', () => {
+      const fac = newFactory('My new factory')
+      expect(countIncompleteTasks(fac)).toBe(0)
+      fac.tasks.push({ completed: false, title: 'Task 1' })
+      expect(countIncompleteTasks(fac)).toBe(1)
+      fac.tasks.push({ completed: false, title: 'Task 2' })
+      expect(countIncompleteTasks(fac)).toBe(2)
+      fac.tasks.push({ completed: false, title: 'Task 3' })
+      expect(countIncompleteTasks(fac)).toBe(3)
+    })
+
+    it('should not count complete tasks', () => {
+      const fac = newFactory('My new factory')
+      expect(countIncompleteTasks(fac)).toBe(0)
+      fac.tasks.push({ completed: true, title: 'Task 1' })
+      expect(countIncompleteTasks(fac)).toBe(0)
+      fac.tasks.push({ completed: false, title: 'Task 2' })
+      expect(countIncompleteTasks(fac)).toBe(1)
+      fac.tasks.push({ completed: true, title: 'Task 3' })
+      expect(countIncompleteTasks(fac)).toBe(1)
     })
   })
 

--- a/web/src/utils/factory-management/factory.spec.ts
+++ b/web/src/utils/factory-management/factory.spec.ts
@@ -1,4 +1,4 @@
-import { countIncompleteTasks, newFactory } from '@/utils/factory-management/factory'
+import { countActiveTasks, newFactory } from '@/utils/factory-management/factory'
 import { describe, expect, it } from 'vitest'
 
 describe('Factory Management', () => {
@@ -12,27 +12,27 @@ describe('Factory Management', () => {
     })
   })
 
-  describe('countIncompleteTasks', () => {
+  describe('countActiveTasks', () => {
     it('should count the number of incomplete tasks', () => {
       const fac = newFactory('My new factory')
-      expect(countIncompleteTasks(fac)).toBe(0)
+      expect(countActiveTasks(fac)).toBe(0)
       fac.tasks.push({ completed: false, title: 'Task 1' })
-      expect(countIncompleteTasks(fac)).toBe(1)
+      expect(countActiveTasks(fac)).toBe(1)
       fac.tasks.push({ completed: false, title: 'Task 2' })
-      expect(countIncompleteTasks(fac)).toBe(2)
+      expect(countActiveTasks(fac)).toBe(2)
       fac.tasks.push({ completed: false, title: 'Task 3' })
-      expect(countIncompleteTasks(fac)).toBe(3)
+      expect(countActiveTasks(fac)).toBe(3)
     })
 
     it('should not count complete tasks', () => {
       const fac = newFactory('My new factory')
-      expect(countIncompleteTasks(fac)).toBe(0)
+      expect(countActiveTasks(fac)).toBe(0)
       fac.tasks.push({ completed: true, title: 'Task 1' })
-      expect(countIncompleteTasks(fac)).toBe(0)
+      expect(countActiveTasks(fac)).toBe(0)
       fac.tasks.push({ completed: false, title: 'Task 2' })
-      expect(countIncompleteTasks(fac)).toBe(1)
+      expect(countActiveTasks(fac)).toBe(1)
       fac.tasks.push({ completed: true, title: 'Task 3' })
-      expect(countIncompleteTasks(fac)).toBe(1)
+      expect(countActiveTasks(fac)).toBe(1)
     })
   })
 

--- a/web/src/utils/factory-management/factory.ts
+++ b/web/src/utils/factory-management/factory.ts
@@ -146,3 +146,7 @@ export const calculateFactories = (factories: Factory[], gameData: DataInterface
 
   return factories
 }
+
+export const countIncompleteTasks = (factory: Factory) => {
+  return factory.tasks.filter(task => !task.completed).length
+}

--- a/web/src/utils/factory-management/factory.ts
+++ b/web/src/utils/factory-management/factory.ts
@@ -147,6 +147,6 @@ export const calculateFactories = (factories: Factory[], gameData: DataInterface
   return factories
 }
 
-export const countIncompleteTasks = (factory: Factory) => {
+export const countActiveTasks = (factory: Factory) => {
   return factory.tasks.filter(task => !task.completed).length
 }


### PR DESCRIPTION
Completes #261 

### Factory headers

- The tasks chip is visible if there is at least one **incomplete** task, the number of which is displayed
- The notes chip is visible if there is any contents in the notes for the factory
- Clicking either chip will expand the factory and smooth scroll to the tasks / notes

<img width="440" alt="Screenshot 2024-12-07 at 7 56 02 PM" src="https://github.com/user-attachments/assets/f02b5412-d152-4891-b313-87c4bd27b113">
<img width="330" alt="Screenshot 2024-12-07 at 7 57 13 PM" src="https://github.com/user-attachments/assets/8ba8728c-5c69-4c45-b72c-d1dcffe01c23">
<img width="337" alt="Screenshot 2024-12-07 at 7 57 26 PM" src="https://github.com/user-attachments/assets/d6331dfa-efbc-4511-9e77-d92ef34235a3">
<img width="298" alt="Screenshot 2024-12-07 at 7 57 41 PM" src="https://github.com/user-attachments/assets/21c03eb3-09a4-41c8-afce-72bd492c6007">

**Note:** it now says "tasks" instead of "todos" but I don't want to re-create the screenshots haha

### Factory list

- New indicators for # of tasks or presence of notes
- Visibility conditions are the same as for the chips
- Clicking will scroll to the relevant section, just as with the chips
- Tooltip text matches the chip text (i.e. "Tasks: #" or "See notes")
- Icons are grey by default, white on hover to indicate they can be clicked
- Also fixed the wrapping on factory names, everything remains centered

<img width="383" alt="image" src="https://github.com/user-attachments/assets/3c7530b3-d152-47dd-9cf1-ebb48473162a">
<img width="324" alt="Screenshot 2024-12-08 at 9 06 48 PM" src="https://github.com/user-attachments/assets/b19d79a2-cd97-4d7a-8dd2-7d052add22ae">

### Bonus: Renamed "Todos" to "Tasks" and added icons

<img width="1050" alt="Screenshot 2024-12-08 at 4 04 39 PM" src="https://github.com/user-attachments/assets/ec957bb0-45bd-442d-8e84-6115bc3c0dae">
