### PR TITLE
fix: correction to ensure building shows when no ingredients

### DIFF
--- a/web/src/components/planner/products/Product.vue
+++ b/web/src/components/planner/products/Product.vue
@@ -133,7 +133,7 @@
         </v-chip>
       </div>
       <div
-        v-if="Object.keys(product.requirements).length > 0"
+        v-if="Object.keys(product.requirements).length > 0 || product.buildingRequirements"
         class="d-flex align-center"
       >
         <p class="mr-2">Requires:</p>


### PR DESCRIPTION
Fix #272 

This pull request includes a minor update to the `Product.vue` component in the `planner/products` section. The change ensures that the "Requires" section is displayed if there are either product requirements or building requirements.