### PR TITLE
Allow editing product ingredient amounts

### DIFF
--- a/web/src/components/planner/products/Product.spec.ts
+++ b/web/src/components/planner/products/Product.spec.ts
@@ -1,0 +1,80 @@
+import vuetify from '@/plugins/vuetify'
+import { createPinia, setActivePinia } from 'pinia'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, test } from 'vitest'
+import Product from './Product.vue'
+import { calculateFactory, newFactory } from '@/utils/factory-management/factory'
+import { addProductToFactory } from '@/utils/factory-management/products'
+import { useGameDataStore } from '@/stores/game-data-store'
+
+describe('Product', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  test('should update produced amount when requirement amount is changed', async () => {
+    const factory = newFactory('test')
+    const gameData = useGameDataStore().getGameData()
+    addProductToFactory(factory, {
+      id: 'IronIngot',
+      amount: 30,
+      recipe: 'IngotIron',
+    })
+    calculateFactory(factory, [factory], gameData)
+    const subject = mount(Product, {
+      propsData: {
+        factory,
+        helpText: false,
+      },
+      global: {
+        plugins: [vuetify],
+        provide: {
+          getBuildingDisplayName: (x: any) => x,
+          updateFactory: (factory: any) => {
+            calculateFactory(factory, [factory], gameData)
+          },
+        },
+      },
+    })
+    const productionInput = subject.find('input[name="IronIngot.amount"]')
+    expect(productionInput?.attributes?.()?.value).toBe('30')
+    const ironOreInput = subject.find('input[name="IronIngot.ingredients.OreIron"]')
+    expect(ironOreInput?.attributes?.()?.value).toBe('30')
+
+    await ironOreInput.setValue('60')
+    expect(productionInput?.attributes?.()?.value).toBe('60')
+  })
+
+  test('should update produced amount when byproduct amount is changed', async () => {
+    const factory = newFactory('test')
+    const gameData = useGameDataStore().getGameData()
+    addProductToFactory(factory, {
+      id: 'LiquidFuel',
+      amount: 40,
+      recipe: 'LiquidFuel',
+    })
+    calculateFactory(factory, [factory], gameData)
+    const subject = mount(Product, {
+      propsData: {
+        factory,
+        helpText: false,
+      },
+      global: {
+        plugins: [vuetify],
+        provide: {
+          getBuildingDisplayName: (x: any) => x,
+          updateFactory: (factory: any) => {
+            calculateFactory(factory, [factory], gameData)
+          },
+        },
+      },
+    })
+    const productionInput = subject.find('input[name="LiquidFuel.amount"]')
+    expect(productionInput?.attributes?.()?.value).toBe('40')
+    const byProductInput = subject.find('input[name="LiquidFuel.byProducts.PolymerResin"]')
+    expect(byProductInput?.attributes?.()?.value).toBe('30')
+
+    await byProductInput.setValue('60')
+    expect(productionInput?.attributes?.()?.value).toBe('80')
+  })
+})

--- a/web/src/components/planner/products/Product.vue
+++ b/web/src/components/planner/products/Product.vue
@@ -50,6 +50,7 @@
           label="Qty /min"
           :max-width="smAndDown ? undefined : '110px'"
           :min-width="smAndDown ? undefined : '100px'"
+          :name="`${product.id}.amount`"
           type="number"
           variant="outlined"
           @input="updateFactory(factory)"
@@ -128,13 +129,30 @@
         >
           <game-asset :subject="byProduct.id" type="item" />
           <span class="ml-2">
-            <b>{{ getPartDisplayName(byProduct.id) }}</b>: {{ formatNumber(byProduct.amount) }}/min
+            <b>{{ getPartDisplayName(byProduct.id) }}</b>:
+          </span>
+
+          <v-text-field
+            v-model.number="byProduct.amount"
+            class="inline-inputs product-secondary-input"
+            flat
+            hide-details
+            hide-spin-buttons
+            min="0"
+            :name="`${product.id}.byProducts.${byProduct.id}`"
+            :product="product.id"
+            type="number"
+            width="60px"
+            @input="setProductQtyByByproduct(product, byProduct.id)"
+          />
+          <span>
+            /min
           </span>
         </v-chip>
       </div>
       <div
         v-if="Object.keys(product.requirements).length > 0 || product.buildingRequirements"
-        class="d-flex align-center"
+        class="d-flex flex-sm-wrap align-center"
       >
         <p class="mr-2">Requires:</p>
         <v-chip
@@ -145,8 +163,22 @@
         >
           <game-asset :subject="part.toString()" type="item" />
           <span class="ml-2">
-            <b>{{ getPartDisplayName(part.toString()) }}</b>: {{ formatNumber(requirement.amount) }}/min
+            <b>{{ getPartDisplayName(part.toString()) }}</b>:
           </span>
+          <v-text-field
+            v-model.number="requirement.amount"
+            class="inline-inputs product-secondary-input"
+            flat
+            hide-details
+            hide-spin-buttons
+            min="0"
+            :name="`${product.id}.ingredients.${part}`"
+            :product="product.id"
+            type="number"
+            width="60px"
+            @input="setProductQtyByRequirement(product, part.toString())"
+          />
+          <span>/min</span>
         </v-chip>
         <v-chip
           class="sf-chip orange"
@@ -163,6 +195,7 @@
             hide-details
             hide-spin-buttons
             min="0"
+            :name="`${product.id}.buildingAmount`"
             :product="product.id"
             type="number"
             width="60px"
@@ -190,7 +223,7 @@
     trimProduct,
   } from '@/utils/factory-management/products'
   import { getPartDisplayName } from '@/utils/helpers'
-  import { formatNumber, formatPower } from '@/utils/numberFormatter'
+  import { formatPower } from '@/utils/numberFormatter'
   import { Factory, FactoryItem } from '@/interfaces/planner/FactoryInterface'
   import { useGameDataStore } from '@/stores/game-data-store'
   import { useDisplay } from 'vuetify'
@@ -248,6 +281,66 @@
     updateOrder(props.factory.products, direction, product)
   }
 
+  type Recipe = NonNullable<ReturnType<typeof getRecipeById>>
+
+  const recipeIngredientPerMinGetter = (part: string) => {
+    return (recipe: Recipe) => {
+      const ingredient = recipe.ingredients.find(i => i.part === part)
+      if (!ingredient) {
+        console.error('No ingredient found for part', part, ' in recipe ', recipe)
+        throw new Error('No ingredient found for part!')
+      }
+      return ingredient.perMin
+    }
+  }
+  const recipeByproductPerMinGetter = (part: string) => {
+    return (recipe: Recipe) => {
+      // Seems byproduct is used in power recipes
+      const byproduct = [...recipe.products, ...(recipe.byproduct ?? [])].find(bp => bp.part === part)
+      if (!byproduct) {
+        console.error('No byproduct found for part', part, ' in recipe ', recipe)
+        throw new Error('No byproduct found for part!')
+      }
+      return byproduct.perMin
+    }
+  }
+
+  const getProductQtyByAmount = (product: FactoryItem, getAmountFromRecipe: (recipe: Recipe) => number, newAmount: number | undefined) => {
+    if (!newAmount || newAmount < 0) {
+      return 0
+    }
+    const recipe = getRecipeById(product.recipe)
+    if (!recipe) {
+      console.error('No recipe found for product!', product)
+      throw new Error('No recipe found for product!')
+    }
+    const recipeAmount = getAmountFromRecipe(recipe)
+    if (!recipeAmount) {
+      return 0
+    }
+    return recipe.products[0].perMin * newAmount / recipeAmount
+  }
+
+  const setProductQtyByByproduct = (product: FactoryItem, part: string) => {
+    const byProduct = product.byProducts?.find(bp => bp.id === part)
+    if (!byProduct) {
+      console.error('No byproduct ', part, ' found for product ', product)
+      throw new Error('No byproduct found for product!')
+    }
+    product.amount = getProductQtyByAmount(product, recipeByproductPerMinGetter(part), byProduct.amount)
+    updateFactory(props.factory)
+  }
+
+  const setProductQtyByRequirement = (product: FactoryItem, part: string) => {
+    const ingredient = product.requirements[part]
+    if (!ingredient) {
+      console.error('No ingredient ', part, ' found for product ', product)
+      throw new Error('No ingredient found for product!')
+    }
+    product.amount = getProductQtyByAmount(product, recipeIngredientPerMinGetter(part), ingredient.amount)
+    updateFactory(props.factory)
+  }
+
   const increaseProductQtyByBuilding = (product: FactoryItem) => {
     // Get what is now the new buildingRequirement for the product
     const newVal = product.buildingRequirements.amount
@@ -296,5 +389,9 @@
 <style lang="scss" scoped>
   .product {
     border-left: 5px solid #2196f3 !important
+  }
+  div.product-secondary-input:deep(input) {
+    // Match input's font size to the rest of the requirement chip
+    font-size: 0.875rem;
   }
 </style>

--- a/web/src/setup-vitest.ts
+++ b/web/src/setup-vitest.ts
@@ -1,0 +1,34 @@
+import { vi } from 'vitest'
+import path from 'node:path'
+import { readFileSync } from 'node:fs'
+import { config } from '@/config/config'
+import { createPinia, setActivePinia } from 'pinia'
+
+let gameData: any = null
+let gameDataVersion: string | null = null
+
+try {
+  gameData = JSON.parse(readFileSync(
+    path.join(__dirname, `../public/gameData_v${config.dataVersion}.json`),
+    { encoding: 'utf-8' },
+  ))
+  gameDataVersion = config.dataVersion
+} catch (err) {
+  console.error('Cannot load local game data', err)
+}
+
+// Load game data from local file
+vi.mock('./stores/local-game-data-loader.ts', () => {
+  return {
+    loadLocalGameData: () => {
+      return {
+        gameData,
+        version: gameDataVersion,
+      }
+    },
+  }
+})
+
+// Create pinia so that stores that are created during module don't throw
+// errors because pinia is not set up.
+setActivePinia(createPinia())

--- a/web/src/stores/game-data-store.ts
+++ b/web/src/stores/game-data-store.ts
@@ -3,10 +3,12 @@ import { ref } from 'vue'
 import { DataInterface } from '@/interfaces/DataInterface'
 import { config } from '@/config/config'
 import { PowerRecipe, Recipe } from '@/interfaces/Recipes'
+import { loadLocalGameData } from './local-game-data-loader'
 
 export const useGameDataStore = defineStore('game-data', () => {
-  const gameData = ref<DataInterface | null>(JSON.parse(<string>localStorage.getItem('gameData') ?? 'null'))
-  const localDataVersion = ref<string | null>(localStorage.getItem('localDataVersion') ?? null)
+  const localData = loadLocalGameData()
+  const gameData = ref<DataInterface | null>(localData.gameData)
+  const localDataVersion = ref<string | null>(localData.version)
 
   const dataVersion: string = config.dataVersion ?? ''
 

--- a/web/src/stores/local-game-data-loader.ts
+++ b/web/src/stores/local-game-data-loader.ts
@@ -1,0 +1,6 @@
+import { DataInterface } from '@/interfaces/DataInterface'
+
+export const loadLocalGameData = () => ({
+  gameData: JSON.parse(<string>localStorage.getItem('gameData') ?? 'null') as DataInterface | null,
+  version: localStorage.getItem('localDataVersion') ?? null,
+})

--- a/web/vite.config.mts
+++ b/web/vite.config.mts
@@ -74,5 +74,6 @@ export default defineConfig(() => ({
     globals: true,
     environment: 'jsdom',
     pool: 'vmThreads',
+    setupFiles: ['src/setup-vitest.ts'],
   },
 }))


### PR DESCRIPTION
Fixes #173

![image](https://github.com/user-attachments/assets/85471e9e-c3f3-4a31-813f-8edd76b637ce)

This PR contains a bit of trickery I needed to make component tests work, otherwise they raised errors because:
- game data loading was browser-specific, the easiest way was to refactor it into a module and mock the loader to load from local file during tests instead
- pinia storage was not ready at the moment `@/utils/helpers` was imported, which executed `useGameDataStore()` at the top level, so i added a very early test setup to prepare pinia

I also added names for some of the inputs to simplify selecting them in tests. I don't have a strong opinions on what should be the final names for those.
