### PR TITLE
fix: adding missing raw resources

### DIFF
--- a/parsing/gameData.json
+++ b/parsing/gameData.json
@@ -1198,68 +1198,100 @@
             "CrystalShard": "Power Shard"
         },
         "rawResources": {
-            "OreIron": {
-                "name": "Iron Ore",
-                "limit": 92100
-            },
-            "Water": {
-                "name": "Water",
-                "limit": 9007199254740991
-            },
             "Coal": {
                 "name": "Coal",
                 "limit": 42300
             },
-            "NitrogenGas": {
-                "name": "Nitrogen Gas",
-                "limit": 12000
+            "Crystal": {
+                "name": "Blue Power Slug",
+                "limit": 596
             },
-            "Sulfur": {
-                "name": "Sulfur",
-                "limit": 10800
+            "Crystal_mk2": {
+                "name": "Yellow Power Slug",
+                "limit": 389
             },
-            "SAM": {
-                "name": "SAM",
-                "limit": 10200
+            "Crystal_mk3": {
+                "name": "Purple Power Slug",
+                "limit": 257
             },
-            "OreBauxite": {
-                "name": "Bauxite",
-                "limit": 12300
+            "Gift": {
+                "name": "Gift",
+                "limit": 100000000
             },
-            "OreGold": {
-                "name": "Caterium Ore",
-                "limit": 15000
+            "HatcherParts": {
+                "name": "Hatcher Parts",
+                "limit": 100000000
             },
-            "OreCopper": {
-                "name": "Copper Ore",
-                "limit": 36900
-            },
-            "RawQuartz": {
-                "name": "Raw Quartz",
-                "limit": 13500
-            },
-            "Stone": {
-                "name": "Limestone",
-                "limit": 69900
-            },
-            "OreUranium": {
-                "name": "Uranium",
-                "limit": 2100
-            },
-            "LiquidOil": {
-                "name": "Crude Oil",
-                "limit": 12600
+            "HogParts": {
+                "name": "How Parts",
+                "limit": 100000000
             },
             "Leaves": {
                 "name": "Leaves",
                 "limit": 100000000
             },
-            "Wood": {
-                "name": "Wood",
-                "limit": 100000000
+            "LiquidOil": {
+                "name": "Crude Oil",
+                "limit": 12600
             },
             "Mycelia": {
                 "name": "Mycelia",
+                "limit": 100000000
+            },
+            "NitrogenGas": {
+                "name": "Nitrogen Gas",
+                "limit": 12000
+            },
+            "OreBauxite": {
+                "name": "Bauxite",
+                "limit": 12300
+            },
+            "OreCopper": {
+                "name": "Copper Ore",
+                "limit": 36900
+            },
+            "OreGold": {
+                "name": "Caterium Ore",
+                "limit": 15000
+            },
+            "OreIron": {
+                "name": "Iron Ore",
+                "limit": 92100
+            },
+            "OreUranium": {
+                "name": "Uranium",
+                "limit": 2100
+            },
+            "RawQuartz": {
+                "name": "Raw Quartz",
+                "limit": 13500
+            },
+            "SAM": {
+                "name": "SAM",
+                "limit": 10200
+            },
+            "SpitterParts": {
+                "name": "Spitter Parts",
+                "limit": 100000000
+            },
+            "StingerParts": {
+                "name": "Stinger Parts",
+                "limit": 100000000
+            },
+            "Stone": {
+                "name": "Limestone",
+                "limit": 69900
+            },
+            "Sulfur": {
+                "name": "Sulfur",
+                "limit": 10800
+            },
+            "Water": {
+                "name": "Water",
+                "limit": 9007199254740991
+            },
+            "Wood": {
+                "name": "Wood",
                 "limit": 100000000
             }
         }

--- a/parsing/gameData.json
+++ b/parsing/gameData.json
@@ -1223,7 +1223,7 @@
                 "limit": 100000000
             },
             "HogParts": {
-                "name": "How Parts",
+                "name": "Hog Parts",
                 "limit": 100000000
             },
             "Leaves": {

--- a/parsing/package.json
+++ b/parsing/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "start": "node dist/index.js game-docs.json gameData.json",
     "dev": "ts-node src/index.ts game-docs.json gameData.json",
-    "test": "jest --verbose --coverage",
+    "test": "jest --silent --coverage",
     "lint": "eslint . --fix --ignore-path .gitignore",
     "lint-check": "eslint . --ignore-path .gitignore"
   },

--- a/parsing/package.json
+++ b/parsing/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "start": "node dist/index.js game-docs.json gameData.json",
     "dev": "ts-node src/index.ts game-docs.json gameData.json",
-    "test": "jest --silent --coverage",
+    "test": "jest --verbose --coverage",
     "lint": "eslint . --fix --ignore-path .gitignore",
     "lint-check": "eslint . --ignore-path .gitignore"
   },

--- a/parsing/src/parts.ts
+++ b/parsing/src/parts.ts
@@ -317,23 +317,64 @@ function getRawResources(data: any[]): { [key: string]: ParserRawResource } {
             }
         });
 
-    // Manually add "Leaves" and "Wood" to the rawResources list
+    // Manually add Leaves, Wood, Mycelia to the rawResources list
     rawResources["Leaves"] = {
         name: "Leaves",
         limit: limits["Leaves"] || 100000000  
     };
-
     rawResources["Wood"] = {
         name: "Wood",
         limit: limits["Wood"] || 100000000  
     };
-
     rawResources["Mycelia"] = {
         name: "Mycelia",
         limit: limits["Mycelia"] || 100000000  
     };
 
-    return rawResources;
+    //Manually add alien parts to the rawResources list
+    rawResources["HatcherParts"] = {
+        name: "Hatcher Parts",
+        limit: 100000000  
+    };
+    rawResources["HogParts"] = {
+        name: "How Parts",
+        limit: 100000000  
+    };
+    rawResources["SpitterParts"] = {
+        name: "Spitter Parts",
+        limit: 100000000  
+    };
+    rawResources["StingerParts"] = {
+        name: "Stinger Parts",
+        limit: 100000000  
+    };
+
+    //Manually add slugs. Numbers from Satisfactory Calculator map
+    rawResources["Crystal"] = {
+        name: "Blue Power Slug",
+        limit: 596  
+    };
+    rawResources["Crystal_mk2"] = {
+        name: "Yellow Power Slug",
+        limit: 389  
+    };
+    rawResources["Crystal_mk3"] = {
+        name: "Purple Power Slug",
+        limit: 257  
+    };
+    
+    //Ficmas items
+    rawResources["Gift"] = {
+        name: "Gift",
+        limit: 100000000  
+    };
+
+    // Order the rawResources by key
+    const orderedRawResources: { [key: string]: ParserRawResource } = {};
+    Object.keys(rawResources).sort().forEach(key => {
+        orderedRawResources[key] = rawResources[key];
+    });
+    return orderedRawResources;
 }
 
 function fixItemNames(items: ParserItemDataInterface): void {

--- a/parsing/tests/parsing.spec.ts
+++ b/parsing/tests/parsing.spec.ts
@@ -23,14 +23,20 @@ describe('common', () => {
             expect(Object.keys(results.items.parts).length).toBe(168);
         })
         test('raw resources should be of expected length', async () => {
-            // debugging code to print out all raw resources for verification
-            // let rawString = '';
-            // Object.keys(results.items.rawResources).forEach((key: string) => {
-            //     const rawResource = results.items.rawResources[key];
-            //     rawString +=`Key: ${key}, Name: ${rawResource.name}, Limit: ${rawResource.limit} \n`;
-            // });
-            // console.log(rawString)
-            expect(Object.keys(results.items.rawResources).length).toBe(23);
+            //debugging code to print out all raw resources for verification
+            let rawString = '';
+            Object.keys(results.items.rawResources).forEach((key: string) => {
+                const rawResource = results.items.rawResources[key];
+                rawString +=`Key: ${key}, Name: ${rawResource.name}, Limit: ${rawResource.limit} \n`;
+            });
+            console.log(rawString)
+            expect(Object.keys(results.items.rawResources).length).toBe(24);
+            expect(results.items.rawResources["Coal"].name).toBe('Coal');
+            expect(results.items.rawResources["Coal"].limit).toBe(42300);
+            expect(results.items.rawResources["Crystal"].name).toBe('Blue Power Slug');
+            expect(results.items.rawResources["Crystal"].limit).toBe(596);
+            expect(results.items.rawResources["Wood"].name).toBe('Wood');
+            expect(results.items.rawResources["Wood"].limit).toBe(100000000);
         })
 
         test('iron plate part should be correct', async () => {

--- a/parsing/tests/parsing.spec.ts
+++ b/parsing/tests/parsing.spec.ts
@@ -22,6 +22,16 @@ describe('common', () => {
         test('parts should be of expected length', async () => {
             expect(Object.keys(results.items.parts).length).toBe(168);
         })
+        test('raw resources should be of expected length', async () => {
+            // debugging code to print out all raw resources for verification
+            // let rawString = '';
+            // Object.keys(results.items.rawResources).forEach((key: string) => {
+            //     const rawResource = results.items.rawResources[key];
+            //     rawString +=`Key: ${key}, Name: ${rawResource.name}, Limit: ${rawResource.limit} \n`;
+            // });
+            // console.log(rawString)
+            expect(Object.keys(results.items.rawResources).length).toBe(23);
+        })
 
         test('iron plate part should be correct', async () => {
             const part : ParserPart = results.items.parts["IronPlate"];

--- a/parsing/tests/parsing.spec.ts
+++ b/parsing/tests/parsing.spec.ts
@@ -24,12 +24,12 @@ describe('common', () => {
         })
         test('raw resources should be of expected length', async () => {
             //debugging code to print out all raw resources for verification
-            let rawString = '';
-            Object.keys(results.items.rawResources).forEach((key: string) => {
-                const rawResource = results.items.rawResources[key];
-                rawString +=`Key: ${key}, Name: ${rawResource.name}, Limit: ${rawResource.limit} \n`;
-            });
-            console.log(rawString)
+            // let rawString = '';
+            // Object.keys(results.items.rawResources).forEach((key: string) => {
+            //     const rawResource = results.items.rawResources[key];
+            //     rawString +=`Key: ${key}, Name: ${rawResource.name}, Limit: ${rawResource.limit} \n`;
+            // });
+            // console.log(rawString)
             expect(Object.keys(results.items.rawResources).length).toBe(24);
             expect(results.items.rawResources["Coal"].name).toBe('Coal');
             expect(results.items.rawResources["Coal"].limit).toBe(42300);

--- a/web/public/gameData_v1.0-26.json
+++ b/web/public/gameData_v1.0-26.json
@@ -1198,68 +1198,100 @@
             "CrystalShard": "Power Shard"
         },
         "rawResources": {
-            "OreIron": {
-                "name": "Iron Ore",
-                "limit": 92100
-            },
-            "Water": {
-                "name": "Water",
-                "limit": 9007199254740991
-            },
             "Coal": {
                 "name": "Coal",
                 "limit": 42300
             },
-            "NitrogenGas": {
-                "name": "Nitrogen Gas",
-                "limit": 12000
+            "Crystal": {
+                "name": "Blue Power Slug",
+                "limit": 596
             },
-            "Sulfur": {
-                "name": "Sulfur",
-                "limit": 10800
+            "Crystal_mk2": {
+                "name": "Yellow Power Slug",
+                "limit": 389
             },
-            "SAM": {
-                "name": "SAM",
-                "limit": 10200
+            "Crystal_mk3": {
+                "name": "Purple Power Slug",
+                "limit": 257
             },
-            "OreBauxite": {
-                "name": "Bauxite",
-                "limit": 12300
+            "Gift": {
+                "name": "Gift",
+                "limit": 100000000
             },
-            "OreGold": {
-                "name": "Caterium Ore",
-                "limit": 15000
+            "HatcherParts": {
+                "name": "Hatcher Parts",
+                "limit": 100000000
             },
-            "OreCopper": {
-                "name": "Copper Ore",
-                "limit": 36900
-            },
-            "RawQuartz": {
-                "name": "Raw Quartz",
-                "limit": 13500
-            },
-            "Stone": {
-                "name": "Limestone",
-                "limit": 69900
-            },
-            "OreUranium": {
-                "name": "Uranium",
-                "limit": 2100
-            },
-            "LiquidOil": {
-                "name": "Crude Oil",
-                "limit": 12600
+            "HogParts": {
+                "name": "How Parts",
+                "limit": 100000000
             },
             "Leaves": {
                 "name": "Leaves",
                 "limit": 100000000
             },
-            "Wood": {
-                "name": "Wood",
-                "limit": 100000000
+            "LiquidOil": {
+                "name": "Crude Oil",
+                "limit": 12600
             },
             "Mycelia": {
                 "name": "Mycelia",
+                "limit": 100000000
+            },
+            "NitrogenGas": {
+                "name": "Nitrogen Gas",
+                "limit": 12000
+            },
+            "OreBauxite": {
+                "name": "Bauxite",
+                "limit": 12300
+            },
+            "OreCopper": {
+                "name": "Copper Ore",
+                "limit": 36900
+            },
+            "OreGold": {
+                "name": "Caterium Ore",
+                "limit": 15000
+            },
+            "OreIron": {
+                "name": "Iron Ore",
+                "limit": 92100
+            },
+            "OreUranium": {
+                "name": "Uranium",
+                "limit": 2100
+            },
+            "RawQuartz": {
+                "name": "Raw Quartz",
+                "limit": 13500
+            },
+            "SAM": {
+                "name": "SAM",
+                "limit": 10200
+            },
+            "SpitterParts": {
+                "name": "Spitter Parts",
+                "limit": 100000000
+            },
+            "StingerParts": {
+                "name": "Stinger Parts",
+                "limit": 100000000
+            },
+            "Stone": {
+                "name": "Limestone",
+                "limit": 69900
+            },
+            "Sulfur": {
+                "name": "Sulfur",
+                "limit": 10800
+            },
+            "Water": {
+                "name": "Water",
+                "limit": 9007199254740991
+            },
+            "Wood": {
+                "name": "Wood",
                 "limit": 100000000
             }
         }

--- a/web/public/gameData_v1.0-26.json
+++ b/web/public/gameData_v1.0-26.json
@@ -1223,7 +1223,7 @@
                 "limit": 100000000
             },
             "HogParts": {
-                "name": "How Parts",
+                "name": "Hog Parts",
                 "limit": 100000000
             },
             "Leaves": {

--- a/web/src/config/config.ts
+++ b/web/src/config/config.ts
@@ -1,4 +1,4 @@
 export const config = {
   apiUrl: import.meta.env.VITE_ENV === 'dev' ? 'http://localhost:3001' : 'https://api.satisfactory-factories.app',
-  dataVersion: '1.0-25',
+  dataVersion: '1.0-26',
 }


### PR DESCRIPTION
The first in a series of parser upgrades. 

This pull request includes updates to the raw resources data and related functionality in the parsing module to include missing raw resources and sort the final list of raw resources, ensuring the data file has the accurate list of raw resources. 

None of these new resources should appear in the statistics panel. There are a few recipes today that are missing these items, and will allow recipes using them to work. It's expected that the impact of this fix is very low, but we know some people creating [Ficmas recipes have noticed](https://github.com/satisfactory-factories/application/issues/274). 

fixes #274



