### PR TITLE
PowerProducer: fix browser compatibility for Firefox ESR

### DIFF
--- a/web/src/components/planner/products/PowerProducer.vue
+++ b/web/src/components/planner/products/PowerProducer.vue
@@ -221,7 +221,7 @@
       buildings.add(recipe.building.name)
     })
 
-    const buildingsArray: string[] = buildings.values().toArray()
+    const buildingsArray: string[] = [...buildings.values()]
 
     // Sort
     buildingsArray.sort((a, b) => a.localeCompare(b))


### PR DESCRIPTION
This change should fix #289

Looks like [toArray is only available in Firefox starting with 131](https://caniuse.com/?search=toArray), and the user reported running [floorp browser which is based on Firefox ESR (128)](https://www.reddit.com/r/Floorp/comments/1hdvmxr/useragent_for_floorp_identify_as_firefox_128/)