### PR TITLE
fix: adding remaining label

### DIFF
--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -118,7 +118,7 @@
                 class="sf-chip small"
                 :class="part.satisfied ? 'green' : 'red'"
               >
-                <b>{{ formatNumber(part.amountRemaining) }}/min {{ getSatisfactoryLabel(part.amountRemaining) }}</b>
+                <b>{{ formatNumber(part.amountRemaining) }}/min {{ getSatisfactionLabel(part.amountRemaining) }}</b>
               </v-chip>
             </div>
           </td>
@@ -257,7 +257,7 @@
     return factory.exportCalculator[part]?.selected === factoryId.toString()
   }
 
-  const getSatisfactoryLabel = (total: number) => {
+  const getSatisfactionLabel = (total: number) => {
     return total >= 0 ? 'remaining' : 'shortage'
   }
 

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -258,7 +258,7 @@
   }
 
   const getSatisfactionLabel = (total: number) => {
-    return total >= 0 ? 'remaining' : 'shortage'
+    return total >= 0 ? 'surplus' : 'shortage'
   }
 
   // const getCalculatorSettings = (factory: Factory, part: string | null): ExportCalculatorSettings | undefined => {

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -118,7 +118,7 @@
                 class="sf-chip small"
                 :class="part.satisfied ? 'green' : 'red'"
               >
-                <b>{{ formatNumber(part.amountRemaining) }}/min remaining</b>
+                <b>{{ formatNumber(part.amountRemaining) }}/min {{ getSatisfactoryLabel(part.amountRemaining) }}</b>
               </v-chip>
             </div>
           </td>
@@ -255,6 +255,10 @@
       return false
     }
     return factory.exportCalculator[part]?.selected === factoryId.toString()
+  }
+
+  const getSatisfactoryLabel = (total: number) => {
+    return total >= 0 ? 'remaining' : 'shortage'
   }
 
   // const getCalculatorSettings = (factory: Factory, part: string | null): ExportCalculatorSettings | undefined => {

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -118,7 +118,7 @@
                 class="sf-chip small"
                 :class="part.satisfied ? 'green' : 'red'"
               >
-                <b>{{ formatNumber(part.amountRemaining) }}/min</b>
+                <b>{{ formatNumber(part.amountRemaining) }}/min remaining</b>
               </v-chip>
             </div>
           </td>


### PR DESCRIPTION
Adds a little suffix to the parts 'remaining'. If it is a negative number (and is highlighted red), it shows the suffix 'shortage'.

![image](https://github.com/user-attachments/assets/374722d2-23b6-45e6-bfc7-2aea53c740fd)

![image](https://github.com/user-attachments/assets/bca16ad3-2e05-433e-841f-62854c9ccc39)
