### PR TITLE
315 non exportable parts imports fix

### DIFF
--- a/web/src/components/Templates.vue
+++ b/web/src/components/Templates.vue
@@ -50,6 +50,7 @@
   import { useAppStore } from '@/stores/app-store'
   import { Factory } from '@/interfaces/planner/FactoryInterface'
   import { create290Scenario } from '@/utils/factory-setups/290-multiple-byproduct-imports'
+  import { create315Scenario } from '@/utils/factory-setups/315-non-exportable-parts-imports'
 
   const { setFactories, isDebugMode } = useAppStore()
 
@@ -86,9 +87,16 @@
       isDebug: true,
     },
     {
-      name: 'Multi-input',
+      name: '#290 Multiple product imports',
       description: '3 factory setup where one factory is importing the same product from two different factories. Related to issue #290. The Imports on Iron Plates should render correctly with the correct part name, and NOT be called "IronPlate", rather "Iron Plate".',
       data: create290Scenario().getFactories(),
+      show: isDebugMode,
+      isDebug: true,
+    },
+    {
+      name: '#315 Import exportable parts',
+      description: '#315 - For testing import candidate code. Aluminium factory in this example should not be able to import Copper Ingots from Copper Parts',
+      data: create315Scenario().getFactories(),
       show: isDebugMode,
       isDebug: true,
     },

--- a/web/src/utils/factory-management/inputs.spec.ts
+++ b/web/src/utils/factory-management/inputs.spec.ts
@@ -169,6 +169,17 @@ describe('inputs', () => {
         expect(result[1]).toBeUndefined()
       })
 
+      it('should return empty if all possible import parts have been exhausted', () => {
+        const factories = create315Scenario().getFactories()
+        calculateFactories(factories, gameData, true)
+
+        const aluminiumPartsFac = findFacByName('Aluminium Parts Fac', factories)
+
+        const result = calculateImportCandidates(aluminiumPartsFac, calculatePossibleImports(aluminiumPartsFac, getExportableFactories(factories)))
+
+        expect(result).toHaveLength(0)
+      })
+
       describe('Multiple import candidates', () => {
         beforeEach(() => {
           // Add RIPs to iron rods fac 2. Screws already has iron rods fac 2 selected for Iron Rods, so this factory should show up again in the list.

--- a/web/src/utils/factory-management/inputs.spec.ts
+++ b/web/src/utils/factory-management/inputs.spec.ts
@@ -13,6 +13,7 @@ import {
 import { getExportableFactories } from '@/utils/factory-management/exports'
 import { gameData } from '@/utils/gameData'
 import { create290Scenario } from '@/utils/factory-setups/290-multiple-byproduct-imports'
+import { create315Scenario } from '@/utils/factory-setups/315-non-exportable-parts-imports'
 
 describe('inputs', () => {
   let mockFactory: Factory
@@ -167,6 +168,7 @@ describe('inputs', () => {
         expect(result[0].name).toBe(ironRodsFac.name)
         expect(result[1]).toBeUndefined()
       })
+
       describe('Multiple import candidates', () => {
         beforeEach(() => {
           // Add RIPs to iron rods fac 2. Screws already has iron rods fac 2 selected for Iron Rods, so this factory should show up again in the list.
@@ -327,6 +329,19 @@ describe('inputs', () => {
         expect(partResult2).toHaveLength(1)
         expect(partResult[0]).toBe('IronIngot')
         expect(partResult2[0]).toBe('IronIngot') // #290 bug was here where this was empty as it was already "selected".
+        expect(partResult[1]).toBeUndefined()
+      })
+      it('should not show parts that are not exportable', () => {
+        const factories = create315Scenario().getFactories()
+        const copperParts = findFacByName('Copper Parts Fac', factories)
+        const aluminiumPartsFac = findFacByName('Aluminium Parts Fac', factories)
+
+        // Calculate factories
+        calculateFactories(factories, gameData, true)
+
+        // Now check that we should NOT be able to select copper ingots from the copperPartsFac within aluminiumPartsFac.
+        const partResult = importPartSelections(copperParts, aluminiumPartsFac, 1)
+        expect(partResult[0]).toStrictEqual('CopperSheet')
         expect(partResult[1]).toBeUndefined()
       })
     })

--- a/web/src/utils/factory-management/inputs.ts
+++ b/web/src/utils/factory-management/inputs.ts
@@ -163,7 +163,11 @@ export const importPartSelections = (
   Object.keys(inputFactory.parts).forEach(part => {
     const selectedPartKey = `${inputFactory.id}-${part}`
     if (partsWithRequirements.includes(part) && !selectedFactoryParts.has(selectedPartKey)) {
-      availableInputParts.add(part)
+      // We need to also check if the part is exportable
+      const partData = inputFactory.parts[part]
+      if (partData.exportable) {
+        availableInputParts.add(part)
+      }
     }
   })
 

--- a/web/src/utils/factory-management/inputs.ts
+++ b/web/src/utils/factory-management/inputs.ts
@@ -88,7 +88,8 @@ export const calculateImportCandidates = (factory: Factory, possibleImports: Fac
   const importCandidates = new Set<string>()
   possibleImports.forEach(importFac => {
     Object.keys(importFac.parts).forEach(part => {
-      if (partsWithRequirements.includes(part)) {
+      const partData = importFac.parts[part]
+      if (partsWithRequirements.includes(part) && partData.exportable) {
         importCandidates.add(`${importFac.id}-${part}`)
       }
     })
@@ -162,12 +163,14 @@ export const importPartSelections = (
   // Using Sets like this ensures uniqueness and prevents duplicate inputs.
   Object.keys(inputFactory.parts).forEach(part => {
     const selectedPartKey = `${inputFactory.id}-${part}`
-    if (partsWithRequirements.includes(part) && !selectedFactoryParts.has(selectedPartKey)) {
-      // We need to also check if the part is exportable
-      const partData = inputFactory.parts[part]
-      if (partData.exportable) {
-        availableInputParts.add(part)
-      }
+    const partData = inputFactory.parts[part]
+
+    if (
+      partsWithRequirements.includes(part) &&
+      !selectedFactoryParts.has(selectedPartKey) &&
+      partData.exportable
+    ) {
+      availableInputParts.add(part)
     }
   })
 

--- a/web/src/utils/factory-setups/315-non-exportable-parts-imports.spec.ts
+++ b/web/src/utils/factory-setups/315-non-exportable-parts-imports.spec.ts
@@ -1,0 +1,43 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { calculateFactories, findFacByName } from '@/utils/factory-management/factory'
+import { gameData } from '@/utils/gameData'
+import { create315Scenario } from '@/utils/factory-setups/315-non-exportable-parts-imports'
+
+let factories: Factory[]
+let copperIngots: Factory
+let copperPartsFac: Factory
+let aluminiumPartsFac: Factory
+
+describe('315 Scenario Plan', () => {
+  beforeAll(() => {
+    const templateInstance = create315Scenario()
+    factories = templateInstance.getFactories()
+    copperIngots = findFacByName('Copper Ingots Fac', factories)
+    copperPartsFac = findFacByName('Copper Parts Fac', factories)
+    aluminiumPartsFac = findFacByName('Aluminium Parts Fac', factories)
+    calculateFactories(factories, gameData, true) // Needed to calculate part metrics, dependencies will not work otherwise.
+    calculateFactories(factories, gameData)
+  })
+
+  describe('Aluminium Processing', () => {
+    it('should have the correct products', () => {
+      expect(aluminiumPartsFac.products.length).toBe(2)
+      expect(aluminiumPartsFac.products[0].id).toBe('AluminumPlateReinforced')
+      expect(aluminiumPartsFac.products[0].amount).toBe(10)
+      expect(aluminiumPartsFac.products[0].recipe).toBe('HeatSink')
+      expect(aluminiumPartsFac.products[1].id).toBe('AluminumPlate')
+      expect(aluminiumPartsFac.products[1].amount).toBe(50)
+      expect(aluminiumPartsFac.products[1].recipe).toBe('AluminumSheet')
+    })
+    // It should not have two
+    it('should have a single input', () => {
+      expect(aluminiumPartsFac.inputs.length).toBe(1)
+      expect(aluminiumPartsFac.inputs[0]).toEqual({
+        factoryId: copperIngots.id,
+        outputPart: 'CopperIngot',
+        amount: 20,
+      })
+    })
+  })
+})

--- a/web/src/utils/factory-setups/315-non-exportable-parts-imports.spec.ts
+++ b/web/src/utils/factory-setups/315-non-exportable-parts-imports.spec.ts
@@ -6,6 +6,7 @@ import { create315Scenario } from '@/utils/factory-setups/315-non-exportable-par
 
 let factories: Factory[]
 let copperIngots: Factory
+let copperParts: Factory
 let aluminiumPartsFac: Factory
 
 describe('315 Scenario Plan', () => {
@@ -13,6 +14,7 @@ describe('315 Scenario Plan', () => {
     const templateInstance = create315Scenario()
     factories = templateInstance.getFactories()
     copperIngots = findFacByName('Copper Ingots Fac', factories)
+    copperParts = findFacByName('Copper Parts Fac', factories)
     aluminiumPartsFac = findFacByName('Aluminium Parts Fac', factories)
     calculateFactories(factories, gameData, true) // Needed to calculate part metrics, dependencies will not work otherwise.
     calculateFactories(factories, gameData)
@@ -28,13 +30,18 @@ describe('315 Scenario Plan', () => {
       expect(aluminiumPartsFac.products[1].amount).toBe(50)
       expect(aluminiumPartsFac.products[1].recipe).toBe('AluminumSheet')
     })
-    // It should not have two
-    it('should have a single input', () => {
-      expect(aluminiumPartsFac.inputs.length).toBe(1)
+    // It should not have three imports (one in the scenario is purposefully invalid on a non-exportable part)
+    it('should contain the correct inputs', () => {
+      expect(aluminiumPartsFac.inputs.length).toBe(2)
       expect(aluminiumPartsFac.inputs[0]).toEqual({
         factoryId: copperIngots.id,
         outputPart: 'CopperIngot',
         amount: 20,
+      })
+      expect(aluminiumPartsFac.inputs[1]).toEqual({
+        factoryId: copperParts.id,
+        outputPart: 'CopperSheet',
+        amount: 30,
       })
     })
   })

--- a/web/src/utils/factory-setups/315-non-exportable-parts-imports.spec.ts
+++ b/web/src/utils/factory-setups/315-non-exportable-parts-imports.spec.ts
@@ -6,7 +6,6 @@ import { create315Scenario } from '@/utils/factory-setups/315-non-exportable-par
 
 let factories: Factory[]
 let copperIngots: Factory
-let copperPartsFac: Factory
 let aluminiumPartsFac: Factory
 
 describe('315 Scenario Plan', () => {
@@ -14,7 +13,6 @@ describe('315 Scenario Plan', () => {
     const templateInstance = create315Scenario()
     factories = templateInstance.getFactories()
     copperIngots = findFacByName('Copper Ingots Fac', factories)
-    copperPartsFac = findFacByName('Copper Parts Fac', factories)
     aluminiumPartsFac = findFacByName('Aluminium Parts Fac', factories)
     calculateFactories(factories, gameData, true) // Needed to calculate part metrics, dependencies will not work otherwise.
     calculateFactories(factories, gameData)

--- a/web/src/utils/factory-setups/315-non-exportable-parts-imports.ts
+++ b/web/src/utils/factory-setups/315-non-exportable-parts-imports.ts
@@ -5,9 +5,9 @@ import { addInputToFactory } from '@/utils/factory-management/inputs'
 
 export const create315Scenario = (): { getFactories: () => Factory[] } => {
   // Local variables to ensure a fresh instance on every call
-  const copperIngotsFac = newFactory('Copper Ingots Fac', 0)
-  const copperPartsFac = newFactory('Copper Parts Fac', 1)
-  const aluminiumPartsFac = newFactory('Aluminium Parts Fac', 2)
+  const copperIngotsFac = newFactory('Copper Ingots Fac', 0, 1)
+  const copperPartsFac = newFactory('Copper Parts Fac', 1, 2)
+  const aluminiumPartsFac = newFactory('Aluminium Parts Fac', 2, 3)
 
   // Store factories in an array
   const factories = [copperIngotsFac, copperPartsFac, aluminiumPartsFac]
@@ -47,6 +47,11 @@ export const create315Scenario = (): { getFactories: () => Factory[] } => {
       factoryId: copperIngotsFac.id,
       outputPart: 'CopperIngot',
       amount: 20,
+    })
+    addInputToFactory(aluminiumPartsFac, {
+      factoryId: copperPartsFac.id,
+      outputPart: 'CopperSheet',
+      amount: 30,
     })
 
     // INVALID INPUT and should be removed by code

--- a/web/src/utils/factory-setups/315-non-exportable-parts-imports.ts
+++ b/web/src/utils/factory-setups/315-non-exportable-parts-imports.ts
@@ -1,0 +1,68 @@
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { newFactory } from '@/utils/factory-management/factory'
+import { addProductToFactory } from '@/utils/factory-management/products'
+import { addInputToFactory } from '@/utils/factory-management/inputs'
+
+export const create315Scenario = (): { getFactories: () => Factory[] } => {
+  // Local variables to ensure a fresh instance on every call
+  const copperIngotsFac = newFactory('Copper Ingots Fac', 0)
+  const copperPartsFac = newFactory('Copper Parts Fac', 1)
+  const aluminiumPartsFac = newFactory('Aluminium Parts Fac', 2)
+
+  // Store factories in an array
+  const factories = [copperIngotsFac, copperPartsFac, aluminiumPartsFac]
+
+  // Add products, producers, and imports
+  const addProductsToFactories = () => {
+    addProductToFactory(copperIngotsFac, {
+      id: 'CopperIngot',
+      amount: 300,
+      recipe: 'IngotCopper',
+    })
+    addProductToFactory(copperPartsFac, {
+      id: 'CopperSheet',
+      amount: 100,
+      recipe: 'CopperSheet',
+    })
+    addProductToFactory(aluminiumPartsFac, {
+      id: 'AluminumPlateReinforced',
+      amount: 10,
+      recipe: 'HeatSink',
+    })
+    addProductToFactory(aluminiumPartsFac, {
+      id: 'AluminumPlate',
+      amount: 50,
+      recipe: 'AluminumSheet',
+    })
+  }
+
+  const addImportsToFactories = () => {
+    addInputToFactory(copperPartsFac, {
+      factoryId: copperIngotsFac.id,
+      outputPart: 'CopperIngot',
+      amount: 200,
+    })
+
+    addInputToFactory(aluminiumPartsFac, {
+      factoryId: copperIngotsFac.id,
+      outputPart: 'CopperIngot',
+      amount: 20,
+    })
+
+    // INVALID INPUT and should be removed by code
+    addInputToFactory(aluminiumPartsFac, {
+      factoryId: copperPartsFac.id,
+      outputPart: 'CopperIngot',
+      amount: 100,
+    })
+  }
+
+  // Execute setup functions
+  addProductsToFactories()
+  addImportsToFactories()
+
+  // Return an object with a method to access the factories
+  return {
+    getFactories: () => factories, // Expose factories as a method
+  }
+}


### PR DESCRIPTION
Closes #315 

<img width="1074" alt="Screenshot 2025-01-02 at 13 58 42" src="https://github.com/user-attachments/assets/1ac080cc-7623-418f-8f37-1a197b266f3a" />

Now correctly stops the user from selecting the part and also removes invalid imports for non exportable parts via `calculateFactories`.