### PR TITLE
Multiple inputs helper buttons logic fixes

### DIFF
--- a/web/src/components/Templates.vue
+++ b/web/src/components/Templates.vue
@@ -53,6 +53,7 @@
   import { create315Scenario } from '@/utils/factory-setups/315-non-exportable-parts-imports'
   import { create317Scenario } from '@/utils/factory-setups/317-malformed-plan'
   import { createMaelsBigBoiPlan } from '@/utils/factory-setups/maels-big-boi-plan'
+  import { create251Scenario } from '@/utils/factory-setups/251-redundant-import'
 
   const { prepareLoader, isDebugMode } = useAppStore()
 
@@ -113,6 +114,13 @@
       name: 'Invalid migration',
       description: 'Contains a factory plan that has lots of invalid data. This was a real plan that broke the app, and was used to fix the migration code. It is expected that when you load the template, the plan operates effectively. Originally, supply for certain factories e.g. Gun Powder was broken due to missing part data (due to errors).',
       data: create317Scenario(),
+      show: isDebugMode,
+      isDebug: true,
+    },
+    {
+      name: 'Redundant Imports',
+      description: 'Contains a factory plan where there is a redundant import (on Iron Plates Fac). The UI should show this properly as a warning.',
+      data: create251Scenario().getFactories(),
       show: isDebugMode,
       isDebug: true,
     },

--- a/web/src/components/planner/PlannerFactoryImports.vue
+++ b/web/src/components/planner/PlannerFactoryImports.vue
@@ -94,7 +94,7 @@
               color="yellow"
               prepend-icon="fas fa-arrow-down"
               size="default"
-              @click="updateInputToSatisfy(factory, input)"
+              @click="updateInputToSatisfy(inputIndex, factory)"
             >Trim</v-btn>
             <v-btn
               v-show="input.outputPart && !requirementSatisfied(factory, input.outputPart)"
@@ -102,7 +102,7 @@
               color="green"
               prepend-icon="fas fa-arrow-up"
               size="default"
-              @click="updateInputToSatisfy(factory, input)"
+              @click="updateInputToSatisfy(inputIndex, factory)"
             >Satisfy</v-btn>
             <v-btn
               class="rounded"
@@ -132,7 +132,8 @@
               <span class="ml-2">Redundant!</span>
             </v-chip>
           </div>
-        </div></v-card>
+        </div>
+      </v-card>
       <div class="input-row d-flex align-center">
         <v-btn
           v-show="Object.keys(factory.parts).length > 0"
@@ -161,7 +162,7 @@
     calculateImportCandidates,
     calculatePossibleImports,
     importFactorySelections,
-    importPartSelections, isImportRedundant,
+    importPartSelections, isImportRedundant, satisfyImport,
   } from '@/utils/factory-management/inputs'
   import { getPartDisplayName } from '@/utils/helpers'
   import { formatNumber } from '@/utils/numberFormatter'
@@ -170,7 +171,6 @@
   import { getExportableFactories } from '@/utils/factory-management/exports'
   import { calculateDependencies } from '@/utils/factory-management/dependencies'
   import { useGameDataStore } from '@/stores/game-data-store'
-  import { shouldShowNotInDemand } from '@/utils/factory-management/products'
 
   const { getFactories } = useAppStore()
   const { getGameData } = useGameDataStore()
@@ -307,14 +307,9 @@
     return requirement.amountRemaining > 0
   }
 
-  const updateInputToSatisfy = (factory: Factory, input: FactoryInput) => {
-    if (!input.outputPart) {
-      console.error('updateInputToSatisfy: No output part selected for input:', input)
-      return
-    }
-    input.amount = factory.parts[input.outputPart].amountRequired
-
-    updateFactories(factory, input)
+  const updateInputToSatisfy = (inputIndex: number, factory: Factory) => {
+    satisfyImport(inputIndex, factory)
+    updateFactories(factory, factory.inputs[inputIndex])
   }
 
   const updateFactories = (factory: Factory, input: FactoryInput) => {

--- a/web/src/components/planner/PlannerFactoryImports.vue
+++ b/web/src/components/planner/PlannerFactoryImports.vue
@@ -127,6 +127,10 @@
               <i class="fas fa-exclamation-triangle" />
               <span class="ml-2">No amount set!</span>
             </v-chip>
+            <v-chip v-if="isImportRedundant(inputIndex, factory)" class="sf-chip small orange">
+              <i class="fas fa-exclamation-triangle" />
+              <span class="ml-2">Redundant!</span>
+            </v-chip>
           </div>
         </div></v-card>
       <div class="input-row d-flex align-center">
@@ -157,7 +161,7 @@
     calculateImportCandidates,
     calculatePossibleImports,
     importFactorySelections,
-    importPartSelections,
+    importPartSelections, isImportRedundant,
   } from '@/utils/factory-management/inputs'
   import { getPartDisplayName } from '@/utils/helpers'
   import { formatNumber } from '@/utils/numberFormatter'
@@ -166,6 +170,7 @@
   import { getExportableFactories } from '@/utils/factory-management/exports'
   import { calculateDependencies } from '@/utils/factory-management/dependencies'
   import { useGameDataStore } from '@/stores/game-data-store'
+  import { shouldShowNotInDemand } from '@/utils/factory-management/products'
 
   const { getFactories } = useAppStore()
   const { getGameData } = useGameDataStore()

--- a/web/src/utils/factory-management/dependencies.ts
+++ b/web/src/utils/factory-management/dependencies.ts
@@ -184,7 +184,7 @@ export const calculateFactoryDependencies = (
 
     // Check if the provider factory has the part that the dependant factory is requesting.
     if (!loadMode && !provider.parts[input.outputPart]) {
-      console.error(`Factory ${provider.name} (${provider.id}) does not have the part ${input.outputPart} requested by ${factory.name} (${factory.id}). Removing input.`)
+      console.error(`dependencies: calculateFactoryDependencies: Factory ${provider.name} (${provider.id}) does not have the part ${input.outputPart} requested by ${factory.name} (${factory.id}). Removing input.`)
       factory.inputs = factory.inputs.filter(i => i !== input)
       return
     }

--- a/web/src/utils/factory-management/inputs.spec.ts
+++ b/web/src/utils/factory-management/inputs.spec.ts
@@ -8,13 +8,14 @@ import {
   addInputToFactory, calculateAbleToImport,
   calculateImportCandidates,
   calculatePossibleImports, importFactorySelections,
-  importPartSelections, isImportRedundant,
+  importPartSelections, isImportRedundant, satisfyImport,
 } from '@/utils/factory-management/inputs'
 import { getExportableFactories } from '@/utils/factory-management/exports'
 import { gameData } from '@/utils/gameData'
 import { create290Scenario } from '@/utils/factory-setups/290-multiple-byproduct-imports'
 import { create315Scenario } from '@/utils/factory-setups/315-non-exportable-parts-imports'
 import { calculateDependencies } from '@/utils/factory-management/dependencies'
+import { create251Scenario } from '@/utils/factory-setups/251-redundant-import'
 
 describe('inputs', () => {
   let mockFactory: Factory
@@ -510,6 +511,35 @@ describe('inputs', () => {
           expect(isImportRedundant(0, mockFactory2)).toBe(false)
         })
       })
+    })
+  })
+  describe('satisfyImport', () => {
+    let factories: Factory[]
+    let ironPlateFac: Factory
+    beforeEach(() => {
+      factories = create251Scenario().getFactories()
+      ironPlateFac = findFacByName('Iron Plates', factories)
+    })
+
+    it('should update the import amount when there are no other factories', () => {
+      // Remove the additional import in iron plates
+      ironPlateFac.inputs = ironPlateFac.inputs.slice(0, 1)
+
+      calculateFactories(factories, gameData)
+      satisfyImport(0, ironPlateFac)
+
+      expect(ironPlateFac.inputs[0].amount).toBe(75)
+    })
+
+    it('should update the import based on other imports', () => {
+      // Set up the imports so import index 1 should be 25
+      ironPlateFac.inputs[0].amount = 50
+      ironPlateFac.inputs[1].amount = 0
+
+      calculateFactories(factories, gameData)
+      satisfyImport(1, ironPlateFac)
+      expect(ironPlateFac.inputs[0].amount).toBe(50) // Shouldn't have changed
+      expect(ironPlateFac.inputs[1].amount).toBe(25)
     })
   })
 })

--- a/web/src/utils/factory-management/inputs.spec.ts
+++ b/web/src/utils/factory-management/inputs.spec.ts
@@ -499,6 +499,16 @@ describe('inputs', () => {
           // The total requirement is 150, and we have 1000 from the other import. So this import IS redundant.
           expect(isImportRedundant(1, mockFactory2)).toBe(true)
         })
+
+        // Import favouring largest
+        it('should return false if the current import is the largest', () => {
+          // Increase the input from factory 3 to be higher than the requirement
+          mockFactory2.inputs[0].amount = 500
+          calculateFactories([mockFactory, mockFactory2, mockFactory3], gameData)
+
+          // The total requirement is 150, and we have 1000 from the other import. So this import IS redundant.
+          expect(isImportRedundant(0, mockFactory2)).toBe(false)
+        })
       })
     })
   })

--- a/web/src/utils/factory-management/inputs.ts
+++ b/web/src/utils/factory-management/inputs.ts
@@ -223,7 +223,21 @@ export const isImportRedundant = (importIndex: number, factory: Factory): boolea
     return acc + factory.parts[input.outputPart].amountSuppliedViaInput
   }, 0)
 
+  // In a multi-input scenario, if there's an over supply, inform the user one of their imports are redundant.
+  // Try to be deterministic by favouring the largest import.
+  // Loop each of the imports, enter their values into an array, then check if the current import is the largest.
+  const otherImportsValues: number[] = []
+  otherImports.forEach(input => {
+    if (!input.outputPart) return 0
+    otherImportsValues.push(input.amount ?? 0)
+  })
+  const largestOtherImport = Math.max(...otherImportsValues)
+
+  // If the current import is the largest, then it's not redundant.
+  // This does annoyingly mean that if they are both EXACTLY the same, both will be redundant. Can't really get around it.
+  if (input.amount > largestOtherImport) return false
+
   const remainingToImportAfterOtherImports = required - produced - otherImportsTotal
 
-  return imported === 0 || remainingToImport < 0 || remainingToImportAfterOtherImports <= 0
+  return imported === 0 || remainingToImport < 0 || remainingToImportAfterOtherImports < 0
 }

--- a/web/src/utils/factory-management/inputs.ts
+++ b/web/src/utils/factory-management/inputs.ts
@@ -241,3 +241,28 @@ export const isImportRedundant = (importIndex: number, factory: Factory): boolea
 
   return imported === 0 || remainingToImport < 0 || remainingToImportAfterOtherImports < 0
 }
+
+export const satisfyImport = (importIndex: number, factory: Factory): void => {
+  const input = factory.inputs[importIndex]
+  if (!input.outputPart) {
+    console.error('updateInputToSatisfy: No output part selected for input:', input)
+    return
+  }
+
+  // Gather all the other imports of the same part
+  const otherImports = factory.inputs.filter((_, index) =>
+    index !== importIndex &&
+    factory.inputs[index].outputPart === input.outputPart
+  )
+
+  // Calculate the total amount of the part that is being imported
+  const totalImported = otherImports.reduce((acc, input) => {
+    return acc + input.amount
+  }, 0)
+
+  // Calculate the remaining amount of the part that needs to be imported
+  const partData = factory.parts[input.outputPart]
+  input.amount = partData.amountRequired -
+    partData.amountSuppliedViaProduction -
+    totalImported
+}

--- a/web/src/utils/factory-setups/251-redundant-import.ts
+++ b/web/src/utils/factory-setups/251-redundant-import.ts
@@ -1,0 +1,47 @@
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { newFactory } from '@/utils/factory-management/factory'
+import { addProductToFactory } from '@/utils/factory-management/products'
+import { addInputToFactory } from '@/utils/factory-management/inputs'
+
+export const create251Scenario = (): { getFactories: () => Factory[] } => {
+  // Local variables to ensure a fresh instance on every call
+  const ironIngotFac = newFactory('Iron Ingots', 0, 1)
+  const ironIngotFac2 = newFactory('Iron Ingots 2', 1, 2)
+  const ironPlateFac = newFactory('Iron Plates', 2, 3)
+
+  // Store factories in an array
+  const factories = [ironIngotFac, ironIngotFac2, ironPlateFac]
+
+  // Add products and imports
+  addProductToFactory(ironIngotFac, {
+    id: 'IronIngot',
+    amount: 200,
+    recipe: 'IngotIron',
+  })
+  addProductToFactory(ironIngotFac2, {
+    id: 'IronIngot',
+    amount: 100,
+    recipe: 'IngotIron',
+  })
+
+  addProductToFactory(ironPlateFac, {
+    id: 'IronPlate',
+    amount: 50,
+    recipe: 'IronPlate',
+  })
+  addInputToFactory(ironPlateFac, {
+    factoryId: ironIngotFac.id,
+    outputPart: 'IronIngot',
+    amount: 200,
+  })
+  addInputToFactory(ironPlateFac, {
+    factoryId: ironIngotFac2.id,
+    outputPart: 'IronIngot',
+    amount: 100, // Redundant import
+  })
+
+  // Return an object with a method to access the factories
+  return {
+    getFactories: () => factories, // Expose factories as a method
+  }
+}


### PR DESCRIPTION
Closes #251
Related: #299 

Inputs buttons now handle the following cases:
- If there are >1 inputs of the same part:
  - If one input is satisfactory to fulfil demand, the other input(s) are marked as redundant to prompt the user to delete them. Largest is preferred, smallest ones will be flagged for deletion.
  - If there is a deficit, pressing SATISIFY on an input will adjust the input to comply with the demand, taking into account other inputs of the same part and calculating the difference.
    - This differs from the original issue where it was updating the value of the input to match the TOTAL requirement.
  - If there is a surplus, pressing TRIM will reduce the amount on the input to requirements, leaving all other inputs alone.
