### PR TITLE
Satisfaction button refactor and enhancements, added correct manually condition

### DIFF
--- a/web/src/assets/styles/global.scss
+++ b/web/src/assets/styles/global.scss
@@ -15,6 +15,7 @@
   }
 
   &.x-small {
+    height: 26px !important;
     padding: 0 8px !important;
     font-size: 12px !important;
   }
@@ -31,6 +32,11 @@
   &.blue {
     color: rgb(33, 150, 243) !important;
     border-color: rgb(1, 111, 204) !important;
+  }
+
+  &.cyan {
+    color: rgb(163, 206, 255) !important;
+    border-color: rgb(75, 151, 223) !important;
   }
 
   &.orange {

--- a/web/src/components/Templates.vue
+++ b/web/src/components/Templates.vue
@@ -148,6 +148,13 @@
       show: isDebugMode,
       isDebug: true,
     },
+    {
+      name: '#220: Byproduct only parts handling',
+      description: 'Contains a factory that contains a byproduct only part. The planner used to show "Fix Production" for it, but it did nothing as it does not know how to correct the issue. Now, it shows a "Correct Manually" "button" which instructs the user to correct it manually.',
+      data: JSON.stringify(create251Scenario().getFactories()),
+      show: isDebugMode,
+      isDebug: true,
+    },
   ]
 
   const loadTemplate = (template: Template) => {

--- a/web/src/components/Templates.vue
+++ b/web/src/components/Templates.vue
@@ -57,6 +57,7 @@
   import { create242Scenario } from '@/utils/factory-setups/242-inputs-byproducts'
   import { create321Scenario } from '@/utils/factory-setups/321-product-byproduct-trimming'
   import { create251Scenario } from '@/utils/factory-setups/251-multiple-imports'
+  import { create220Scenario } from '@/utils/factory-setups/220-byproduct-only-part'
 
   const { prepareLoader, isDebugMode } = useAppStore()
 
@@ -151,7 +152,7 @@
     {
       name: '#220: Byproduct only parts handling',
       description: 'Contains a factory that contains a byproduct only part. The planner used to show "Fix Production" for it, but it did nothing as it does not know how to correct the issue. Now, it shows a "Correct Manually" "button" which instructs the user to correct it manually.',
-      data: JSON.stringify(create251Scenario().getFactories()),
+      data: JSON.stringify(create220Scenario().getFactories()),
       show: isDebugMode,
       isDebug: true,
     },

--- a/web/src/components/planner/PlannerFactoryImports.vue
+++ b/web/src/components/planner/PlannerFactoryImports.vue
@@ -19,7 +19,7 @@
           <v-chip
             v-for="(resource, resourceKey) in factory.rawResources"
             :key="resourceKey"
-            class="sf-chip blue"
+            class="sf-chip cyan"
           >
             <game-asset :subject="resourceKey.toString() ?? 'unknown'" type="item" />
             <span class="ml-2">

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -136,6 +136,16 @@
               >
                 <b>{{ formatNumber(part.amountRemaining) }}/min {{ getSatisfactionLabel(part.amountRemaining) }}</b>
               </v-chip>
+              <template v-if="part.isRaw">
+                <v-tooltip bottom>
+                  <template #activator="{ props }">
+                    <v-chip v-bind="props" class="sf-chip cyan small">
+                      <i class="fas fa-info-circle" /><span class="ml-1">Raw</span>
+                    </v-chip>
+                  </template>
+                  <span>Raw parts are always satisfied. Expand the Satisfaction Breakdowns or look at the Inputs section for details of how much is needed.</span>
+                </v-tooltip>
+              </template>
             </div>
           </td>
           <td :class="satisfactionShading(part)">

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -43,7 +43,23 @@
                 <span v-else class="ml-2">
                   <v-icon icon="fas fa-times" />
                 </span>
-                <span class="ml-2 text-body-1"><b>{{ getPartDisplayName(partId.toString()) }}</b></span>
+                <div class="ml-2 text-body-1">
+                  <div>
+                    <b>{{ getPartDisplayName(partId.toString()) }}</b>
+                  </div>
+                  <v-chip v-if="showProductChip(factory, partId.toString())" class="sf-chip blue x-small mr-2">
+                    Product
+                  </v-chip>
+                  <v-chip v-if="showByProductChip(factory, partId.toString())" class="sf-chip gray x-small mr-2">
+                    Byproduct
+                  </v-chip>
+                  <v-chip v-if="showImportedChip(factory, partId.toString())" class="sf-chip gray x-small mr-2">
+                    Imported
+                  </v-chip>
+                  <v-chip v-if="showRawChip(factory, partId.toString())" class="sf-chip cyan x-small mr-2">
+                    Raw
+                  </v-chip>
+                </div>
               </div>
               <!-- Action buttons -->
               <div class="align-self-center text-right">
@@ -80,7 +96,7 @@
                         <i class="fas fa-exclamation-circle" /><span class="ml-1">CORRECT MANUALLY</span>
                       </div>
                     </template>
-                    <span>This needs to be corrected manually. Since you can produce this item via <b>both</b> product and byproduct production, <br>the planner does not know how to automatically resolve this for you.</span>
+                    <span>This item is a byproduct, currently the planner does not know how to scale byproducts correctly<br> as there could be a number of ways to do it that the user may not want.<br> Please scale it manually.</span>
                   </v-tooltip>
                 </v-btn>
                 <v-btn
@@ -136,7 +152,7 @@
               >
                 <b>{{ formatNumber(part.amountRemaining) }}/min {{ getSatisfactionLabel(part.amountRemaining) }}</b>
               </v-chip>
-              <template v-if="part.isRaw">
+              <template v-if="showRawChip(factory, partId.toString())">
                 <v-tooltip bottom>
                   <template #activator="{ props }">
                     <v-chip v-bind="props" class="sf-chip cyan small">
@@ -208,7 +224,12 @@
   import { getRequestsForFactoryByPart } from '@/utils/factory-management/exports'
   import { formatNumber } from '@/utils/numberFormatter'
   import { useAppStore } from '@/stores/app-store'
-  import { showSatisfactionItemButton } from '@/utils/factory-management/satisfaction'
+  import {
+    showByProductChip,
+    showImportedChip,
+    showProductChip, showRawChip,
+    showSatisfactionItemButton,
+  } from '@/utils/factory-management/satisfaction'
 
   const updateFactory = inject('updateFactory') as (factory: Factory) => void
   const findFactory = inject('findFactory') as (factoryId: string | number) => Factory

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -59,6 +59,9 @@
                   <v-chip v-if="showRawChip(factory, partId.toString())" class="sf-chip cyan x-small mr-2">
                     Raw
                   </v-chip>
+                  <v-chip v-if="showInternalChip(factory, partId.toString())" class="sf-chip green x-small mr-2">
+                    Internal
+                  </v-chip>
                 </div>
               </div>
               <!-- Action buttons -->
@@ -226,7 +229,7 @@
   import { useAppStore } from '@/stores/app-store'
   import {
     showByProductChip,
-    showImportedChip,
+    showImportedChip, showInternalChip,
     showProductChip, showRawChip,
     showSatisfactionItemButton,
   } from '@/utils/factory-management/satisfaction'

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -67,7 +67,7 @@
                   <i class="fas fa-wrench" /><span class="ml-1">Fix Product</span>
                 </v-btn>
                 <v-btn
-                  v-if="showSatisfactionItemButton(factory, partId.toString(), 'addManually')"
+                  v-if="showSatisfactionItemButton(factory, partId.toString(), 'correctManually')"
                   class="d-block my-1"
                   color="grey"
                   :ripple="false"
@@ -77,7 +77,7 @@
                   <v-tooltip bottom>
                     <template #activator="{ props }">
                       <div v-bind="props">
-                        <i class="fas fa-exclamation-circle" /><span class="ml-1">ADD MANUALLY</span>
+                        <i class="fas fa-exclamation-circle" /><span class="ml-1">CORRECT MANUALLY</span>
                       </div>
                     </template>
                     <span>This needs to be corrected manually. Since you can produce this item via <b>both</b> product and byproduct production, <br>the planner does not know how to automatically resolve this for you.</span>

--- a/web/src/components/planner/StatisticsItems.vue
+++ b/web/src/components/planner/StatisticsItems.vue
@@ -12,7 +12,7 @@
     <v-chip
       v-for="(product) in allFactoryProducts"
       :key="product.id"
-      class="sf-chip"
+      class="sf-chip blue"
     >
       <span class="mr-2">
         <game-asset :subject="product.id" type="item" />

--- a/web/src/components/planner/StatisticsResources.vue
+++ b/web/src/components/planner/StatisticsResources.vue
@@ -10,7 +10,7 @@
   </p>
   <div v-if="allFactoryRawResources.length > 0">
     <span v-for="(resource, id) in allFactoryRawResources" :key="id">
-      <v-chip class="sf-chip blue" variant="tonal">
+      <v-chip class="sf-chip cyan" variant="tonal">
         <game-asset :subject="resource.id.toString()" type="item" />
         <span class="ml-2">
           <b>{{ getPartDisplayName(resource.id.toString()) }}</b>: {{ formatNumber(resource.totalAmount) }}/min

--- a/web/src/components/planner/products/Product.vue
+++ b/web/src/components/planner/products/Product.vue
@@ -151,7 +151,8 @@
         <v-chip
           v-for="(requirement, part) in product.requirements"
           :key="`ingredients-${part}`"
-          class="sf-chip blue"
+          class="sf-chip"
+          :class="factory.parts[part].isRaw ? 'cyan': 'blue'"
           variant="tonal"
         >
           <game-asset :subject="part.toString()" type="item" />

--- a/web/src/utils/factory-management/products.ts
+++ b/web/src/utils/factory-management/products.ts
@@ -202,3 +202,13 @@ export const fixProduct = (product: FactoryItem | ByProductItem, factory: Factor
   // Whatever calls this MUST then trigger a calculation.
   product.amount = diff + product.amount
 }
+
+export const getProduct = (factory: Factory, productId: string, productOnly = false): FactoryItem | ByProductItem | undefined => {
+  const product = factory.products.find(product => product.id === productId)
+  const byProduct = factory.byProducts.find(product => product.id === productId)
+
+  if (productOnly) {
+    return product ?? undefined
+  }
+  return product ?? byProduct ?? undefined
+}

--- a/web/src/utils/factory-management/products.ts
+++ b/web/src/utils/factory-management/products.ts
@@ -203,12 +203,15 @@ export const fixProduct = (product: FactoryItem | ByProductItem, factory: Factor
   product.amount = diff + product.amount
 }
 
-export const getProduct = (factory: Factory, productId: string, productOnly = false): FactoryItem | ByProductItem | undefined => {
+export const getProduct = (factory: Factory, productId: string, productOnly = false, byProductOnly = false): FactoryItem | ByProductItem | undefined => {
   const product = factory.products.find(product => product.id === productId)
   const byProduct = factory.byProducts.find(product => product.id === productId)
 
   if (productOnly) {
     return product ?? undefined
+  }
+  if (byProductOnly) {
+    return byProduct ?? undefined
   }
   return product ?? byProduct ?? undefined
 }

--- a/web/src/utils/factory-management/satisfaction.spec.ts
+++ b/web/src/utils/factory-management/satisfaction.spec.ts
@@ -1,40 +1,92 @@
-import { beforeEach, describe, expect, test } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { Factory } from '@/interfaces/planner/FactoryInterface'
-import { createNewPart } from '@/utils/factory-management/common'
-import { newFactory } from '@/utils/factory-management/factory'
+import { create220Scenario } from '@/utils/factory-setups/220-byproduct-only-part'
 import { addProductToFactory } from '@/utils/factory-management/products'
+import { showSatisfactionItemButton } from '@/utils/factory-management/satisfaction'
+import { calculateFactories, newFactory } from '@/utils/factory-management/factory'
+import { gameData } from '@/utils/gameData'
+import { addInputToFactory } from '@/utils/factory-management/inputs'
 
 describe('satisfaction', () => {
+  let factories: Factory[]
   let mockFactory: Factory
-
   beforeEach(() => {
-    mockFactory = newFactory('Test Factory')
-    addProductToFactory(mockFactory, {
-      id: 'CompactedCoal',
-      amount: 1234,
-      recipe: 'CompactedCoal',
-    })
+    factories = create220Scenario().getFactories()
+    mockFactory = factories[0]
+    calculateFactories(factories, gameData)
   })
 
-  describe('createNewPart', () => {
-    test('should create a new part', () => {
-      const part = 'NewPart'
+  describe('showSatisfactionItemButton', () => {
+    describe('addProduct', () => {
+      it('should should NOT show if there is already a product', () => {
+        expect(showSatisfactionItemButton(mockFactory, 'SteelPlateReinforced', 'addProduct')).toBe(false)
+      })
+      it('should show for a part that is not a byproduct, and is not satisfied', () => {
+        // SteelPlate is an ingredient of EncasedIndustrialBeam
+        expect(showSatisfactionItemButton(mockFactory, 'SteelPlate', 'addProduct')).toBe(true)
+      })
+      it('should NOT show for a part that is raw', () => {
+        // Add a product that requires a raw ingredient
+        addProductToFactory(mockFactory, {
+          id: 'IronIngot',
+          amount: 10,
+          recipe: 'IngotIron',
+        })
+        calculateFactories(factories, gameData)
 
-      createNewPart(mockFactory, part)
+        expect(showSatisfactionItemButton(mockFactory, 'OreIron', 'addProduct')).toBe(false)
+      })
+      it('should NOT show for a part that is satisfied', () => {
+        // Add import to satisfy the part
+        const steelFac = newFactory('Steel')
+        addProductToFactory(steelFac, {
+          id: 'SteelPlate',
+          amount: 1000,
+          recipe: 'SteelPlate',
+        })
+        factories.push(steelFac)
+        addInputToFactory(mockFactory, {
+          factoryId: steelFac.id,
+          outputPart: 'SteelPlate',
+          amount: 1000,
+        })
+        calculateFactories(factories, gameData)
 
-      expect(mockFactory.parts[part]).toBeDefined()
+        // SteelPlateReinforced is now satisfied
+        expect(showSatisfactionItemButton(mockFactory, 'SteelPlate', 'addProduct')).toBe(false)
+      })
+      it('should NOT show for a part that is already a byproduct within the factory', () => {
+        expect(showSatisfactionItemButton(mockFactory, 'HeavyOilResidue', 'addProduct')).toBe(false)
+      })
     })
-
-    test('should not overwrite existing parts', () => {
-      const part = 'CompactedCoal'
-
-      createNewPart(mockFactory, part)
-      mockFactory.parts[part].amountRequired = 1234
-
-      createNewPart(mockFactory, part)
-
-      // If it was to make a new one it would be initialized as 0.
-      expect(mockFactory.parts[part].amountRequired).toBe(1234)
+    describe('showFixProduct', () => {
+      beforeEach(() => {
+        // Add SteelPlates to the factory, at a deficit
+        addProductToFactory(mockFactory, {
+          id: 'SteelPlate',
+          amount: 1,
+          recipe: 'SteelPlate',
+        })
+      })
+      it('should show if a part is a product and is not producing enough', () => {
+        expect(showSatisfactionItemButton(mockFactory, 'SteelPlate', 'fixProduct')).toBe(true)
+      })
+    })
+    describe('correctManually', () => {
+      it('should show for a part that is already a byproduct within the factory', () => {
+        expect(showSatisfactionItemButton(mockFactory, 'HeavyOilResidue', 'correctManually')).toBe(true)
+      })
+      it('should NOT show for a product already in the factory', () => {
+        addProductToFactory(mockFactory, {
+          id: 'SteelPlate',
+          amount: 1,
+          recipe: 'SteelPlate',
+        })
+        expect(showSatisfactionItemButton(mockFactory, 'SteelPlate', 'correctManually')).toBe(false)
+      })
+      it('should NOT show for a part that can be added as a product directly', () => {
+        expect(showSatisfactionItemButton(mockFactory, 'SteelPlate', 'correctManually')).toBe(false)
+      })
     })
   })
 })

--- a/web/src/utils/factory-management/satisfaction.spec.ts
+++ b/web/src/utils/factory-management/satisfaction.spec.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { createNewPart } from '@/utils/factory-management/common'
+import { newFactory } from '@/utils/factory-management/factory'
+import { addProductToFactory } from '@/utils/factory-management/products'
+
+describe('satisfaction', () => {
+  let mockFactory: Factory
+
+  beforeEach(() => {
+    mockFactory = newFactory('Test Factory')
+    addProductToFactory(mockFactory, {
+      id: 'CompactedCoal',
+      amount: 1234,
+      recipe: 'CompactedCoal',
+    })
+  })
+
+  describe('createNewPart', () => {
+    test('should create a new part', () => {
+      const part = 'NewPart'
+
+      createNewPart(mockFactory, part)
+
+      expect(mockFactory.parts[part]).toBeDefined()
+    })
+
+    test('should not overwrite existing parts', () => {
+      const part = 'CompactedCoal'
+
+      createNewPart(mockFactory, part)
+      mockFactory.parts[part].amountRequired = 1234
+
+      createNewPart(mockFactory, part)
+
+      // If it was to make a new one it would be initialized as 0.
+      expect(mockFactory.parts[part].amountRequired).toBe(1234)
+    })
+  })
+})

--- a/web/src/utils/factory-management/satisfaction.ts
+++ b/web/src/utils/factory-management/satisfaction.ts
@@ -1,5 +1,5 @@
-import { Factory, PartMetrics } from '@/interfaces/planner/FactoryInterface'
-import { getProduct } from '@/utils/factory-management/products'
+import { Factory, FactoryItem, PartMetrics } from '@/interfaces/planner/FactoryInterface'
+import { getProduct, shouldShowInternal } from '@/utils/factory-management/products'
 
 export const showSatisfactionItemButton = (
   factory: Factory,
@@ -61,4 +61,11 @@ export const showImportedChip = (factory: Factory, partId: string) => {
 }
 export const showRawChip = (factory: Factory, partId: string) => {
   return factory.parts[partId].isRaw
+}
+export const showInternalChip = (factory: Factory, partId: string) => {
+  const product = getProduct(factory, partId, true) as FactoryItem
+  if (!product) {
+    return false
+  }
+  return shouldShowInternal(product, factory)
 }

--- a/web/src/utils/factory-management/satisfaction.ts
+++ b/web/src/utils/factory-management/satisfaction.ts
@@ -1,0 +1,44 @@
+import { Factory, PartMetrics } from '@/interfaces/planner/FactoryInterface'
+import { getProduct } from '@/utils/factory-management/products'
+
+export const showSatisfactionItemButton = (
+  factory: Factory,
+  partId: string,
+  type: string
+) => {
+  const part = factory.parts[partId]
+  if (!part) {
+    console.error(`satisfaction: showSatisfactionItemButton: Part ${partId} not found in factory.`)
+    return false
+  }
+
+  switch (type) {
+    case 'addProduct':
+      return showAddProduct(factory, part, partId)
+    case 'fixProduct':
+      return showFixProduct(factory, part, partId)
+    case 'addManually':
+      return showAddManually(factory, part, partId)
+    case 'fixImport':
+      return showFixImport(factory, part, partId)
+    default:
+      return false
+  }
+}
+
+export const showAddProduct = (factory: Factory, part: PartMetrics, partId: string) => {
+  return !getProduct(factory, partId) && !part.isRaw && !part.satisfied
+}
+
+export const showFixProduct = (factory: Factory, part: PartMetrics, partId: string) => {
+  return getProduct(factory, partId, true) && !part.isRaw && !part.satisfied
+}
+
+export const showAddManually = (factory: Factory, part: PartMetrics, partId: string) => {
+  return !getProduct(factory, partId, true) && !part.isRaw && !part.satisfied
+}
+
+export const showFixImport = (factory: Factory, part: PartMetrics, partId: string) => {
+  const input = factory.inputs.find(input => input.outputPart === partId)
+  return input?.outputPart && !part.satisfied
+}

--- a/web/src/utils/factory-management/satisfaction.ts
+++ b/web/src/utils/factory-management/satisfaction.ts
@@ -17,8 +17,8 @@ export const showSatisfactionItemButton = (
       return showAddProduct(factory, part, partId)
     case 'fixProduct':
       return showFixProduct(factory, part, partId)
-    case 'addManually':
-      return showAddManually(factory, part, partId)
+    case 'correctManually':
+      return showCorrectManually(factory, part, partId)
     case 'fixImport':
       return showFixImport(factory, part, partId)
     default:
@@ -34,7 +34,7 @@ export const showFixProduct = (factory: Factory, part: PartMetrics, partId: stri
   return getProduct(factory, partId, true) && !part.isRaw && !part.satisfied
 }
 
-export const showAddManually = (factory: Factory, part: PartMetrics, partId: string) => {
+export const showCorrectManually = (factory: Factory, part: PartMetrics, partId: string) => {
   return !getProduct(factory, partId, true) && !part.isRaw && !part.satisfied
 }
 

--- a/web/src/utils/factory-management/satisfaction.ts
+++ b/web/src/utils/factory-management/satisfaction.ts
@@ -9,7 +9,7 @@ export const showSatisfactionItemButton = (
   const part = factory.parts[partId]
   if (!part) {
     console.error(`satisfaction: showSatisfactionItemButton: Part ${partId} not found in factory.`)
-    return false
+    return null
   }
 
   switch (type) {
@@ -35,10 +35,30 @@ export const showFixProduct = (factory: Factory, part: PartMetrics, partId: stri
 }
 
 export const showCorrectManually = (factory: Factory, part: PartMetrics, partId: string) => {
-  return !getProduct(factory, partId, true) && !part.isRaw && !part.satisfied
+  const isByProduct = factory.byProducts.find(byProduct => byProduct.id === partId)
+  // If the product is already a byproduct, isn't raw and isn't satisfied, show it
+  if (isByProduct && !part.isRaw && !part.satisfied) {
+    return true
+  }
+
+  // Beyond a byproduct, we don't care about it's state
+  return false
 }
 
 export const showFixImport = (factory: Factory, part: PartMetrics, partId: string) => {
   const input = factory.inputs.find(input => input.outputPart === partId)
   return input?.outputPart && !part.satisfied
+}
+
+export const showProductChip = (factory: Factory, partId: string) => {
+  return getProduct(factory, partId, true)
+}
+export const showByProductChip = (factory: Factory, partId: string) => {
+  return getProduct(factory, partId, false, true)
+}
+export const showImportedChip = (factory: Factory, partId: string) => {
+  return factory.inputs.find(input => input.outputPart === partId)
+}
+export const showRawChip = (factory: Factory, partId: string) => {
+  return factory.parts[partId].isRaw
 }

--- a/web/src/utils/factory-setups/220-byproduct-only-part.ts
+++ b/web/src/utils/factory-setups/220-byproduct-only-part.ts
@@ -1,49 +1,35 @@
 import { Factory } from '@/interfaces/planner/FactoryInterface'
 import { newFactory } from '@/utils/factory-management/factory'
 import { addProductToFactory } from '@/utils/factory-management/products'
-import { addInputToFactory } from '@/utils/factory-management/inputs'
 
-// https://github.com/satisfactory-factories/application/issues/251
-// Share link: https://satisfactory-factories.app/share/microscopic-gifted-vase
-export const create251Scenario = (): { getFactories: () => Factory[] } => {
-  const factoryA = newFactory('Factory A', 0, 1)
-  const factoryB = newFactory('Factory B', 1, 2)
-  const factoryC = newFactory('Factory C', 2, 3)
+// https://github.com/satisfactory-factories/application/issues/220
+// Share link: https://satisfactory-factories.app/share/beautiful-important-man // Love it :D
+export const create220Scenario = (): { getFactories: () => Factory[] } => {
+  const mockFactory = newFactory('Oil', 0, 1)
 
   // Store factories in an array
-  const factories = [factoryA, factoryB, factoryC]
+  const factories = [mockFactory]
 
   // Add products and imports
-  addProductToFactory(factoryA, {
-    id: 'CompactedCoal',
-    amount: 540,
-    recipe: 'Alternate_EnrichedCoal',
+  addProductToFactory(mockFactory, {
+    id: 'Plastic',
+    amount: 840,
+    recipe: 'Plastic',
   })
-  addProductToFactory(factoryB, {
-    id: 'CompactedCoal',
-    amount: 450,
-    recipe: 'Alternate_EnrichedCoal',
+  addProductToFactory(mockFactory, {
+    id: 'Rubber',
+    amount: 240,
+    recipe: 'Rubber',
   })
-  addProductToFactory(factoryC, {
+  addProductToFactory(mockFactory, {
     id: 'LiquidFuel',
-    amount: 1200,
-    recipe: 'LiquidFuel',
+    amount: 473,
+    recipe: 'ResidualFuel',
   })
-  addProductToFactory(factoryC, {
-    id: 'LiquidTurboFuel',
-    amount: 1000,
-    recipe: 'Alternate_Turbofuel',
-  })
-
-  addInputToFactory(factoryC, {
-    factoryId: factoryA.id,
-    outputPart: 'CompactedCoal',
-    amount: 540,
-  })
-  addInputToFactory(factoryC, {
-    factoryId: factoryB.id,
-    outputPart: 'CompactedCoal',
-    amount: 450,
+  addProductToFactory(mockFactory, {
+    id: 'SteelPlateReinforced',
+    amount: 30,
+    recipe: 'EncasedIndustrialBeam',
   })
 
   // Return an object with a method to access the factories

--- a/web/src/utils/factory-setups/220-byproduct-only-part.ts
+++ b/web/src/utils/factory-setups/220-byproduct-only-part.ts
@@ -1,0 +1,53 @@
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { newFactory } from '@/utils/factory-management/factory'
+import { addProductToFactory } from '@/utils/factory-management/products'
+import { addInputToFactory } from '@/utils/factory-management/inputs'
+
+// https://github.com/satisfactory-factories/application/issues/251
+// Share link: https://satisfactory-factories.app/share/microscopic-gifted-vase
+export const create251Scenario = (): { getFactories: () => Factory[] } => {
+  const factoryA = newFactory('Factory A', 0, 1)
+  const factoryB = newFactory('Factory B', 1, 2)
+  const factoryC = newFactory('Factory C', 2, 3)
+
+  // Store factories in an array
+  const factories = [factoryA, factoryB, factoryC]
+
+  // Add products and imports
+  addProductToFactory(factoryA, {
+    id: 'CompactedCoal',
+    amount: 540,
+    recipe: 'Alternate_EnrichedCoal',
+  })
+  addProductToFactory(factoryB, {
+    id: 'CompactedCoal',
+    amount: 450,
+    recipe: 'Alternate_EnrichedCoal',
+  })
+  addProductToFactory(factoryC, {
+    id: 'LiquidFuel',
+    amount: 1200,
+    recipe: 'LiquidFuel',
+  })
+  addProductToFactory(factoryC, {
+    id: 'LiquidTurboFuel',
+    amount: 1000,
+    recipe: 'Alternate_Turbofuel',
+  })
+
+  addInputToFactory(factoryC, {
+    factoryId: factoryA.id,
+    outputPart: 'CompactedCoal',
+    amount: 540,
+  })
+  addInputToFactory(factoryC, {
+    factoryId: factoryB.id,
+    outputPart: 'CompactedCoal',
+    amount: 450,
+  })
+
+  // Return an object with a method to access the factories
+  return {
+    getFactories: () => factories, // Expose factories as a method
+  }
+}


### PR DESCRIPTION
Closes #220 

- Refactor Satisfaction item button code, simplifying the conditions and fully tested.
- Added "Correct Manually" "button" with tooltip.
<img width="1301" alt="Screenshot 2025-01-10 at 14 55 29" src="https://github.com/user-attachments/assets/d26175ae-7713-401b-aa24-23664019181c" />

# Satisfaction section changes
- Added various chips to denote the role of the part within the factory. These roles are:
  - Product
  - Imported
  - Raw
  - Internal
  - A part can at maximum be a Product, Imported and Internal.
- Made Raw Items distinct in colour (cyan)
- Added "Raw" chip to the entry next to the Satisfaction surplus / deficit, informing the user that this a automatically assumed part.
<img width="811" alt="Screenshot 2025-01-10 at 17 24 03" src="https://github.com/user-attachments/assets/cdae8a5e-ec88-4cd0-a71f-ead882abd74c" />
