### PR TITLE
Satisfaction: Nuclear / Plutonium Waste handling

### DIFF
--- a/web/src/components/Templates.vue
+++ b/web/src/components/Templates.vue
@@ -61,6 +61,7 @@
   import { create220Scenario } from '@/utils/factory-setups/220-byproduct-only-part'
   import { create338Scenario } from '@/utils/factory-setups/338-satisfaction-chips'
   import { create341Scenario } from '@/utils/factory-setups/341-fissible-uranium-issues'
+  import { create267Scenario } from '@/utils/factory-setups/267-nuclear-waste-handling'
 
   const { prepareLoader, isDebugMode } = useAppStore()
 
@@ -170,6 +171,13 @@
       name: '#314: Byproduct / Requirements <=0 breakage',
       description: 'Setting the requirement ingredients of the product to 0 used to break the UI.',
       data: JSON.stringify(create341Scenario().getFactories()),
+      show: isDebugMode,
+      isDebug: true,
+    },
+    {
+      name: '#267: Nuclear Waste handling',
+      description: 'Nuclear waste was possible to be added via a +Product button in Satisfaction. Now it should show +Generator to add a generator directly instead.',
+      data: JSON.stringify(create267Scenario().getFactories()),
       show: isDebugMode,
       isDebug: true,
     },

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -87,6 +87,16 @@
                   +&nbsp;<i class="fas fa-bolt mr-0" style="max-height: 16px" /><span class="ml-1">Generator</span>
                 </v-btn>
                 <v-btn
+                  v-if="showSatisfactionItemButton(factory, partId.toString(), 'fixGenerator')"
+                  class="d-block mb-1"
+                  color="green"
+                  size="small"
+                  variant="outlined"
+                  @click="doFixGenerator(factory, partId.toString(), part.amountRequired)"
+                >
+                  <i class="fas fa-wrench" /><span class="ml-1">Fix Generator</span>
+                </v-btn>
+                <v-btn
                   v-if="showSatisfactionItemButton(factory, partId.toString(), 'fixProduct')"
                   class="d-block my-1"
                   color="green"
@@ -371,6 +381,24 @@
       return
     }
     fixProduct(product, factory)
+    updateFactory(factory)
+  }
+
+  const doFixGenerator = (factory: Factory, part: string, amount: number) => {
+    const generator = factory.powerProducers.find(producer => producer.recipe === getGeneratorFuelRecipeByPart(part)?.id)
+    const recipe = getGeneratorFuelRecipeByPart(part)
+
+    if (!generator) {
+      alert('Could not fix the generator due to there not being a generator! Please report this to Discord with a share link, quoting the factory in question.')
+      console.error(`Could not find generator for part ${part}`)
+      return
+    }
+
+    if (!recipe) {
+      console.error(`Could not find generator fuel recipe for part ${part}`)
+      return
+    }
+    generator.ingredientAmount = convertWasteToGeneratorFuel(recipe, Math.abs(amount))
     updateFactory(factory)
   }
 

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -96,6 +96,26 @@
                 >
                   <i class="fas fa-wrench" /><span class="ml-1">Fix Generator</span>
                 </v-btn>
+
+                <template v-if="showSatisfactionItemButton(factory, partId.toString(), 'fixGeneratorManually')">
+                  <v-btn
+                    class="d-block my-1"
+                    color="grey"
+                    :ripple="false"
+                    size="small"
+                    variant="outlined"
+                  >
+                    <v-tooltip bottom>
+                      <template #activator="{ props }">
+                        <div v-bind="props">
+                          <i class="fas fa-exclamation-circle" /><span class="ml-1">FIX GENS MANUALLY</span>
+                        </div>
+                      </template>
+                      <span>You have multiple Generator groups for this waste. Since the planner cannot read your mind, we don't know which group to fix.<br>Please either fix manually or reduce to one Generator & Fuel group.</span>
+                    </v-tooltip>
+                  </v-btn>
+                  <p class="text-center"><b>+{{ showFuelRodsNeeded(partId.toString(), part.amountRemaining) }}</b> rods needed</p>
+                </template>
                 <v-btn
                   v-if="showSatisfactionItemButton(factory, partId.toString(), 'fixProduct')"
                   class="d-block my-1"
@@ -322,8 +342,6 @@
       return
     }
 
-    console.log('addGenerator', factory, part, amount)
-
     // We need to add the power producer first so the DOM renders it.
     // We need to change the ingredients after the fact because reactivity doesn't work correctly with the byproduct display. It needs a calculation.
     addPowerProducerToFactory(factory, {
@@ -340,6 +358,17 @@
 
     producer.ingredientAmount = convertWasteToGeneratorFuel(recipe, Math.abs(amount))
     updateFactory(factory)
+  }
+
+  const showFuelRodsNeeded = (part: string, amount: number) => {
+    const recipe = getGeneratorFuelRecipeByPart(part)
+
+    if (!recipe) {
+      console.error(`Could not find generator fuel recipe for part ${part}`)
+      return
+    }
+
+    return convertWasteToGeneratorFuel(recipe, Math.abs(amount))
   }
 
   const fixSatisfactionImport = (factory: Factory, partIndex: string) => {

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -427,6 +427,7 @@
       console.error(`Could not find generator fuel recipe for part ${part}`)
       return
     }
+
     generator.ingredientAmount = convertWasteToGeneratorFuel(recipe, Math.abs(amount))
     updateFactory(factory)
   }

--- a/web/src/stores/game-data-store.spec.ts
+++ b/web/src/stores/game-data-store.spec.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useGameDataStore } from '@/stores/game-data-store'
+
+let gameDataStore: ReturnType<typeof useGameDataStore>
+
+describe('game-data-store', () => {
+  beforeEach(() => {
+    gameDataStore = useGameDataStore()
+  })
+
+  it('should return the correct recipe for nuclear waste', () => {
+    const result = gameDataStore.getGeneratorFuelRecipeByPart('NuclearWaste')
+
+    if (!result) {
+      throw new Error('No PowerRecipe found!')
+    }
+
+    expect(result.id).toEqual('GeneratorNuclear_NuclearFuelRod')
+    expect(result.displayName).toBe('Nuclear Power Plant (Uranium Fuel Rod)') // Shortened by UI
+  })
+
+  it('should return the correct recipe for plutonium waste', () => {
+    const result = gameDataStore.getGeneratorFuelRecipeByPart('PlutoniumWaste')
+
+    if (!result) {
+      throw new Error('No PowerRecipe found!')
+    }
+
+    expect(result.id).toEqual('GeneratorNuclear_PlutoniumFuelRod')
+    expect(result.displayName).toBe('Nuclear Power Plant (Plutonium Fuel Rod)')
+  })
+})

--- a/web/src/stores/game-data-store.ts
+++ b/web/src/stores/game-data-store.ts
@@ -124,6 +124,23 @@ export const useGameDataStore = defineStore('game-data', () => {
     return recipes[0]
   }
 
+  const getGeneratorFuelRecipeByPart = (part: string): PowerRecipe | null => {
+    if (!gameData.value || !part) {
+      return null
+    }
+
+    // Filter the recipes by byproduct and return the matching ones
+    const recipes = gameData.value.powerGenerationRecipes.filter(recipe => {
+      return recipe.byproduct?.part === part
+    })
+
+    if (recipes.length === 0) {
+      return null
+    }
+
+    return recipes[0]
+  }
+
   return {
     gameData,
     getGameData,
@@ -134,5 +151,6 @@ export const useGameDataStore = defineStore('game-data', () => {
     getRecipesForPowerProducer,
     getDefaultRecipeForPart,
     getDefaultRecipeForPowerProducer,
+    getGeneratorFuelRecipeByPart,
   }
 })

--- a/web/src/utils/factory-management/power.spec.ts
+++ b/web/src/utils/factory-management/power.spec.ts
@@ -149,5 +149,28 @@ describe('power', () => {
         })
       })
     })
+
+    describe('waste to fuel conversion', () => {
+      it('should properly calculate the amount of fuel rods needed to convert waste to fuel', () => {
+        // Given we calculate that we to consume 25 waste per minute to produce 0.5 fuel rods per minute
+
+        factory = newFactory('My nuclear plant')
+        // Add one nuclear power plant
+        addPowerProducerToFactory(factory, {
+          building: 'generatornuclear',
+          ingredientAmount: 0.5,
+          recipe: 'GeneratorNuclear_NuclearFuelRod',
+          updated: 'ingredient',
+        })
+
+        calculateFactories([factory], gameData)
+
+        // I know for a fact that given we want to burn 25 nuclear waste it should be 0.5 rods / min or 6250MW.
+
+        expect(factory.powerProducers[0].powerProduced).toBe(6250)
+        expect(factory.powerProducers[0].ingredientAmount).toBe(0.5)
+        expect(factory.powerProducers[0].byproduct?.amount).toBe(25)
+      })
+    })
   })
 })

--- a/web/src/utils/factory-management/power.ts
+++ b/web/src/utils/factory-management/power.ts
@@ -2,7 +2,7 @@ import { Factory, FactoryPowerProducer } from '@/interfaces/planner/FactoryInter
 import { DataInterface } from '@/interfaces/DataInterface'
 import { getPowerRecipeById } from '@/utils/factory-management/common'
 import { PowerRecipe } from '@/interfaces/Recipes'
-import { formatNumber } from '@/utils/numberFormatter'
+import { formatNumberFully } from '@/utils/numberFormatter'
 
 // For internal testing use
 export const addPowerProducerToFactory = (
@@ -63,7 +63,7 @@ export const calculatePowerProducers = (
 
       // Now we've handled the updated values, we can calculate the power generation again
       producer.powerProduced = calculatePowerAmount(producer, recipe)
-      producer.powerAmount = Number(formatNumber(producer.powerProduced))
+      producer.powerAmount = formatNumberFully(producer.powerProduced)
     }
 
     if (producer.updated === 'building') {
@@ -75,7 +75,7 @@ export const calculatePowerProducers = (
 
       // Now we need to increase the power so the supplemental fuel is calculated correctly
       producer.powerProduced = calculatePowerAmount(producer, recipe)
-      producer.powerAmount = Number(formatNumber(producer.powerProduced))
+      producer.powerAmount = formatNumberFully(producer.powerProduced)
     }
 
     // For supplemental fuels, we need to know the power produced in order to calculate them
@@ -86,7 +86,7 @@ export const calculatePowerProducers = (
     if (producer.updated !== 'building') {
       // Now calculate the amount of buildings the user needs to build
       producer.buildingCount = producer.powerProduced / recipe.building.power
-      producer.buildingAmount = Number(formatNumber(producer.buildingCount))
+      producer.buildingAmount = formatNumberFully(producer.buildingCount)
     }
 
     // Now add the byproducts

--- a/web/src/utils/factory-management/satisfaction.spec.ts
+++ b/web/src/utils/factory-management/satisfaction.spec.ts
@@ -13,6 +13,7 @@ import { calculateFactories, newFactory } from '@/utils/factory-management/facto
 import { gameData } from '@/utils/gameData'
 import { addInputToFactory, getAllInputs, getInput } from '@/utils/factory-management/inputs'
 import { create338Scenario } from '@/utils/factory-setups/338-satisfaction-chips'
+import { addPowerProducerToFactory } from '@/utils/factory-management/power'
 
 describe('satisfaction', () => {
   let factories: Factory[]
@@ -101,6 +102,7 @@ describe('satisfaction', () => {
         expect(showSatisfactionItemButton(mockFactory, 'SteelPlate', 'correctManually')).toBe(false)
       })
     })
+
     describe('fixImport', () => {
       beforeEach(() => {
         // Add an import
@@ -175,6 +177,83 @@ describe('satisfaction', () => {
 
           expect(showSatisfactionItemButton(mockFactory, 'SteelPlate', 'fixImport')).toBe(false)
         })
+      })
+    })
+
+    describe('addGenerator', () => {
+      beforeEach(() => {
+        // Add a product needing nuclear waste (25)
+        addProductToFactory(mockFactory, {
+          id: 'PlutoniumPellet',
+          amount: 30,
+          recipe: 'Plutonium',
+        })
+        calculateFactories(factories, gameData)
+      })
+
+      it('should return true for a nuclear part that requires a generator', () => {
+        expect(showSatisfactionItemButton(mockFactory, 'NuclearWaste', 'addGenerator')).toBe(true)
+      })
+
+      it('should return false for a nuclear part that has a generator', () => {
+        // Add a generator for NuclearWaste
+        addPowerProducerToFactory(mockFactory, {
+          building: 'generatornuclear',
+          buildingAmount: 1,
+          recipe: 'GeneratorNuclear_NuclearFuelRod',
+          updated: 'building',
+        })
+        calculateFactories(factories, gameData)
+        expect(showSatisfactionItemButton(mockFactory, 'NuclearWaste', 'addGenerator')).toBe(false)
+      })
+
+      it('should ignore non nuclear parts', () => {
+        expect(showSatisfactionItemButton(mockFactory, 'SteelPlate', 'addGenerator')).toBe(false)
+      })
+    })
+
+    describe('fixGenerator', () => {
+      beforeEach(() => {
+        // Add a product needing nuclear waste (25)
+        addProductToFactory(mockFactory, {
+          id: 'PlutoniumPellet',
+          amount: 30,
+          recipe: 'Plutonium',
+        })
+        calculateFactories(factories, gameData)
+      })
+
+      it('should not show if the part is not a nuclear part', () => {
+        expect(showSatisfactionItemButton(mockFactory, 'SteelPlate', 'fixGenerator')).toBe(false)
+      })
+
+      it('should not show if there is no generator', () => {
+        expect(showSatisfactionItemButton(mockFactory, 'NuclearWaste', 'fixGenerator')).toBe(false)
+      })
+
+      it('should not show if the part is satisfied', () => {
+        addPowerProducerToFactory(mockFactory, {
+          building: 'generatornuclear',
+          buildingAmount: 100, // Will deffo be satisfied lol
+          recipe: 'GeneratorNuclear_NuclearFuelRod',
+          updated: 'building',
+        })
+        calculateFactories(factories, gameData)
+
+        expect(showSatisfactionItemButton(mockFactory, 'NuclearWaste', 'fixGenerator')).toBe(false)
+      })
+
+      it('should show if there is already a generator and it is insufficient', () => {
+        // Add a generator for NuclearWaste
+        addPowerProducerToFactory(mockFactory, {
+          building: 'generatornuclear',
+          buildingAmount: 1,
+          recipe: 'GeneratorNuclear_NuclearFuelRod',
+          updated: 'building',
+        })
+        calculateFactories(factories, gameData)
+
+        expect(showSatisfactionItemButton(mockFactory, 'NuclearWaste', 'fixGenerator')).toBe(true)
       })
     })
   })

--- a/web/src/utils/factory-management/satisfaction.spec.ts
+++ b/web/src/utils/factory-management/satisfaction.spec.ts
@@ -3,6 +3,7 @@ import { Factory } from '@/interfaces/planner/FactoryInterface'
 import { create220Scenario } from '@/utils/factory-setups/220-byproduct-only-part'
 import { addProductToFactory } from '@/utils/factory-management/products'
 import {
+  convertWasteToGeneratorFuel,
   showByProductChip,
   showImportedChip, showInternalChip,
   showProductChip, showRawChip,
@@ -272,6 +273,26 @@ describe('satisfaction', () => {
       it('should NOT show for a raw part', () => {
         expect(showInternalChip(mockFactory, 'LiquidOil')).toBe(false)
       })
+    })
+  })
+
+  describe('convertWasteToGeneratorFuel', () => {
+    it('should correctly convert nuclear waste to generator fuel rods', () => {
+      const recipe = gameData.powerGenerationRecipes.find(recipe => recipe.id === 'GeneratorNuclear_NuclearFuelRod')
+      if (!recipe) {
+        throw new Error('No recipe found for NuclearWaste')
+      }
+      const result = convertWasteToGeneratorFuel(recipe, 25)
+      expect(result).toBe(0.5)
+    })
+
+    it('should correctly convert nuclear waste to generator fuel rods #2', () => {
+      const recipe = gameData.powerGenerationRecipes.find(recipe => recipe.id === 'GeneratorNuclear_NuclearFuelRod')
+      if (!recipe) {
+        throw new Error('No recipe found for NuclearWaste')
+      }
+      const result = convertWasteToGeneratorFuel(recipe, 1000)
+      expect(result).toBe(20)
     })
   })
 })

--- a/web/src/utils/factory-management/satisfaction.spec.ts
+++ b/web/src/utils/factory-management/satisfaction.spec.ts
@@ -424,5 +424,14 @@ describe('satisfaction', () => {
       const result = convertWasteToGeneratorFuel(recipe, 1000)
       expect(result).toBe(20)
     })
+
+    it('should properly overproduce slightly to accommodate for a non-fixable scenario with nuclear waste', () => {
+      const recipe = gameData.powerGenerationRecipes.find(recipe => recipe.id === 'GeneratorNuclear_NuclearFuelRod')
+      if (!recipe) {
+        throw new Error('No recipe found for NuclearWaste')
+      }
+      const result = convertWasteToGeneratorFuel(recipe, 1.667)
+      expect(result).toBe(0.034)
+    })
   })
 })

--- a/web/src/utils/factory-management/satisfaction.spec.ts
+++ b/web/src/utils/factory-management/satisfaction.spec.ts
@@ -255,6 +255,57 @@ describe('satisfaction', () => {
 
         expect(showSatisfactionItemButton(mockFactory, 'NuclearWaste', 'fixGenerator')).toBe(true)
       })
+
+      it('should not show if there is more than 1 generator group', () => {
+        // Add a generator for NuclearWaste
+        addPowerProducerToFactory(mockFactory, {
+          building: 'generatornuclear',
+          buildingAmount: 1,
+          recipe: 'GeneratorNuclear_NuclearFuelRod',
+          updated: 'building',
+        })
+        addPowerProducerToFactory(mockFactory, {
+          building: 'generatornuclear',
+          buildingAmount: 1,
+          recipe: 'GeneratorNuclear_NuclearFuelRod',
+          updated: 'building',
+        })
+        calculateFactories(factories, gameData)
+
+        expect(showSatisfactionItemButton(mockFactory, 'NuclearWaste', 'fixGenerator')).toBe(false)
+      })
+    })
+
+    describe('fixGeneratorManually', () => {
+      beforeEach(() => {
+        // Add a product needing nuclear waste (25)
+        addProductToFactory(mockFactory, {
+          id: 'PlutoniumPellet',
+          amount: 30,
+          recipe: 'Plutonium',
+        })
+        addPowerProducerToFactory(mockFactory, {
+          building: 'generatornuclear',
+          buildingAmount: 1,
+          recipe: 'GeneratorNuclear_NuclearFuelRod',
+          updated: 'building',
+        })
+        calculateFactories(factories, gameData)
+      })
+      it('should NOT show if there is only one group', () => {
+        expect(showSatisfactionItemButton(mockFactory, 'NuclearWaste', 'fixGeneratorManually')).toBe(false)
+      })
+
+      it('should show if there is more than one group', () => {
+        addPowerProducerToFactory(mockFactory, {
+          building: 'generatornuclear',
+          buildingAmount: 1,
+          recipe: 'GeneratorNuclear_NuclearFuelRod',
+          updated: 'building',
+        })
+        calculateFactories(factories, gameData)
+        expect(showSatisfactionItemButton(mockFactory, 'NuclearWaste', 'fixGeneratorManually')).toBe(true)
+      })
     })
   })
   describe('chips', () => {

--- a/web/src/utils/factory-management/satisfaction.ts
+++ b/web/src/utils/factory-management/satisfaction.ts
@@ -25,6 +25,8 @@ export const showSatisfactionItemButton = (
       return showFixProduct(factory, part, partId)
     case 'fixGenerator':
       return showFixGenerator(factory, part, partId)
+    case 'fixGeneratorManually':
+      return showFixGeneratorManually(factory, part, partId)
     case 'correctManually':
       return showCorrectManually(factory, part, partId)
     case 'fixImport':
@@ -78,10 +80,21 @@ export const showFixGenerator = (factory: Factory, part: PartMetrics, partId: st
   if (part.satisfied) return false
   if (!nuclearParts.includes(partId)) return false
 
-  const powerProducer = factory.powerProducers.find(producer => producer.byproduct?.part === partId)
+  const powerProducer = factory.powerProducers.filter(producer => producer.byproduct?.part === partId)
 
   // If a powerProducer is found, return true as it's not satisfied by it.
-  return !!powerProducer
+  return powerProducer.length === 1
+}
+
+export const showFixGeneratorManually = (factory: Factory, part: PartMetrics, partId: string): boolean => {
+  if (part.satisfied) return false
+  if (!nuclearParts.includes(partId)) return false
+
+  // Find all power producers with the part
+  const powerProducers = factory.powerProducers.filter(producer => producer.byproduct?.part === partId)
+
+  // If there are multiple power producers, we can't fix it.
+  return powerProducers.length > 1
 }
 
 // Satisfaction item chips

--- a/web/src/utils/factory-management/satisfaction.ts
+++ b/web/src/utils/factory-management/satisfaction.ts
@@ -129,6 +129,11 @@ export const convertWasteToGeneratorFuel = (recipe: PowerRecipe, amount: number)
 
   const rodsPerWaste = rodsPerMin / wastePerMin // 0.02
 
+  let result = rodsPerWaste * amount // 0.5
+
+  // Since the result may be 0.000x, we need to round it up to the nearest 0.001 to ensure the user can actually achieve it in game
+  result = Math.ceil(result * 1000) / 1000
+
   // The total rods needed to get the desired amount of waste
-  return formatNumberFully(rodsPerWaste * amount) // 0.5
+  return formatNumberFully(result) // 0.5
 }

--- a/web/src/utils/factory-management/satisfaction.ts
+++ b/web/src/utils/factory-management/satisfaction.ts
@@ -121,16 +121,14 @@ export const showInternalChip = (factory: Factory, partId: string) => {
 
 export const convertWasteToGeneratorFuel = (recipe: PowerRecipe, amount: number) => {
   // In order to get the fuel amount to insert into the UI, we need to do some math.
-
   // We know the amount of waste we require.
   // We need to get the amount of fuel rods it takes to produce that amount of waste.
 
   const rodsPerMin = recipe.ingredients[0].perMin // 0.2
   const wastePerMin = recipe.byproduct?.perMin ?? 0 // 10
 
-  // rodsPerWaste = rodsPerMin / wastePerMin
   const rodsPerWaste = rodsPerMin / wastePerMin // 0.02
 
-  // The total rods needed to get the desired 'amount' of waste
+  // The total rods needed to get the desired amount of waste
   return formatNumberFully(rodsPerWaste * amount) // 0.5
 }

--- a/web/src/utils/factory-management/satisfaction.ts
+++ b/web/src/utils/factory-management/satisfaction.ts
@@ -2,6 +2,7 @@ import { Factory, FactoryItem, PartMetrics } from '@/interfaces/planner/FactoryI
 import { getProduct, shouldShowInternal } from '@/utils/factory-management/products'
 import { getAllInputs } from '@/utils/factory-management/inputs'
 import { PowerRecipe } from '@/interfaces/Recipes'
+import { formatNumberFully } from '@/utils/numberFormatter'
 
 const nuclearParts = ['NuclearWaste', 'PlutoniumWaste']
 
@@ -131,5 +132,5 @@ export const convertWasteToGeneratorFuel = (recipe: PowerRecipe, amount: number)
   const rodsPerWaste = rodsPerMin / wastePerMin // 0.02
 
   // The total rods needed to get the desired 'amount' of waste
-  return rodsPerWaste * amount // 0.5
+  return formatNumberFully(rodsPerWaste * amount) // 0.5
 }

--- a/web/src/utils/factory-management/satisfaction.ts
+++ b/web/src/utils/factory-management/satisfaction.ts
@@ -20,9 +20,11 @@ export const showSatisfactionItemButton = (
     case 'addProduct':
       return showAddProduct(factory, part, partId)
     case 'addGenerator':
-      return showAddGenerator(factory, partId)
+      return showAddGenerator(factory, part, partId)
     case 'fixProduct':
       return showFixProduct(factory, part, partId)
+    case 'fixGenerator':
+      return showFixGenerator(factory, part, partId)
     case 'correctManually':
       return showCorrectManually(factory, part, partId)
     case 'fixImport':
@@ -64,8 +66,22 @@ export const showFixImport = (factory: Factory, part: PartMetrics, partId: strin
 }
 
 // If the part ID is of a nuclear power product, show the button
-export const showAddGenerator = (factory: Factory, partId: string) => {
-  return nuclearParts.includes(partId)
+export const showAddGenerator = (factory: Factory, part: PartMetrics, partId: string): boolean => {
+  if (part.satisfied) return false
+
+  // Attempt to find the powerProducer that produces the part
+  const powerProducer = factory.powerProducers.find(producer => producer.byproduct?.part === partId)
+
+  return nuclearParts.includes(partId) && !powerProducer
+}
+export const showFixGenerator = (factory: Factory, part: PartMetrics, partId: string): boolean => {
+  if (part.satisfied) return false
+  if (!nuclearParts.includes(partId)) return false
+
+  const powerProducer = factory.powerProducers.find(producer => producer.byproduct?.part === partId)
+
+  // If a powerProducer is found, return true as it's not satisfied by it.
+  return !!powerProducer
 }
 
 // Satisfaction item chips

--- a/web/src/utils/factory-setups/267-nuclear-waste-handling.ts
+++ b/web/src/utils/factory-setups/267-nuclear-waste-handling.ts
@@ -1,0 +1,27 @@
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { newFactory } from '@/utils/factory-management/factory'
+import { addProductToFactory } from '@/utils/factory-management/products'
+
+export const create267Scenario = (): { getFactories: () => Factory[] } => {
+  // Local variables to ensure a fresh instance on every call
+  const nuclearFac = newFactory('Nuclear', 0)
+
+  // Store factories in an array
+  const factories = [nuclearFac]
+
+  addProductToFactory(nuclearFac, {
+    id: 'PlutoniumPellet',
+    amount: 30,
+    recipe: 'Plutonium',
+  })
+  addProductToFactory(nuclearFac, {
+    id: 'Ficsonium',
+    amount: 10,
+    recipe: 'Ficsonium',
+  })
+
+  // Return an object with a method to access the factories
+  return {
+    getFactories: () => factories, // Expose factories as a method
+  }
+}

--- a/web/src/utils/factory-setups/269-power-generator-multiple-same.spec.ts
+++ b/web/src/utils/factory-setups/269-power-generator-multiple-same.spec.ts
@@ -2,14 +2,14 @@ import { beforeAll, describe, expect, it } from 'vitest'
 import { Factory } from '@/interfaces/planner/FactoryInterface'
 import { calculateFactories, findFacByName } from '@/utils/factory-management/factory'
 import { gameData } from '@/utils/gameData'
-import { create269Scenraio } from '@/utils/factory-setups/269-power-generator-multiple-same'
+import { create269Scenario } from '@/utils/factory-setups/269-power-generator-multiple-same'
 
 let factories: Factory[]
 let fuelFac: Factory
 
 describe('269 Scenario Plan', () => {
   beforeAll(() => {
-    const templateInstance = create269Scenraio()
+    const templateInstance = create269Scenario()
     factories = templateInstance.getFactories()
     fuelFac = findFacByName('Fuel Power', factories)
     calculateFactories(factories, gameData)

--- a/web/src/utils/factory-setups/269-power-generator-multiple-same.ts
+++ b/web/src/utils/factory-setups/269-power-generator-multiple-same.ts
@@ -2,7 +2,7 @@ import { Factory } from '@/interfaces/planner/FactoryInterface'
 import { newFactory } from '@/utils/factory-management/factory'
 import { addPowerProducerToFactory } from '@/utils/factory-management/power'
 
-export const create269Scenraio = (): { getFactories: () => Factory[] } => {
+export const create269Scenario = (): { getFactories: () => Factory[] } => {
   // Local variables to ensure a fresh instance on every call
   const fuelFac = newFactory('Fuel Power', 0)
 

--- a/web/src/utils/numberFormatter.ts
+++ b/web/src/utils/numberFormatter.ts
@@ -8,6 +8,10 @@ export function formatNumber (value: any): string {
   return num % 1 === 0 ? num.toFixed(0) : parseFloat(num.toFixed(3)).toString()
 }
 
+export function formatNumberFully (value: any): number {
+  return Number(formatNumber(value))
+}
+
 // Returns a number formatted in the value of megawatts or gigawatts. If supplied GW, the number is divided by 1000.
 export function formatPower (value: number): { value: string, unit: string } {
   let formattedValue = formatNumber(value)


### PR DESCRIPTION
Closes #267 

# Testing instructions

## Setup
1. Open preview site. https://satisfactory-factories-h0iyknrc0-maelstromeous-projects.vercel.app/
2. Open templates.
3. Choose `#267: Nuclear Waste Handling` (bottom button).

## Add Generators
1. Add Uranium via +Generator button.
2. Check Uranium waste is satisfied, it should amount to 0.5 UFRs and create 25 NW as a byproduct, and 6.25GW.
4. Add Plutonium  via +Generator button.
5. Check Plutonium waste is satisfied, it should amount to 1 PFR and create 10 PW as a byproduct and 25GW.

## Fix Generators
1. Using the previously added generators, decrease one of the fuel rods.
2. The associated fuel should now be unsatisfied and show "Fix Generator".
3. Pressing Fix Generator should rectify the generator group.

Increasing the demand for the waste should also make the fix generator button appear.

## Single Fuel Multiple Groups
1. Add Nuclear Waste with two groups of generators.
2. Decrease their fuel rods to 0.1 (minimum).
3. Observe that a "FIX GEN MANUALLY" tooltip button has appeared.
6. Observe the amount of rods needed is shown.

I did debate whether to fix the generator groups on behalf on the user on this one, but with a similar case with Inputs, we wouldn't know exactly which group to change.

# TODO
- [x] Ensure fixer overproduces rather than underproduces on waste in order to fix the factory. It is acceptable to have a 0.016 surplus.