### PR TITLE
Better byproduct product selection handling & waste product removal fix

### DIFF
--- a/web/src/components/Templates.vue
+++ b/web/src/components/Templates.vue
@@ -62,6 +62,7 @@
   import { create338Scenario } from '@/utils/factory-setups/338-satisfaction-chips'
   import { create341Scenario } from '@/utils/factory-setups/341-fissible-uranium-issues'
   import { create267Scenario } from '@/utils/factory-setups/267-nuclear-waste-handling'
+  import { create375Scenario } from '@/utils/factory-setups/375-byproduct-ghost-surplus'
 
   const { prepareLoader, isDebugMode } = useAppStore()
 
@@ -178,6 +179,13 @@
       name: '#267: Nuclear Waste handling',
       description: 'Nuclear waste was possible to be added via a +Product button in Satisfaction. Now it should show +Generator to add a generator directly instead.',
       data: JSON.stringify(create267Scenario().getFactories()),
+      show: isDebugMode,
+      isDebug: true,
+    },
+    {
+      name: '#375: Byproduct products handling',
+      description: 'Contains a factory that has selected a byproduct as a product. In the issue, a ghost surplus was created as it was counting both the product quantity of 100, and the byproduct quantity of 100. The UI should show Rubber as the main recipe, and HOR as the byproduct.',
+      data: JSON.stringify(create375Scenario().getFactories()),
       show: isDebugMode,
       isDebug: true,
     },

--- a/web/src/components/Toast.vue
+++ b/web/src/components/Toast.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-snackbar v-model="showToast" :color="toastType" top>
+  <v-snackbar v-model="showToast" :color="toastType" :timeout="timeout" top>
     <span v-html="toastMessage" />
   </v-snackbar>
 </template>
@@ -9,22 +9,27 @@
 
   export interface ToastData {
     message: string
-    type?: 'success' | 'warning' | 'error'
+    type?: 'info' | 'success' | 'warning' | 'error'
+    timeout?: number
   }
 
   const showToast = ref(false)
   const toastType = ref('success')
   const toastMessage = ref('')
+  const timeout = ref(3000)
 
   const showToastMessage = (data: ToastData) => {
     if (data.type === 'error') {
       toastType.value = 'red'
     } else if (data.type === 'warning') {
       toastType.value = 'amber'
+    } else if (data.type === 'info') {
+      toastType.value = 'blue'
     } else {
       toastType.value = 'success'
     }
     toastMessage.value = data.message
+    timeout.value = data.timeout || 3000
     showToast.value = true
   }
 

--- a/web/src/components/planner/products/Product.vue
+++ b/web/src/components/planner/products/Product.vue
@@ -40,7 +40,7 @@
           max-width="350px"
           variant="outlined"
           width="350px"
-          @update:model-value="updateFactory(factory)"
+          @update:model-value="updateRecipe(product, factory)"
         />
       </div>
       <div class="input-row d-flex align-center">
@@ -212,9 +212,11 @@
 <script setup lang="ts">
   import {
     fixProduct,
+    isPartByProductOfRecipe,
     shouldShowFix,
     shouldShowInternal,
     shouldShowNotInDemand,
+    swapByProductRecipeForProduct,
     updateProductAmountViaByproduct,
     updateProductAmountViaRequirement,
   } from '@/utils/factory-management/products'
@@ -276,6 +278,23 @@
 
     product.recipe = getDefaultRecipeForPart(product.id)
     product.amount = 1
+
+    const isByProduct = isPartByProductOfRecipe(product.id, product.recipe, gameData)
+
+    console.log('isByProduct updateProduct', isByProduct)
+
+    updateFactory(factory)
+  }
+
+  const updateRecipe = (product: FactoryItem, factory: Factory) => {
+    // We need to check if the recipe the user is adding a byproduct via a recipe where the item is a byproduct
+    const isByProduct = isPartByProductOfRecipe(product.id, product.recipe, gameData)
+
+    console.log('isByProduct updateRecipe', isByProduct)
+
+    if (isByProduct) {
+      swapByProductRecipeForProduct(product, gameData)
+    }
 
     updateFactory(factory)
   }

--- a/web/src/components/planner/products/Product.vue
+++ b/web/src/components/planner/products/Product.vue
@@ -272,7 +272,9 @@
 
     if (product.id === 'NuclearWaste' || product.id === 'PlutoniumWaste') {
       alert('Uranium and Plutonium Waste are created by adding a Power Generator (and adding a Nuclear Power Plant). This product will now be cleared.')
+      product.recipe = ''
       product.id = ''
+      updateFactory(factory)
       return
     }
 

--- a/web/src/components/planner/products/Product.vue
+++ b/web/src/components/planner/products/Product.vue
@@ -211,12 +211,11 @@
 
 <script setup lang="ts">
   import {
+    byProductAsProductCheck,
     fixProduct,
-    isPartByProductOfRecipe,
     shouldShowFix,
     shouldShowInternal,
     shouldShowNotInDemand,
-    swapByProductRecipeForProduct,
     updateProductAmountViaByproduct,
     updateProductAmountViaRequirement,
   } from '@/utils/factory-management/products'
@@ -281,23 +280,13 @@
     product.recipe = getDefaultRecipeForPart(product.id)
     product.amount = 1
 
-    const isByProduct = isPartByProductOfRecipe(product.id, product.recipe, gameData)
-
-    console.log('isByProduct updateProduct', isByProduct)
+    byProductAsProductCheck(product, gameData)
 
     updateFactory(factory)
   }
 
   const updateRecipe = (product: FactoryItem, factory: Factory) => {
-    // We need to check if the recipe the user is adding a byproduct via a recipe where the item is a byproduct
-    const isByProduct = isPartByProductOfRecipe(product.id, product.recipe, gameData)
-
-    console.log('isByProduct updateRecipe', isByProduct)
-
-    if (isByProduct) {
-      swapByProductRecipeForProduct(product, gameData)
-    }
-
+    byProductAsProductCheck(product, gameData)
     updateFactory(factory)
   }
 

--- a/web/src/utils/eventBus.ts
+++ b/web/src/utils/eventBus.ts
@@ -6,7 +6,7 @@ type Events = {
   sessionExpired: undefined;
   dataSynced: undefined;
   dataOutOfSync: undefined;
-  toast: { message: string; type?: 'success' | 'warning' | 'error' };
+  toast: { message: string; type?: 'info' | 'success' | 'warning' | 'error', timeout?: number };
   // Initial factory loading dialog
   loadingCompleted: undefined;
   incrementLoad: { step: string }; // Payload to denote loading or calculation step

--- a/web/src/utils/factory-management/common.ts
+++ b/web/src/utils/factory-management/common.ts
@@ -23,15 +23,28 @@ export const createNewPart = (factory: Factory, part: string) => {
 
 // You may think that this is duplication with the gameDataStore. It kind of is, however, trying to mock the store in tests is a gigantic pain in the arse.
 // Therefore, usage of gameDataStore within the ./factory-management files is to be used sparingly, and proxies created here.
-export const getRecipe = (partId: any, gameData: DataInterface): Recipe | undefined => {
-  const recipe = gameData.recipes.find(r => r.id === partId)
+export const getRecipe = (recipeId: any, gameData: DataInterface): Recipe | undefined => {
+  const recipe = gameData.recipes.find(r => r.id === recipeId)
 
   if (!recipe) {
-    console.error(`Recipe with ID ${partId} not found.`)
+    console.error(`Recipe with ID ${recipeId} not found.`)
     return
   }
 
   return recipe
+}
+
+export const getPartDisplayNameWithoutDataStore = (part: string, gameData: DataInterface): string => {
+  if (!part) {
+    return 'NO PART!!!'
+  }
+  if (!gameData) {
+    console.error('getPartDisplayName: No game data!!')
+    return 'NO DATA!!!'
+  }
+  return gameData.items.rawResources[part]?.name ||
+    gameData.items.parts[part]?.name ||
+    `UNKNOWN PART ${part}!`
 }
 
 export const getPowerRecipeById = (id: string, gameData: DataInterface): PowerRecipe | null => {

--- a/web/src/utils/factory-management/parts.spec.ts
+++ b/web/src/utils/factory-management/parts.spec.ts
@@ -119,4 +119,22 @@ describe('parts', () => {
       expect(otherMockFactory.parts.CompactedCoal.exportable).toBe(true)
     })
   })
+
+  it('should properly remove part data with no name', () => {
+    const mockFactory = newFactory('Test Factory')
+    addProductToFactory(mockFactory, {
+      id: 'CompactedCoal',
+      amount: 50,
+      recipe: 'Alternate_EnrichedCoal',
+    })
+
+    // @ts-ignore
+    mockFactory.parts[''] = {
+      amountRequired: 0,
+    }
+
+    calculateFactories([mockFactory], gameData)
+
+    expect(mockFactory.parts['']).toBeUndefined()
+  })
 })

--- a/web/src/utils/factory-management/parts.ts
+++ b/web/src/utils/factory-management/parts.ts
@@ -41,6 +41,13 @@ export const calculatePartMetrics = (factory: Factory, gameData: DataInterface) 
 
   // Now we calculate the remaining amount of parts required after all inputs and internal products are accounted for.
   for (const part in factory.parts) {
+    // If for some reason the part key is an empty string, remove it.
+    if (part === '') {
+      console.error('calculatePartMetrics: Part key is an empty string! Flushing part data.', factory.parts)
+      delete factory.parts[part]
+      return
+    }
+
     const partData = factory.parts[part]
 
     // Sum up remaining amount

--- a/web/src/utils/factory-management/products.spec.ts
+++ b/web/src/utils/factory-management/products.spec.ts
@@ -750,4 +750,6 @@ describe('products', () => {
       ).toThrow(`products: recipeIngredientPerMin: No ingredient found for part FooPart in recipe ${recipe.id}!`)
     })
   })
+
+  describe('isPartBy')
 })

--- a/web/src/utils/factory-management/products.spec.ts
+++ b/web/src/utils/factory-management/products.spec.ts
@@ -769,6 +769,9 @@ describe('products', () => {
   })
 
   describe('byProductAsProductCheck', () => {
+    afterEach(() => {
+      vi.resetAllMocks()
+    })
     it('should correctly swap out a byproduct recipe for a product recipe', () => {
       const product = {
         id: 'HeavyOilResidue',
@@ -798,6 +801,23 @@ describe('products', () => {
         id: product.id,
         amount: 100,
         recipe: product.recipe,
+      })
+    })
+
+    it('should emit an event to the user when it has changed', () => {
+      const product = {
+        id: 'HeavyOilResidue',
+        amount: 100,
+        recipe: 'Rubber',
+      } as FactoryItem
+      vi.spyOn(eventBus, 'emit')
+
+      byProductAsProductCheck(product, gameData)
+
+      expect(eventBus.emit).toHaveBeenCalledWith('toast', {
+        message: 'The chosen Byproduct <b>Heavy Oil Residue</b> was swapped for the producing Product <b>Rubber</b>.<br>Update the Byproduct ingredient on <b>Rubber</b> for the desired item quantity.',
+        type: 'info',
+        timeout: 10000,
       })
     })
   })

--- a/web/src/utils/factory-management/products.spec.ts
+++ b/web/src/utils/factory-management/products.spec.ts
@@ -5,12 +5,12 @@ import {
   addProductToFactory,
   fixProduct,
   getProduct,
-  getProductAmountByPart,
+  getProductAmountByPart, isPartByProductOfRecipe,
   recipeByproductPerMin,
   recipeIngredientPerMin,
   shouldShowFix,
   shouldShowInternal,
-  shouldShowNotInDemand,
+  shouldShowNotInDemand, swapByProductRecipeForProduct,
   updateProductAmountViaByproduct,
   updateProductAmountViaRequirement,
 } from '@/utils/factory-management/products'
@@ -751,5 +751,54 @@ describe('products', () => {
     })
   })
 
-  describe('isPartBy')
+  describe('isPartByProductOfRecipe', () => {
+    it('should detect if a part is a byproduct of a recipe', () => {
+      expect(isPartByProductOfRecipe('HeavyOilResidue', 'Rubber', gameData)).toBe(true)
+      expect(isPartByProductOfRecipe('Water', 'Battery', gameData)).toBe(true)
+      expect(isPartByProductOfRecipe('SulfuricAcid', 'UraniumCell', gameData)).toBe(true)
+    })
+
+    it('should not incorrectly detect a byproduct-able part being a byproduct if it is an actual product', () => {
+      // Check it's not detecting legitimate parts as byproducts
+      expect(isPartByProductOfRecipe('UraniumCell', 'UraniumCell', gameData)).toBe(false)
+
+      // Check if it's not detecting itself being a byproduct of other recipes when it is an product in it's own right
+      expect(isPartByProductOfRecipe('Water', 'UnpackageWater', gameData)).toBe(false)
+      expect(isPartByProductOfRecipe('SulphuricAcid', 'SulfuricAcid', gameData)).toBe(false)
+    })
+  })
+
+  describe('swapByProductRecipeForProduct', () => {
+    it('should correctly swap out a byproduct recipe for a product recipe', () => {
+      const product = {
+        id: 'HeavyOilResidue',
+        amount: 100,
+        recipe: 'Rubber',
+      } as FactoryItem
+
+      swapByProductRecipeForProduct(product, gameData)
+
+      expect(product).toEqual({
+        id: product.recipe,
+        amount: 100,
+        recipe: product.recipe,
+      })
+    })
+
+    it('should correctly swap out a byproduct recipe for a product even on weird names', () => {
+      const product = {
+        id: 'HeavyOilResidue',
+        amount: 100,
+        recipe: 'Rubber',
+      } as FactoryItem
+
+      swapByProductRecipeForProduct(product, gameData)
+
+      expect(product).toEqual({
+        id: product.recipe,
+        amount: 100,
+        recipe: product.recipe,
+      })
+    })
+  })
 })

--- a/web/src/utils/factory-management/products.spec.ts
+++ b/web/src/utils/factory-management/products.spec.ts
@@ -3,14 +3,14 @@ import { Factory, FactoryItem } from '@/interfaces/planner/FactoryInterface'
 import { calculateFactories, newFactory } from '@/utils/factory-management/factory'
 import {
   addProductToFactory,
+  byProductAsProductCheck,
   fixProduct,
-  getProduct,
-  getProductAmountByPart, isPartByProductOfRecipe,
+  getProduct, getProductAmountByPart,
+  isPartByProductOfRecipe,
   recipeByproductPerMin,
   recipeIngredientPerMin,
   shouldShowFix,
-  shouldShowInternal,
-  shouldShowNotInDemand, swapByProductRecipeForProduct,
+  shouldShowInternal, shouldShowNotInDemand,
   updateProductAmountViaByproduct,
   updateProductAmountViaRequirement,
 } from '@/utils/factory-management/products'
@@ -768,7 +768,7 @@ describe('products', () => {
     })
   })
 
-  describe('swapByProductRecipeForProduct', () => {
+  describe('byProductAsProductCheck', () => {
     it('should correctly swap out a byproduct recipe for a product recipe', () => {
       const product = {
         id: 'HeavyOilResidue',
@@ -776,7 +776,7 @@ describe('products', () => {
         recipe: 'Rubber',
       } as FactoryItem
 
-      swapByProductRecipeForProduct(product, gameData)
+      byProductAsProductCheck(product, gameData)
 
       expect(product).toEqual({
         id: product.recipe,
@@ -785,17 +785,17 @@ describe('products', () => {
       })
     })
 
-    it('should correctly swap out a byproduct recipe for a product even on weird names', () => {
+    it('should not affect already correct recipes', () => {
       const product = {
-        id: 'HeavyOilResidue',
+        id: 'Water',
         amount: 100,
-        recipe: 'Rubber',
+        recipe: 'UnpackageWater',
       } as FactoryItem
 
-      swapByProductRecipeForProduct(product, gameData)
+      byProductAsProductCheck(product, gameData)
 
       expect(product).toEqual({
-        id: product.recipe,
+        id: product.id,
         amount: 100,
         recipe: product.recipe,
       })

--- a/web/src/utils/factory-management/products.ts
+++ b/web/src/utils/factory-management/products.ts
@@ -339,7 +339,14 @@ export const isPartByProductOfRecipe = (part: string, recipeId: string, gameData
 }
 
 // Takes the byproduct and swaps it for the product recipe otherwise the planner does real dumb shit
-export const swapByProductRecipeForProduct = (product: FactoryItem, gameData: DataInterface) => {
+export const byProductAsProductCheck = (product: FactoryItem, gameData: DataInterface) => {
+  // Check if a swap is required
+  const required = isPartByProductOfRecipe(product.id, product.recipe, gameData)
+
+  if (!required) {
+    return
+  }
+
   // Get what should be the correct product recipe combo. We do this by getting the recipeId and simply replacing the product's productId with that instead and updating the factory.
   const recipe = getRecipe(product.recipe, gameData)
   const oldPartName = getPartDisplayNameWithoutDataStore(product.id, gameData)

--- a/web/src/utils/factory-setups/375-byproduct-ghost-surplus.ts
+++ b/web/src/utils/factory-setups/375-byproduct-ghost-surplus.ts
@@ -1,0 +1,22 @@
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { newFactory } from '@/utils/factory-management/factory'
+import { addProductToFactory } from '@/utils/factory-management/products'
+
+// https://github.com/satisfactory-factories/application/issues/375
+export const create375Scenario = (): { getFactories: () => Factory[] } => {
+  const factory = newFactory('Byproduct product', 0, 1)
+
+  // Store factories in an array
+  const factories = [factory]
+
+  // Add products and imports
+  addProductToFactory(factory, {
+    id: 'HeavyOilResidue',
+    amount: 100,
+    recipe: 'Rubber',
+  })
+  // Return an object with a method to access the factories
+  return {
+    getFactories: () => factories, // Expose factories as a method
+  }
+}

--- a/web/src/utils/helpers.ts
+++ b/web/src/utils/helpers.ts
@@ -16,6 +16,7 @@ export const getPartDisplayName = (part: string | number | null): string => {
     gameData.items.parts[part]?.name ||
     `UNKNOWN PART ${part}!`
 }
+
 export const hasMetricsForPart = (factory: Factory, part: string) => {
   return factory.dependencies.metrics && factory.dependencies.metrics[part]
 }


### PR DESCRIPTION
Closes #375 
Closes #385 

When the user selects a byproduct as a product (e.g. Heavy Oil Residue using the Rubber recipe) the planner would double count the byproduct, and the original producing product (Rubber) would not be counted at all.

This change now enforces the use of the actual product recipe as the product selection, and informs the user that such a change has been made.

## Before:
![image](https://github.com/user-attachments/assets/28590da7-284e-4d60-9318-6994e3d768f8)

## After
![image](https://github.com/user-attachments/assets/7e8fbe4d-6d4b-4bc7-8350-b3bd30746aa7)

