### PR TITLE
Add GitHub release workflow and changelog extraction script

### DIFF
--- a/.github/scripts/changelog-release-notes.mjs
+++ b/.github/scripts/changelog-release-notes.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+// Pulls one release's section out of CHANGELOG.md so the release workflow can
+// publish it verbatim as a GitHub release body.
+//
+// CHANGELOG.md is the source of truth for what shipped, and it is written for
+// humans rather than generated from commits. Rendering it twice — once in the
+// in-app Change Log, once on the GitHub release — beats maintaining a second set
+// of notes that drifts from the first.
+//
+// A release is a `## ` heading naming its version, e.g.
+//
+//   ## Beta v0.6 - The "Groundwork" Update
+//
+// and runs until the next `## ` heading or the end of the file. A heading naming
+// the exact version wins; failing that, the version's major.minor does, so
+// `0.6.0` finds `v0.6`. The changelog titles releases the way the app does
+// ("Beta v0.6") while tags carry the full package version, and that fallback is
+// what bridges the two.
+//
+// Usage:
+//   node .github/scripts/changelog-release-notes.mjs --version 0.6.0 [--out notes.md]
+//   node .github/scripts/changelog-release-notes.mjs --list
+//
+// The release body goes to --out, and a JSON blob of metadata always goes to
+// stdout for the workflow to read with jq. --print echoes the body to stderr,
+// which keeps it out of that JSON while still letting you read it.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+
+// GitHub rejects a release body over 125,000 characters. Fail here with a clear
+// reason rather than letting the API return an opaque 422 half way through a
+// release.
+const MAX_BODY_LENGTH = 125_000
+
+function parseArgs (argv) {
+  const args = { changelog: 'CHANGELOG.md' }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--version': args.version = argv[++i]; break
+      case '--changelog': args.changelog = argv[++i]; break
+      case '--out': args.out = argv[++i]; break
+      case '--list': args.list = true; break
+      case '--print': args.print = true; break
+      default: throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+  return args
+}
+
+// Splits the changelog on its `## ` headings. Fenced code blocks are skipped so
+// a `## ` inside one is never mistaken for a release heading.
+export function parseSections (markdown) {
+  const sections = []
+  let current = null
+  let inFence = false
+
+  for (const line of markdown.split('\n')) {
+    if (/^\s*(```|~~~)/.test(line)) inFence = !inFence
+
+    const heading = !inFence && /^## +(.*\S)\s*$/.exec(line)
+    if (heading) {
+      current = { title: heading[1], lines: [] }
+      sections.push(current)
+      continue
+    }
+
+    current?.lines.push(line)
+  }
+
+  return sections.map(({ title, lines }) => ({ title, body: lines.join('\n').trim() }))
+}
+
+// `0.6.0` -> `0.6`. Also accepts `v0.6` and `Beta v0.6` so the script stays
+// usable by hand, even though the workflow always passes a full x.y.z version.
+export function majorMinor (version) {
+  const match = /(\d+)\.(\d+)/.exec(version ?? '')
+  if (!match) throw new Error(`Could not read a major.minor version out of "${version}"`)
+  return `${match[1]}.${match[2]}`
+}
+
+// `0.6.0` -> `0.6.0`, or null if the version was not given in full.
+function fullVersion (version) {
+  return /\d+\.\d+\.\d+/.exec(version ?? '')?.[0] ?? null
+}
+
+// Matches `0.6` in a title but not `0.60` or `0.6.1`, with or without the `v`.
+function matchOn (sections, token) {
+  if (!token) return []
+  const escaped = token.replaceAll('.', String.raw`\.`)
+  const pattern = new RegExp(String.raw`(?<![\w.])v?${escaped}(?![\d.])`)
+  return sections.filter(section => pattern.test(section.title))
+}
+
+// A patch release that has been given its own heading wins; otherwise the
+// minor's section is the one describing it, since the changelog titles releases
+// the way the app does. Without the first pass, releasing 0.6.1 would quietly
+// republish the v0.6 notes even where a v0.6.1 section exists.
+export function findSection (sections, version) {
+  const exact = matchOn(sections, fullVersion(version))
+  return exact.length > 0 ? exact : matchOn(sections, majorMinor(version))
+}
+
+// Alpha and Beta releases are pre-releases. Every release so far is one, but the
+// day 1.0 ships this stops marking it.
+export function isPrerelease (title) {
+  return /^\s*(alpha|beta|rc\b|release candidate)/i.test(title)
+}
+
+function main () {
+  const args = parseArgs(process.argv.slice(2))
+  const sections = parseSections(readFileSync(args.changelog, 'utf8'))
+
+  if (args.list) {
+    for (const section of sections) console.log(section.title)
+    return
+  }
+
+  if (!args.version) throw new Error('--version is required (e.g. --version 0.6.0)')
+
+  const matches = findSection(sections, args.version)
+  const known = sections.map(section => `  - ${section.title}`).join('\n')
+
+  if (matches.length === 0) {
+    throw new Error(
+      `No section in ${args.changelog} names version ${majorMinor(args.version)}.\n` +
+      `Releases the changelog knows about:\n${known}\n` +
+      'Add a section for it before releasing, or correct the version.'
+    )
+  }
+
+  if (matches.length > 1) {
+    throw new Error(
+      `${matches.length} sections in ${args.changelog} name version ${majorMinor(args.version)}:\n` +
+      matches.map(match => `  - ${match.title}`).join('\n') +
+      '\nOnly one heading may claim a version.'
+    )
+  }
+
+  const [{ title, body }] = matches
+
+  if (body.length === 0) throw new Error(`The "${title}" section is empty; there is nothing to release.`)
+  if (body.length > MAX_BODY_LENGTH) {
+    throw new Error(
+      `The "${title}" section is ${body.length} characters; GitHub caps a release body at ${MAX_BODY_LENGTH}.`
+    )
+  }
+
+  if (args.out) writeFileSync(args.out, `${body}\n`)
+  if (args.print) process.stderr.write(`${body}\n`)
+
+  console.log(JSON.stringify({
+    title,
+    version: args.version,
+    prerelease: isPrerelease(title),
+    characters: body.length,
+  }))
+}
+
+// Only run when invoked directly, so the parsing helpers stay importable.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error.message)
+    process.exit(1)
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,195 @@
+name: "Release: Publish"
+
+# Publishes a GitHub release whose body is the matching section of CHANGELOG.md,
+# verbatim.
+#
+# CHANGELOG.md is written by hand for humans and already mirrors the in-app
+# Change Log. Generating release notes from commit subjects instead would give a
+# third, worse description of the same update, so this workflow does no writing
+# of its own: pick a version, and the section under that version's `## ` heading
+# becomes the release body.
+#
+# Deploys are trunk-based (docs/how-do-we-release.md) — merging to main is what
+# ships the app — so a release here is a record of what shipped, not the act of
+# shipping it. That is also why this is dispatch-only: releases are cut when
+# someone decides an update is done, not on every push to main.
+#
+# The notes always come from CHANGELOG.md on the branch this workflow runs from,
+# while the tag is pinned to `sha`. That split is deliberate: it is what lets a
+# past update be released retroactively, using a section written today against a
+# commit from months ago.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 0.6.0. Becomes the tag, and its major.minor picks the CHANGELOG.md section.'
+        required: true
+        type: string
+      sha:
+        description: 'Commit to pin the release to. Leave blank for the current head of main.'
+        required: false
+        type: string
+      draft:
+        description: 'Publish as a draft, so the notes can be read before anyone else sees them.'
+        type: boolean
+        default: false
+      prerelease:
+        description: 'Mark as a pre-release. "auto" marks anything the changelog titles Alpha or Beta.'
+        type: choice
+        options:
+          - auto
+          - 'true'
+          - 'false'
+        default: auto
+      overwrite:
+        description: 'Rewrite the notes on a release that already exists for this tag, instead of failing.'
+        type: boolean
+        default: false
+
+# Creating a release and its tag is a write to the repository.
+permissions:
+  contents: write
+
+# Two releases at once would race on tag creation, and a re-run started before
+# the first finished would be the likeliest way to cause it.
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # Full history: the sha check below has to be able to see a commit from any
+      # point in the repo's life, not just the last shallow slice of main.
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      # Every input reaches bash through env rather than ${{ }} interpolation, so
+      # nothing a dispatcher types is ever expanded into the script itself.
+      - name: Check the version is a tag we would want
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::\"$VERSION\" is not a version. Give it as x.y.z with no leading v — the existing tags are 0.2.1 and 0.3.0, and the tag is taken from this verbatim."
+            exit 1
+          fi
+
+      # A release pinned to a commit that never reached main would describe an
+      # update nobody was ever served, so both facts are checked before anything
+      # is written.
+      - name: Resolve the commit to pin the release to
+        id: target
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$INPUT_SHA" ]]; then
+            sha="$(git rev-parse origin/main)"
+            echo "No sha given; using the current head of main: $sha"
+          else
+            if ! git cat-file -e "${INPUT_SHA}^{commit}" 2>/dev/null; then
+              echo "::error::$INPUT_SHA is not a commit in this repository."
+              exit 1
+            fi
+            sha="$(git rev-parse "${INPUT_SHA}^{commit}")"
+            if ! git merge-base --is-ancestor "$sha" origin/main; then
+              echo "::error::$sha is not on main. A release has to point at something that actually shipped."
+              exit 1
+            fi
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "subject=$(git log -1 --format=%s "$sha")" >> "$GITHUB_OUTPUT"
+
+      - name: Read the release notes out of CHANGELOG.md
+        id: notes
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          meta="$(node .github/scripts/changelog-release-notes.mjs \
+            --version "$VERSION" \
+            --out "$RUNNER_TEMP/release-notes.md")"
+          echo "$meta"
+          {
+            echo "title=$(jq -r .title <<<"$meta")"
+            echo "prerelease=$(jq -r .prerelease <<<"$meta")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish the release
+        id: publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          TITLE: ${{ steps.notes.outputs.title }}
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+          DRAFT: ${{ inputs.draft }}
+          PRERELEASE_INPUT: ${{ inputs.prerelease }}
+          PRERELEASE_AUTO: ${{ steps.notes.outputs.prerelease }}
+          OVERWRITE: ${{ inputs.overwrite }}
+        run: |
+          set -euo pipefail
+
+          prerelease="$PRERELEASE_INPUT"
+          if [[ "$prerelease" == "auto" ]]; then
+            prerelease="$PRERELEASE_AUTO"
+            echo "prerelease=auto resolved to $prerelease from the title \"$TITLE\""
+          fi
+
+          notes="$RUNNER_TEMP/release-notes.md"
+
+          if gh release view "$VERSION" --json id >/dev/null 2>&1; then
+            if [[ "$OVERWRITE" != "true" ]]; then
+              echo "::error::A release already exists for $VERSION. Re-run with overwrite to rewrite its notes."
+              exit 1
+            fi
+            # A release's tag cannot be re-pointed by editing it. Say so rather
+            # than reporting a sha this run never actually applied.
+            echo "::notice::Rewriting the existing $VERSION release. Its tag keeps pointing where it already did; sha is ignored on an overwrite."
+            gh release edit "$VERSION" \
+              --title "$TITLE" \
+              --notes-file "$notes" \
+              --draft="$DRAFT" \
+              --prerelease="$prerelease"
+          else
+            args=(--target "$TARGET_SHA" --title "$TITLE" --notes-file "$notes")
+            if [[ "$DRAFT" == "true" ]]; then args+=(--draft); fi
+            if [[ "$prerelease" == "true" ]]; then args+=(--prerelease); fi
+            gh release create "$VERSION" "${args[@]}"
+          fi
+
+          echo "url=$(gh release view "$VERSION" --json url --jq .url)" >> "$GITHUB_OUTPUT"
+
+      - name: Summarise what was published
+        env:
+          VERSION: ${{ inputs.version }}
+          TITLE: ${{ steps.notes.outputs.title }}
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+          SUBJECT: ${{ steps.target.outputs.subject }}
+          URL: ${{ steps.publish.outputs.url }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## $TITLE"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Release | [$VERSION]($URL) |"
+            echo "| Tag | \`$VERSION\` |"
+            echo "| Commit | \`${TARGET_SHA:0:8}\` — $SUBJECT |"
+            echo
+            echo "Notes taken from the \`$TITLE\` section of CHANGELOG.md."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-All notable changes to this project are documented in this file. It mirrors the structure of the in-app [Change Log](https://satisfactory-factories.app/changelog) — same sections, full technical detail. For the release history prior to Beta v0.5 (the 0.1.x–0.2.x scaffolding releases), see the [GitHub commit history](https://github.com/satisfactory-factories/application/commits/main).
+All notable changes to this project are documented in this file. It mirrors the structure of the in-app [Change Log](https://satisfactory-factories.app/changelog) — same sections, full technical detail. For the release history prior to Alpha v0.4 (the 0.1.x–0.3.x scaffolding releases), see the [GitHub commit history](https://github.com/satisfactory-factories/application/commits/main).
 
 ## Beta v0.6 - The "Groundwork" Update
+
+_Released 19 August 2026._
 
 Raw resources are no longer assumed. Ore, water, oil and gas are dug up by buildings you place, and planned and exported like anything else. Factory groups, factory icons and status chips arrive to keep a bigger plan in order.
 
@@ -223,6 +225,8 @@ Raw resources are no longer assumed. Ore, water, oil and gas are dug up by build
 
 ## Beta v0.5 — The "Overclocked" Update
 
+_Released 21 July 2026._
+
 After a long hiatus: the highly anticipated Overclocking and Somersloop support via Building Groups, a huge Power update, an item-centric Parts & Recipes browser, and a planner-wide UI refresh.
 
 ### Building Groups — Overclocking & Somersloops
@@ -322,3 +326,52 @@ After a long hiatus: the highly anticipated Overclocking and Somersloop support 
 - Upgraded the web build/test toolchain across two majors: Vite 5 → 7, Vitest 2 → 4 (plus @vitejs/plugin-vue 6, coverage-v8 4, jsdom 29, vite-plugin-vue-devtools 8, @types/node 24). This clears **all 37 known vulnerabilities** in the web package, including a critical arbitrary-file-read/execute hole in Vitest's UI server. Test-suite adaptations for Vitest's new mock semantics (`resetAllMocks` now restores real implementations and `spyOn` reuses existing mocks, so a few tests needed their spy history cleared explicitly).
 - Upgraded every dependency across web, backend and parsing to its latest patch/minor version (highlights: Vuetify 3.7 → 3.12, Vue 3.5.40, Vue Flow 1.48, sass 1.101, Mongoose 8.24, Express 4.22, jsonwebtoken 9.0.3 — which fixes the backend crashing on Node 26, so Node 26 is now supported). Vuetify's `VNumberInput` graduated from labs along the way with two behaviour changes that needed adapting: it now rounds typed values to whole numbers by default (the planner configures unrestricted decimal precision globally, keeping fractional per-minute rates working), and it mis-handles the `v-model.number` modifier (silently dropping every keystroke), so the redundant `.number` modifiers were removed from all number inputs. (vue-router was held at 4.4.x during this pass, then upgraded to 5 in the routing-stack modernisation above.)
 - `pnpm test` no longer runs Vitest in watch mode (it never finished in CI), and tests run with an in-memory `Storage` implementation under Node 24+.
+
+## Alpha v0.4
+
+_Released 25 January 2025._
+
+A stability release: long-running planner bugs squashed (over **20** of them), measures added to stop the planner breaking in the first place, and a large batch of quality-of-life work across Products, Imports and Satisfaction. [Release video](https://www.youtube.com/watch?v=xiE7AwfzOpc) · [itemised list of changes on GitHub](https://github.com/orgs/satisfactory-factories/projects/2/views/1?filterQuery=+milestone%3A%22Alpha+4%22+&sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Title).
+
+### Export Calculator v2
+
+- 🆕 The export calculator returns, and now accounts for multiple transport types: trains (solids & fluids), drones, trucks and tractors (solids only). Attempting to transport a fluid by a solids-only method tells you to package it first.
+- 🆕 Timer buttons on the "drivable" transport methods: ride the route, start the timer, stop it, and the calculator updates itself from what you drove.
+- 🆕 Each transport method shows its accuracy, listing the full assumptions and potential caveats behind the figure.
+
+### Loading Sequence
+
+- 🆕 Loading a plan is completely redesigned. Factories load in sequence, validated as they go to prevent plan corruption, with a progress indicator saying how far along it is. A large plan used to simply appear frozen for 30 seconds or more; now there is feedback at every step.
+
+### Products
+
+- 🆕 Product **ingredients** and **buildings** can have their values changed directly, so adjusting the Wire on a Cable product scales the Cable output to match.
+- 👍 Internal byproducts are accounted for properly: a product that also arrives as a byproduct of the same type (Sulphuric Acid as both a product and a byproduct of Encased Uranium Cells) no longer offers a TRIM button.
+- 🔧 The "FIX PRODUCTION" double buttons are gone, replaced by proper **Satisfy / Trim** buttons that take more scenarios into account, including internal requirements and exports.
+
+### Imports
+
+- 👍 **Import candidate selection is rewritten.** It now weighs the destination factory's requirements far more strongly, byproducts included. The previous system had a number of edge cases where it would show factories that were not relevant (Water imports appearing for no reason) or fail to show ones that were.
+- 👍🔧 **TRIM and SATISFY account for other imports of the same part.** They used to check only the import being trimmed or satisfied against the factory's shortage or overflow; they now calculate the difference across every import of that part.
+- 🔧 A factory is no longer an import candidate if it imports a raw resource the destination factory needs.
+- 🆕 Redundant imports — where one import alone can cover the demand — are flagged **Redundant!** rather than forcing you to rebalance them.
+- 🆕 Imports with no amount set are flagged **No amount set!**.
+- 🔧 The TRIM button no longer shows when an import is also a byproduct in the factory.
+
+### Satisfaction
+
+- 👍 **Uranium / Plutonium waste handling.** Producing waste previously required working out for yourself that you needed a power plant, and it was erroneously possible to select Uranium Waste as a product with no recipe. The Satisfaction section now carries a **+ Generator** button that adds a Nuclear Reactor with the correct fuel rod, at exactly the amount needed to produce that much waste.
+- 👍 **Part roles.** Each part now shows what role it plays in the factory — Product, Byproduct, Import or Internal — making its relationship to the factory much easier to read.
+- 👍 **"MANUALLY FIX" indicators.** Where an automatic fix might not be what you wanted (multiple products, imports or byproducts of the same part), the planner now says so and asks you to fix it by hand rather than guessing.
+- 🔧 **TRIM / SATISFY fixes.** A long tail of edge cases resolved, accounting for byproducts and imports across the factory, so the buttons appear only when they apply — which also fixes them doing nothing when pressed.
+- 🔧 **Generator power & building maths.** Multiple generator groups of the same building and fuel type were not producing correct power or building counts.
+
+### Fixes & minor adjustments
+
+- 🔧 Fixed a **planner-breaking bug** in how Chrome, Edge and other Chromium derivatives render the mobile tray, which broke the planner outright in those browsers.
+- 👍 GameSync now drops factories out of sync when their power generators change.
+- 👍 **Tab memory**: changing tabs and reloading remembers the last opened tab instead of always opening the first.
+- 👍 **Performance improvements**: the hidden factories UI is now genuinely hidden when a factory is expanded, changes written to a factory are reduced so the UI framework has less to do, and various bits of dead code slowing factory calculation down were removed.
+- 👍 The "too many factories open" banner can be dismissed until the page is reloaded.
+- 🔧 The template manager can open multiple templates without needing a page reload.
+- 🔧 Packaged Rocket Fuel shows the correct icon.

--- a/docs/how-do-we-release.md
+++ b/docs/how-do-we-release.md
@@ -2,6 +2,52 @@
 
 This document will describe how the various components of Satisfactory Factories are released to users.
 
+## GitHub releases
+
+Deploys are trunk-based, so merging to `main` is what ships an update. A GitHub
+release is therefore a *record* of an update, cut by hand once it is done —
+nothing waits on it.
+
+Run **Actions → "Release: Publish" → Run workflow**:
+
+| Input | |
+| --- | --- |
+| `version` | The version, as `x.y.z` with no leading `v` (`0.6.0`). It becomes the tag, matching the existing `0.2.1` and `0.3.0`. |
+| `sha` | The commit to pin the release to. Leave blank for the current head of `main`. |
+| `draft` | Publish as a draft first, to read the notes before anyone else does. |
+| `prerelease` | `auto` marks anything the changelog titles Alpha or Beta. |
+| `overwrite` | Rewrite the notes on a release that already exists, instead of failing. |
+
+The release body is the matching section of [`CHANGELOG.md`](../CHANGELOG.md),
+published verbatim, and the release is named after that section's heading. The
+version is matched on its major and minor, so `0.6.0` finds
+`## Beta v0.6 - The "Groundwork" Update`; a patch release gets its own section
+if it needs one, and that section wins where it exists. Nothing is generated
+from commit subjects — the changelog is already written for humans and already
+mirrors the in-app Change Log, so a third description of the same update would
+only drift from the other two.
+
+**So the changelog section has to exist before the release does.** If it does
+not, the run fails and lists the versions it does know about.
+
+Notes are read from `CHANGELOG.md` as it stands on the branch the workflow is
+run from — `main`, normally — while the tag is pinned to `sha`. That split is what lets a past update be released
+retroactively: a section written today, against a commit from months ago. The
+one thing it cannot backdate is the release's own publication date, which is
+why each section carries a `_Released <date>._` line.
+
+`overwrite` cannot re-point an existing release's tag — GitHub does not allow
+it. Delete the release and the tag if a release ended up on the wrong commit.
+
+The extraction is done by
+[`.github/scripts/changelog-release-notes.mjs`](../.github/scripts/changelog-release-notes.mjs),
+which is runnable on its own while writing a changelog entry:
+
+```bash
+node .github/scripts/changelog-release-notes.mjs --list
+node .github/scripts/changelog-release-notes.mjs --version 0.6.0 --print
+```
+
 ## Frontend (web)
 Frontend is automatically deployed whenever main is merged. This is called [Trunk based development](https://trunkbaseddevelopment.com/#trunk-based-development-for-smaller-teams).
 


### PR DESCRIPTION
Adds a trunk-based release process: a manual GitHub Actions workflow that publishes releases by extracting notes from `CHANGELOG.md` verbatim, rather than generating them from commits.

## Summary

Releases are now cut by hand once an update is done, with the release body pulled directly from the matching section of `CHANGELOG.md`. This avoids maintaining a third description of the same update (commits, in-app Change Log, and GitHub release notes would otherwise drift). The workflow is dispatch-only and records what shipped, not the act of shipping it — deploys remain trunk-based (merging to `main` is what ships).

## Key changes

- **`.github/workflows/release.yml`** — New workflow triggered manually via `workflow_dispatch`. Accepts version (x.y.z), optional commit SHA, and flags for draft/prerelease/overwrite. Validates the version format, resolves the target commit (defaulting to `main` head), extracts release notes from `CHANGELOG.md`, and publishes via `gh release create` or `gh release edit`. Includes safety checks: version must be valid semver, commit must exist and be on `main`, and existing releases can only be overwritten if explicitly requested.

- **`.github/scripts/changelog-release-notes.mjs`** — Node script that parses `CHANGELOG.md` and extracts one release's section. Matches versions on exact x.y.z or falls back to major.minor (so `0.6.0` finds `## Beta v0.6 - ...`), handles fenced code blocks to avoid false matches, and detects prerelease status from the title (Alpha/Beta/RC). Outputs JSON metadata (title, version, prerelease flag, character count) to stdout and the release body to a file or stderr. Includes a `--list` mode for browsing available releases and validates that the body is non-empty and under GitHub's 125k character limit.

- **`CHANGELOG.md`** — Updated preamble to reference Alpha v0.4 instead of Beta v0.5 as the cutoff for commit history. Added release dates (`_Released <date>._`) to v0.6 and v0.5 sections, and added a new Alpha v0.4 section with full release notes (export calculator, loading sequence, products, imports, and other improvements).

- **`docs/how-do-we-release.md`** — New "GitHub releases" section documenting the release workflow: how to run it, what each input does, how the changelog section is matched, and why notes are read from the current branch while the tag pins to a specific commit (enabling retroactive releases). Includes examples of running the extraction script standalone while writing changelog entries.

## Implementation notes

- The workflow uses full history (`fetch-depth: 0`) so it can validate commits from any point in the repo's life.
- All user inputs flow through environment variables, never interpolated into scripts, to prevent injection.
- Prerelease detection is automatic (`auto` mode) but can be overridden; the workflow resolves it before publishing.
- The script is importable for testing and reusable outside the workflow (e.g., `--list` and `--print` modes for manual changelog work).
- Concurrency is serialized (`cancel-in-progress: false`) to prevent races on tag creation.

https://claude.ai/code/session_01EaR7PHwg5Xzj3XZbANGv31