### PR TITLE
chore(repo): clear the six high advisories in the dev toolchain

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ catalogs:
       specifier: 8.66.0
       version: 8.66.0
 
+overrides:
+  js-yaml@^3.13.1: 3.15.1
+
 importers:
 
   .: {}
@@ -1874,14 +1877,14 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3113,8 +3116,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -5242,7 +5245,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -6651,16 +6654,16 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8297,7 +8300,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -8558,15 +8561,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,13 @@ allowBuilds:
   unrs-resolver: true
   vue-demi: true
   '@parcel/watcher': false
+
+# js-yaml 3.x reaches us only through jest's coverage tooling
+# (babel-plugin-istanbul -> @istanbuljs/load-nyc-config, which asks for ^3.13.1).
+# 3.15.0 carries GHSA-5p4m-2wfm-xmqj (quadratic CPU in !!omap resolution); the fix
+# landed in 3.15.1 on the v3-legacy line. Nothing updates it on its own -- the range
+# already allows 3.15.1, so pnpm keeps the resolution it has. Match the range and pin
+# the target explicitly: a looser key such as 'js-yaml@3' resolves to the 5.x latest,
+# which is a different API and breaks load-nyc-config.
+overrides:
+  js-yaml@^3.13.1: 3.15.1


### PR DESCRIPTION
Takes `pnpm audit` on `main` from **6 high** to **none**. Two packages, four installed copies, all transitive and all dev-only.

| Package | Was | Now | Advisory | Reached via |
|---|---|---|---|---|
| brace-expansion | 1.1.16 | 1.1.18 | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | `parsing` → jest → babel-plugin-istanbul → test-exclude → minimatch |
| brace-expansion | 2.1.2 | 2.1.4 | both of the above | `parsing` → jest → glob → minimatch |
| brace-expansion | 5.0.8 | 5.0.9 | GHSA-rgw5-rvv9-x895 | `backend` → eslint → minimatch |
| js-yaml | 3.15.0 | 3.15.1 | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | `parsing` → jest → babel-plugin-istanbul → @istanbuljs/load-nyc-config |

The alert count reads higher than the problem is: the two brace-expansion CVEs overlap (the second exists because it bypasses the mitigation for the first) and get counted against each major line separately.

## Severity in context

All four are denial-of-service — unbounded expansion, quadratic CPU. None is in a runtime path: every chain runs through jest or eslint, and `parsing`'s only production dependencies are `fs-extra` and `iconv-lite`. Realistic exposure is a hostile glob pattern or YAML file inside our own build, not anything a user of the planner can reach. Worth fixing, not worth alarm.

## Why the two halves differ

**brace-expansion** needed no intervention — 1.1.18, 2.1.4 and 5.0.9 all sit inside ranges the tree already declares, so a resolution refresh picks them up.

**js-yaml** needed the override. `load-nyc-config` asks for `^3.13.1` and 3.15.1 satisfies it, so pnpm had no reason to move off 3.15.0 — not on `pnpm update js-yaml`, not at `--depth Infinity`. The override has to name both halves precisely:

```yaml
overrides:
  js-yaml@^3.13.1: 3.15.1
```

A shorter key such as `js-yaml@3` resolves to the 5.x `latest` — a different API, which breaks the very package being patched. That failure is quiet, so the comment in `pnpm-workspace.yaml` spells it out.

## One thing to be aware of

An `overrides` entry is a standing instruction and is **not** subject to the 14-day `minimumReleaseAge` guard in `renovate.json`. 3.15.1 is 18 days old and clears that bar on its own, but anything added to this block later will not be checked against it.

Relatedly, and not addressed here: that guard already has a gap for transitive dependencies. It governs what Renovate *proposes*, not what pnpm resolves underneath — #521 landed rolldown 1.2.4 at 6 days old, and Renovate's own branch had pinned it at one day old.

## Verification

Node 24.19.0, against `main` at `2d5224c`:

```
pnpm audit                       No known vulnerabilities
pnpm install --frozen-lockfile   exit 0
pnpm build                       exit 0   (incl. vue-tsc --noEmit && vite build)
pnpm lint-check                  exit 0
pnpm test                        exit 0   web: 96 files, 1800 passed | 1 skipped
                                          backend: 20 passed
```

No `CHANGELOG.md` entry: the changelog mirrors the in-app one and this has no user-visible effect, matching how dependency commits are handled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JC7t8bNrkiYj6yjwAT1vT

---
_Generated by [Claude Code](https://claude.ai/code/session_013JC7t8bNrkiYj6yjwAT1vT)_