### PR TITLE
Build release notes from the in-app Change Log, not CHANGELOG.md

### DIFF
--- a/.github/scripts/changelog-release-notes.mjs
+++ b/.github/scripts/changelog-release-notes.mjs
@@ -1,164 +1,442 @@
 #!/usr/bin/env node
 
-// Pulls one release's section out of CHANGELOG.md so the release workflow can
-// publish it verbatim as a GitHub release body.
+// Turns one release of the in-app Change Log into markdown, so the release
+// workflow can publish it as a GitHub release body.
 //
-// CHANGELOG.md is the source of truth for what shipped, and it is written for
-// humans rather than generated from commits. Rendering it twice — once in the
-// in-app Change Log, once on the GitHub release — beats maintaining a second set
-// of notes that drifts from the first.
+// The source is the page players actually read, web/src/pages/changelog.vue,
+// rather than CHANGELOG.md. The two describe the same updates at very different
+// altitudes: CHANGELOG.md is the exhaustive technical record, paragraphs deep in
+// implementation detail, which reads as noise to someone who just wants to know
+// what is new. The in-app page is the written-for-players version — short
+// sections, screenshots, a key of 🆕 / 👍 / 🔧 — and that is what a release
+// should say.
 //
-// A release is a `## ` heading naming its version, e.g.
+// A release is an `<h1>` naming its version, e.g.
 //
-//   ## Beta v0.6 - The "Groundwork" Update
+//   <h1>Beta v0.6 - The "Groundwork" Update <span class="release-date">19/Aug/2026</span></h1>
 //
-// and runs until the next `## ` heading or the end of the file. A heading naming
-// the exact version wins; failing that, the version's major.minor does, so
-// `0.6.0` finds `v0.6`. The changelog titles releases the way the app does
-// ("Beta v0.6") while tags carry the full package version, and that fallback is
-// what bridges the two.
+// and runs until the next `<h1>`. A heading naming the exact version wins;
+// failing that, the version's major.minor does, so `0.6.0` finds `v0.6`.
 //
 // Usage:
 //   node .github/scripts/changelog-release-notes.mjs --version 0.6.0 [--out notes.md]
 //   node .github/scripts/changelog-release-notes.mjs --list
 //
-// The release body goes to --out, and a JSON blob of metadata always goes to
-// stdout for the workflow to read with jq. --print echoes the body to stderr,
-// which keeps it out of that JSON while still letting you read it.
+// The body goes to --out and a JSON blob of metadata to stdout for the workflow
+// to read with jq. --print echoes the body to stderr, keeping it out of the JSON.
 
 import { readFileSync, writeFileSync } from 'node:fs'
 
+const SOURCE = 'web/src/pages/changelog.vue'
+
+// Screenshots are written as site-absolute paths for the app to serve. A release
+// is read on github.com, so they have to be pointed back at the live site.
+const SITE = 'https://satisfactory-factories.app'
+
 // GitHub rejects a release body over 125,000 characters. Fail here with a clear
-// reason rather than letting the API return an opaque 422 half way through a
-// release.
+// reason rather than letting the API return an opaque 422 mid-release.
 const MAX_BODY_LENGTH = 125_000
 
-function parseArgs (argv) {
-  const args = { changelog: 'CHANGELOG.md' }
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i]
-    switch (arg) {
-      case '--version': args.version = argv[++i]; break
-      case '--changelog': args.changelog = argv[++i]; break
-      case '--out': args.out = argv[++i]; break
-      case '--list': args.list = true; break
-      case '--print': args.print = true; break
-      default: throw new Error(`Unknown argument: ${arg}`)
-    }
-  }
-  return args
+const ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ', '#39': "'" }
+
+// Tags that carry no content of their own.
+const VOID_TAGS = new Set(['br', 'hr', 'img', 'source', 'v-img', 'v-divider', 'game-asset', 'youtube-embed'])
+
+// Layout and decoration that a release body has no use for. Dropped whole,
+// children included.
+const DROPPED = new Set(['nav', 'v-divider', 'game-asset', 'introduction', 'style', 'script'])
+
+// Passed through, contributing only their children.
+const TRANSPARENT = new Set(['v-container', 'v-row', 'v-col', 'template', 'div', 'span', 'small'])
+
+function decode (text) {
+  return text.replace(/&(#?\w+);/g, (whole, name) => ENTITIES[name] ?? whole)
 }
 
-// Splits the changelog on its `## ` headings. Fenced code blocks are skipped so
-// a `## ` inside one is never mistaken for a release heading.
-export function parseSections (markdown) {
-  const sections = []
-  let current = null
-  let inFence = false
+// Finds the `>` closing a tag, ignoring any inside a quoted attribute value.
+function tagEnd (html, start) {
+  let quote = null
+  for (let i = start + 1; i < html.length; i++) {
+    const char = html[i]
+    if (quote) {
+      if (char === quote) quote = null
+    } else if (char === '"' || char === "'") {
+      quote = char
+    } else if (char === '>') {
+      return i
+    }
+  }
+  throw new Error(`Unterminated tag at offset ${start}`)
+}
 
-  for (const line of markdown.split('\n')) {
-    if (/^\s*(```|~~~)/.test(line)) inFence = !inFence
+function parseAttrs (source) {
+  const attrs = {}
+  for (const [, name, value] of source.matchAll(/([:@]?[\w.-]+)(?:\s*=\s*"([^"]*)")?/g)) {
+    attrs[name] = decode(value ?? '')
+  }
+  return attrs
+}
 
-    const heading = !inFence && /^## +(.*\S)\s*$/.exec(line)
-    if (heading) {
-      current = { title: heading[1], lines: [] }
-      sections.push(current)
+// A tolerant tag-soup parser. The input is a linted Vue template rather than
+// arbitrary HTML, so it only has to cope with well-formed markup — but it fails
+// loudly rather than guessing when it meets something it does not know.
+export function parse (html) {
+  const root = { tag: null, children: [] }
+  const stack = [root]
+  let i = 0
+
+  const push = node => stack.at(-1).children.push(node)
+
+  while (i < html.length) {
+    const lt = html.indexOf('<', i)
+    if (lt === -1) {
+      push({ text: html.slice(i) })
+      break
+    }
+    if (lt > i) push({ text: html.slice(i, lt) })
+
+    if (html.startsWith('<!--', lt)) {
+      i = html.indexOf('-->', lt) + 3
       continue
     }
 
-    current?.lines.push(line)
+    const gt = tagEnd(html, lt)
+    const raw = html.slice(lt + 1, gt).trim()
+    i = gt + 1
+
+    if (raw.startsWith('/')) {
+      const tag = raw.slice(1).trim().toLowerCase()
+      // Find the matching open tag, tolerating unclosed inline elements.
+      const depth = stack.findLastIndex(node => node.tag === tag)
+      if (depth > 0) stack.length = depth
+      continue
+    }
+
+    const selfClosing = raw.endsWith('/')
+    const body = selfClosing ? raw.slice(0, -1) : raw
+    const tag = body.match(/^[\w-]+/)?.[0]?.toLowerCase()
+    if (!tag) throw new Error(`Could not read a tag name from "<${raw}>"`)
+
+    const node = { tag, attrs: parseAttrs(body.slice(tag.length)), children: [] }
+    push(node)
+    if (!selfClosing && !VOID_TAGS.has(tag)) stack.push(node)
   }
 
-  return sections.map(({ title, lines }) => ({ title, body: lines.join('\n').trim() }))
+  return root
 }
 
-// `0.6.0` -> `0.6`. Also accepts `v0.6` and `Beta v0.6` so the script stays
-// usable by hand, even though the workflow always passes a full x.y.z version.
+const isText = node => typeof node.text === 'string'
+
+// Collapses runs of whitespace the way HTML rendering does, so the source's
+// indentation never reaches the markdown.
+// Headings and chips space their parts with Vuetify margin utilities rather than
+// whitespace (`<span class="ml-2">Overclocking</span><span class="mx-2">&</span>`),
+// so concatenating the text alone would run the words together.
+const LEADING_SPACE = /\b(?:ml|ms|mx)-\d/
+const TRAILING_SPACE = /\b(?:mr|me|mx)-\d/
+
+function inline (nodes) {
+  let out = ''
+
+  const append = (node, piece) => {
+    if (!piece) return
+    const classes = node.attrs?.class ?? ''
+    if (LEADING_SPACE.test(classes) && out && !/\s$/.test(out)) out += ' '
+    out += piece
+    if (TRAILING_SPACE.test(classes)) out += ' '
+  }
+
+  for (const node of nodes) {
+    if (isText(node)) {
+      out += decode(node.text).replace(/\s+/g, ' ')
+      continue
+    }
+    if (DROPPED.has(node.tag)) continue
+
+    switch (node.tag) {
+      case 'b': case 'strong': {
+        const text = inline(node.children).trim()
+        append(node, text && `**${text}**`)
+        break
+      }
+      case 'em': {
+        const text = inline(node.children).trim()
+        append(node, text && `_${text}_`)
+        break
+      }
+      case 'i': {
+        // Font Awesome icons are empty <i> elements; only a real one has text.
+        const text = inline(node.children).trim()
+        append(node, text && `_${text}_`)
+        break
+      }
+      case 'code': append(node, `\`${inline(node.children).trim()}\``); break
+      case 'a': {
+        const text = inline(node.children).trim()
+        const href = node.attrs.href
+        append(node, href ? `[${text}](${href})` : text)
+        break
+      }
+      // A chip is a visually distinct label in the app; bold is the nearest
+      // thing markdown has.
+      case 'v-chip': {
+        const text = inline(node.children).trim()
+        append(node, text && `**${text}**`)
+        break
+      }
+      case 'br': out += '\n'; break
+      default:
+        if (!TRANSPARENT.has(node.tag)) throw new Error(`No inline rule for <${node.tag}>`)
+        append(node, inline(node.children))
+    }
+  }
+
+  // Collapse the doubles those inserted spaces can create, without touching the
+  // newlines a <br> contributes.
+  return out.replace(/[^\S\n]+/g, ' ')
+}
+
+function asset (src) {
+  return src.startsWith('/') ? `${SITE}${src}` : src
+}
+
+// "loading.mp4" -> "Loading". Videos carry no alt text, so the filename is the
+// only description there is.
+function labelFor (src) {
+  const stem = src.split('/').pop().replace(/\.\w+$/, '').replaceAll('-', ' ')
+  return stem.charAt(0).toUpperCase() + stem.slice(1)
+}
+
+// Returns an array of markdown blocks. Block-level nodes render themselves;
+// stray inline content is gathered into a paragraph.
+function blocks (nodes) {
+  const out = []
+  let pending = ''
+
+  const flush = () => {
+    const text = pending.trim()
+    if (text) out.push(text)
+    pending = ''
+  }
+
+  for (const node of nodes) {
+    if (isText(node)) { pending += decode(node.text).replace(/\s+/g, ' '); continue }
+    if (DROPPED.has(node.tag)) continue
+
+    switch (node.tag) {
+      case 'h1': case 'h2': case 'h3': case 'h4': {
+        flush()
+        const level = '#'.repeat(Number(node.tag[1]))
+        const text = inline(node.children).replace(/\s+/g, ' ').trim()
+        if (text) out.push(`${level} ${text}`)
+        break
+      }
+      case 'p': {
+        flush()
+        const text = inline(node.children).trim()
+        if (text) out.push(text)
+        break
+      }
+      case 'ul': case 'ol': {
+        flush()
+        out.push(list(node, ''))
+        break
+      }
+      case 'v-img': case 'img': {
+        flush()
+        const src = node.attrs.src
+        if (src) out.push(`![${node.attrs.alt ?? ''}](${asset(src)})`)
+        break
+      }
+      case 'video': {
+        flush()
+        // The text inside a <video> is "your browser does not support…"
+        // fallback, so only the <source> matters. mp4s on another origin do not
+        // embed on github.com, so it becomes a link.
+        const src = node.children.find(child => child.tag === 'source')?.attrs?.src
+        if (src) out.push(`[▶ Watch: ${labelFor(src)}](${asset(src)})`)
+        break
+      }
+      case 'youtube-embed': {
+        flush()
+        const id = node.attrs['video-id']
+        if (id) out.push(`[▶ Watch the update video](https://www.youtube.com/watch?v=${id})`)
+        break
+      }
+      default: {
+        if (TRANSPARENT.has(node.tag)) { flush(); out.push(...blocks(node.children)); break }
+        pending += inline([node])
+      }
+    }
+  }
+
+  flush()
+  return out.filter(Boolean)
+}
+
+// A list item can carry a screenshot or a nested list of its own. Those go on
+// their own indented lines under the bullet — a 1200px screenshot inlined into
+// the middle of a sentence is unreadable.
+const BLOCK_IN_ITEM = new Set(['ul', 'ol', 'p', 'v-img', 'img', 'video', 'youtube-embed'])
+
+function list (node, indent) {
+  const ordered = node.tag === 'ol'
+  const items = node.children.filter(child => child.tag === 'li')
+  const pad = `${indent}  `
+
+  return items.map((item, index) => {
+    const marker = ordered ? `${index + 1}.` : '-'
+    const nested = item.children.filter(child => BLOCK_IN_ITEM.has(child.tag))
+    const rest = item.children.filter(child => !nested.includes(child))
+    const text = inline(rest).replace(/\s+/g, ' ').trim()
+
+    let out = `${indent}${marker} ${text}`
+    for (const child of nested) {
+      // A nested list hangs directly off its parent item; a blank line before it
+      // would loosen the whole list. Anything else needs one to be a block.
+      out += (child.tag === 'ul' || child.tag === 'ol')
+        ? `\n${list(child, pad)}`
+        : `\n\n${blocks([child]).map(block => pad + block).join(`\n\n${pad}`)}`
+    }
+    return out
+  }).join('\n')
+}
+
+// Splits the page into releases: each <h1> that names one, plus everything up to
+// the next <h1>. The "Change Log" heading is the page title, not a release.
+export function parseReleases (source) {
+  const start = source.indexOf('<template>')
+  const end = source.lastIndexOf('</template>')
+  if (start === -1 || end === -1) throw new Error(`No <template> block found in ${SOURCE}`)
+
+  const tree = parse(source.slice(start + '<template>'.length, end))
+
+  // The releases sit inside the layout wrappers, so flatten those away first.
+  const flatten = nodes => nodes.flatMap(node =>
+    !isText(node) && TRANSPARENT.has(node.tag) && node.tag !== 'span' ? flatten(node.children) : [node])
+
+  const releases = []
+  for (const node of flatten(tree.children)) {
+    if (node.tag === 'h1') {
+      const dateNode = node.children.find(child => child.attrs?.class?.includes('release-date'))
+      const date = dateNode ? inline(dateNode.children).trim() : ''
+      const title = inline(node.children.filter(child => child !== dateNode)).replace(/\s+/g, ' ').trim()
+      if (!title || title === 'Change Log') { releases.push(null); continue }
+      releases.push({ title, date, nodes: [] })
+      continue
+    }
+    releases.at(-1)?.nodes?.push(node)
+  }
+
+  return releases.filter(Boolean)
+}
+
+export function toMarkdown (release) {
+  const body = blocks(release.nodes).join('\n\n')
+  return release.date ? `_Released ${release.date}._\n\n${body}` : body
+}
+
 export function majorMinor (version) {
   const match = /(\d+)\.(\d+)/.exec(version ?? '')
   if (!match) throw new Error(`Could not read a major.minor version out of "${version}"`)
   return `${match[1]}.${match[2]}`
 }
 
-// `0.6.0` -> `0.6.0`, or null if the version was not given in full.
 function fullVersion (version) {
   return /\d+\.\d+\.\d+/.exec(version ?? '')?.[0] ?? null
 }
 
 // Matches `0.6` in a title but not `0.60` or `0.6.1`, with or without the `v`.
-function matchOn (sections, token) {
+function matchOn (releases, token) {
   if (!token) return []
   const escaped = token.replaceAll('.', String.raw`\.`)
   const pattern = new RegExp(String.raw`(?<![\w.])v?${escaped}(?![\d.])`)
-  return sections.filter(section => pattern.test(section.title))
+  return releases.filter(release => pattern.test(release.title))
 }
 
-// A patch release that has been given its own heading wins; otherwise the
-// minor's section is the one describing it, since the changelog titles releases
-// the way the app does. Without the first pass, releasing 0.6.1 would quietly
-// republish the v0.6 notes even where a v0.6.1 section exists.
-export function findSection (sections, version) {
-  const exact = matchOn(sections, fullVersion(version))
-  return exact.length > 0 ? exact : matchOn(sections, majorMinor(version))
+// A patch release given its own heading wins; otherwise the minor's section is
+// the one describing it, since the page titles releases the way the app does.
+export function findRelease (releases, version) {
+  const exact = matchOn(releases, fullVersion(version))
+  return exact.length > 0 ? exact : matchOn(releases, majorMinor(version))
 }
 
-// Alpha and Beta releases are pre-releases. Every release so far is one, but the
-// day 1.0 ships this stops marking it.
 export function isPrerelease (title) {
   return /^\s*(alpha|beta|rc\b|release candidate)/i.test(title)
 }
 
+function parseArgs (argv) {
+  const args = { source: SOURCE }
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--version': args.version = argv[++i]; break
+      case '--source': args.source = argv[++i]; break
+      case '--out': args.out = argv[++i]; break
+      case '--list': args.list = true; break
+      case '--print': args.print = true; break
+      default: throw new Error(`Unknown argument: ${argv[i]}`)
+    }
+  }
+  return args
+}
+
 function main () {
   const args = parseArgs(process.argv.slice(2))
-  const sections = parseSections(readFileSync(args.changelog, 'utf8'))
+  const releases = parseReleases(readFileSync(args.source, 'utf8'))
 
   if (args.list) {
-    for (const section of sections) console.log(section.title)
+    for (const release of releases) console.log(`${release.title}${release.date ? `  (${release.date})` : ''}`)
     return
   }
 
   if (!args.version) throw new Error('--version is required (e.g. --version 0.6.0)')
 
-  const matches = findSection(sections, args.version)
-  const known = sections.map(section => `  - ${section.title}`).join('\n')
+  const matches = findRelease(releases, args.version)
+  const known = releases.map(release => `  - ${release.title}`).join('\n')
 
   if (matches.length === 0) {
     throw new Error(
-      `No section in ${args.changelog} names version ${majorMinor(args.version)}.\n` +
-      `Releases the changelog knows about:\n${known}\n` +
-      'Add a section for it before releasing, or correct the version.'
+      `No release in ${args.source} names version ${majorMinor(args.version)}.\n` +
+      `Releases the Change Log knows about:\n${known}\n` +
+      'Add it to the page before releasing, or correct the version.'
     )
   }
 
   if (matches.length > 1) {
     throw new Error(
-      `${matches.length} sections in ${args.changelog} name version ${majorMinor(args.version)}:\n` +
+      `${matches.length} releases in ${args.source} name version ${majorMinor(args.version)}:\n` +
       matches.map(match => `  - ${match.title}`).join('\n') +
       '\nOnly one heading may claim a version.'
     )
   }
 
-  const [{ title, body }] = matches
+  const [release] = matches
+  const body = toMarkdown(release)
 
-  if (body.length === 0) throw new Error(`The "${title}" section is empty; there is nothing to release.`)
+  // A conversion that quietly left markup or an unrendered Vue expression behind
+  // would publish it to everyone, so neither is allowed through.
+  const leftover = /<\/?[a-z][\w-]*[\s/>]|\{\{/i.exec(body)
+  if (leftover) {
+    throw new Error(`The converted notes still contain markup near: ${body.slice(Math.max(0, leftover.index - 60), leftover.index + 60)}`)
+  }
+
+  if (body.length === 0) throw new Error(`"${release.title}" converted to nothing; there is no release to publish.`)
   if (body.length > MAX_BODY_LENGTH) {
-    throw new Error(
-      `The "${title}" section is ${body.length} characters; GitHub caps a release body at ${MAX_BODY_LENGTH}.`
-    )
+    throw new Error(`"${release.title}" is ${body.length} characters; GitHub caps a release body at ${MAX_BODY_LENGTH}.`)
   }
 
   if (args.out) writeFileSync(args.out, `${body}\n`)
   if (args.print) process.stderr.write(`${body}\n`)
 
   console.log(JSON.stringify({
-    title,
+    title: release.title,
     version: args.version,
-    prerelease: isPrerelease(title),
+    date: release.date,
+    prerelease: isPrerelease(release.title),
     characters: body.length,
   }))
 }
 
-// Only run when invoked directly, so the parsing helpers stay importable.
 if (import.meta.url === `file://${process.argv[1]}`) {
   try {
     main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,30 @@
 name: "Release: Publish"
 
-# Publishes a GitHub release whose body is the matching section of CHANGELOG.md,
-# verbatim.
+# Publishes a GitHub release whose body is that version's section of the in-app
+# Change Log, converted to markdown.
 #
-# CHANGELOG.md is written by hand for humans and already mirrors the in-app
-# Change Log. Generating release notes from commit subjects instead would give a
-# third, worse description of the same update, so this workflow does no writing
-# of its own: pick a version, and the section under that version's `## ` heading
-# becomes the release body.
+# The source is web/src/pages/changelog.vue — the page players actually read —
+# not CHANGELOG.md. Both describe the same updates, but at very different
+# altitudes: CHANGELOG.md is the exhaustive technical record and reads as noise
+# to someone who only wants to know what is new, while the in-app page is the
+# written-for-players version, with screenshots and a 🆕 / 👍 / 🔧 key. This
+# workflow does no writing of its own: pick a version, and that release's
+# entry becomes the release body.
 #
 # Deploys are trunk-based (docs/how-do-we-release.md) — merging to main is what
 # ships the app — so a release here is a record of what shipped, not the act of
 # shipping it. That is also why this is dispatch-only: releases are cut when
 # someone decides an update is done, not on every push to main.
 #
-# The notes always come from CHANGELOG.md on the branch this workflow runs from,
-# while the tag is pinned to `sha`. That split is deliberate: it is what lets a
-# past update be released retroactively, using a section written today against a
-# commit from months ago.
+# The notes always come from the Change Log on the branch this workflow runs
+# from, while the tag is pinned to `sha`. That split is deliberate: it is what
+# lets a past update be released retroactively, using an entry written today
+# against a commit from months ago.
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release, e.g. 0.6.0. Becomes the tag, and its major.minor picks the CHANGELOG.md section.'
+        description: 'Version to release, e.g. 0.6.0. Becomes the tag, and its major.minor picks the Change Log release.'
         required: true
         type: string
       sha:
@@ -34,7 +36,7 @@ on:
         type: boolean
         default: false
       prerelease:
-        description: 'Mark as a pre-release. "auto" marks anything the changelog titles Alpha or Beta.'
+        description: 'Mark as a pre-release. "auto" marks anything the Change Log titles Alpha or Beta.'
         type: choice
         options:
           - auto
@@ -114,7 +116,7 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "subject=$(git log -1 --format=%s "$sha")" >> "$GITHUB_OUTPUT"
 
-      - name: Read the release notes out of CHANGELOG.md
+      - name: Convert the Change Log entry into release notes
         id: notes
         env:
           VERSION: ${{ inputs.version }}
@@ -191,5 +193,5 @@ jobs:
             echo "| Tag | \`$VERSION\` |"
             echo "| Commit | \`${TARGET_SHA:0:8}\` — $SUBJECT |"
             echo
-            echo "Notes taken from the \`$TITLE\` section of CHANGELOG.md."
+            echo "Notes taken from the \`$TITLE\` entry of the in-app Change Log."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/how-do-we-release.md
+++ b/docs/how-do-we-release.md
@@ -15,33 +15,47 @@ Run **Actions → "Release: Publish" → Run workflow**:
 | `version` | The version, as `x.y.z` with no leading `v` (`0.6.0`). It becomes the tag, matching the existing `0.2.1` and `0.3.0`. |
 | `sha` | The commit to pin the release to. Leave blank for the current head of `main`. |
 | `draft` | Publish as a draft first, to read the notes before anyone else does. |
-| `prerelease` | `auto` marks anything the changelog titles Alpha or Beta. |
+| `prerelease` | `auto` marks anything the Change Log titles Alpha or Beta. |
 | `overwrite` | Rewrite the notes on a release that already exists, instead of failing. |
 
-The release body is the matching section of [`CHANGELOG.md`](../CHANGELOG.md),
-published verbatim, and the release is named after that section's heading. The
-version is matched on its major and minor, so `0.6.0` finds
-`## Beta v0.6 - The "Groundwork" Update`; a patch release gets its own section
-if it needs one, and that section wins where it exists. Nothing is generated
-from commit subjects — the changelog is already written for humans and already
-mirrors the in-app Change Log, so a third description of the same update would
-only drift from the other two.
+The release body is that version's entry from the **in-app Change Log**
+([`web/src/pages/changelog.vue`](../web/src/pages/changelog.vue)), converted to
+markdown, and the release is named after its heading. The version is matched on
+its major and minor, so `0.6.0` finds `Beta v0.6 - The "Groundwork" Update`; a
+patch release gets its own entry if it needs one, and that entry wins where it
+exists.
 
-**So the changelog section has to exist before the release does.** If it does
-not, the run fails and lists the versions it does know about.
+**Deliberately not [`CHANGELOG.md`](../CHANGELOG.md).** Both describe the same
+updates, but at very different altitudes. `CHANGELOG.md` is the exhaustive
+technical record — implementation detail, paragraphs deep — which reads as noise
+to someone who only wants to know what is new. The in-app page is the
+written-for-players version: short sections, screenshots, the 🆕 / 👍 / 🔧 key.
+That is what a release should say, and it means the notes on GitHub and the
+notes in the app can never disagree.
 
-Notes are read from `CHANGELOG.md` as it stands on the branch the workflow is
-run from — `main`, normally — while the tag is pinned to `sha`. That split is what lets a past update be released
-retroactively: a section written today, against a commit from months ago. The
-one thing it cannot backdate is the release's own publication date, which is
-why each section carries a `_Released <date>._` line.
+Screenshots and videos are rewritten to absolute
+`https://satisfactory-factories.app` URLs so they render on github.com; videos
+become links, since an mp4 from another origin will not play inline there.
+Vuetify layout — the in-page contents nav, dividers, icons — is dropped.
+
+**So the Change Log entry has to exist before the release does.** If it does
+not, the run fails and lists the versions it does know about. The conversion
+also refuses to publish notes with leftover markup in them, rather than shipping
+a stray tag to everyone.
+
+Notes are read from the Change Log as it stands on the branch the workflow is
+run from — `main`, normally — while the tag is pinned to `sha`. That split is
+what lets a past update be released retroactively: an entry read today, against
+a commit from months ago. The one thing it cannot backdate is the release's own
+publication date, so the entry's `release-date` is carried into the top of the
+notes as a `_Released …_` line.
 
 `overwrite` cannot re-point an existing release's tag — GitHub does not allow
 it. Delete the release and the tag if a release ended up on the wrong commit.
 
-The extraction is done by
+The conversion is done by
 [`.github/scripts/changelog-release-notes.mjs`](../.github/scripts/changelog-release-notes.mjs),
-which is runnable on its own while writing a changelog entry:
+which is runnable on its own while writing a Change Log entry:
 
 ```bash
 node .github/scripts/changelog-release-notes.mjs --list


### PR DESCRIPTION
Follow-up to #552. The release notes that workflow produced read as word salad, because it was sourcing the wrong document.

## The problem

`CHANGELOG.md` is the exhaustive technical record — implementation detail, paragraphs deep — which is noise to someone who only wants to know what is new. Beta v0.6 came out of it at **76,000 characters**.

The in-app Change Log (`web/src/pages/changelog.vue`) is the written-for-players version of the same update: short sections, screenshots, the 🆕 / 👍 / 🔧 key. That is what a release should say. The same release is now **14,000 characters**, and the notes on GitHub can no longer disagree with the notes in the app, because they are the same text.

| Release | Was (`CHANGELOG.md`) | Now (in-app) |
| --- | --- | --- |
| Beta v0.6 | 76,089 | 14,461 |
| Beta v0.5 | 34,071 | 9,540 |
| Alpha v0.4 | 4,993 | 7,383 |

Alpha v0.4 grows because the in-app entry has the screenshots and videos the markdown copy never had.

## Changes

- **`.github/scripts/changelog-release-notes.mjs`** — now converts the Vue template to markdown rather than copying a block of text out of a file. Headings, paragraphs, nested lists, bold, links and chips carry over. Screenshots and videos are rewritten to absolute `https://satisfactory-factories.app` URLs so they resolve on github.com, with videos linked rather than embedded because an mp4 from another origin will not play inline there. The in-page contents nav, dividers and Font Awesome icons are dropped. Still dependency-free, so the workflow needs no install step.
- **`.github/workflows/release.yml`** — unchanged in shape; the inputs, the sha pinning and the overwrite guard all behave as before. Only the source and the wording around it changed.
- **`docs/how-do-we-release.md`** — documents the new source and, more importantly, why it is not `CHANGELOG.md`.

Two details the markup forced:

- A screenshot inside a list item becomes an indented block under the bullet. Inlining a 1200px capture mid-sentence is unreadable.
- Vuetify margin utilities are read as spacing. Headings space their parts with `ml-2`/`mx-2` rather than whitespace, so `Overclocking & Somersloops` was concatenating to `Overclocking&Somersloops`.

## Safety

Anything the converter does not recognise fails the release naming the tag, rather than silently dropping or mangling it. Notes that still contain markup or an unrendered `{{ }}` expression are refused outright rather than published to everyone.

## Testing

Converted all three releases and read the output end to end; scanned for HTML entities, `undefined`, empty links and leftover markup — clean. Re-ran the workflow's real `run:` blocks against a stubbed `gh`: new release, existing-release refusal, `draft: true`, and an unknown version all behave as intended. Verified an unrecognised tag throws, and that nested lists and list-item screenshots render correctly.

## Note

The existing `0.6.0` draft release was generated from the old source, so it still holds the 76k body. Re-running with `overwrite: true` rewrites a draft's notes in place.

The `CHANGELOG.md` edits from #552 (the Alpha v0.4 section and the `_Released_` date lines) are left as they are. They are no longer load-bearing for releases, but they document v0.4 where nothing did before. Happy to revert that part if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaR7PHwg5Xzj3XZbANGv31

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaR7PHwg5Xzj3XZbANGv31)_