### PR TITLE
Stop marking shipped releases as pre-releases

### DIFF
--- a/.github/scripts/changelog-release-notes.mjs
+++ b/.github/scripts/changelog-release-notes.mjs
@@ -361,10 +361,6 @@ export function findRelease (releases, version) {
   return exact.length > 0 ? exact : matchOn(releases, majorMinor(version))
 }
 
-export function isPrerelease (title) {
-  return /^\s*(alpha|beta|rc\b|release candidate)/i.test(title)
-}
-
 function parseArgs (argv) {
   const args = { source: SOURCE }
   for (let i = 0; i < argv.length; i++) {
@@ -432,7 +428,6 @@ function main () {
     title: release.title,
     version: args.version,
     date: release.date,
-    prerelease: isPrerelease(release.title),
     characters: body.length,
   }))
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,14 @@ on:
         description: 'Publish as a draft, so the notes can be read before anyone else sees them.'
         type: boolean
         default: false
+      # Alpha and Beta are this project's maturity branding, not a statement
+      # that a build was never shipped: every one of them went out to
+      # satisfactory-factories.app. GitHub's pre-release flag means "not ready
+      # for general use", so it is off unless a release genuinely is.
       prerelease:
-        description: 'Mark as a pre-release. "auto" marks anything the Change Log titles Alpha or Beta.'
-        type: choice
-        options:
-          - auto
-          - 'true'
-          - 'false'
-        default: auto
+        description: 'Mark as a pre-release — a build not meant for general use. Off for anything that actually shipped.'
+        type: boolean
+        default: false
       overwrite:
         description: 'Rewrite the notes on a release that already exists for this tag, instead of failing.'
         type: boolean
@@ -126,10 +126,7 @@ jobs:
             --version "$VERSION" \
             --out "$RUNNER_TEMP/release-notes.md")"
           echo "$meta"
-          {
-            echo "title=$(jq -r .title <<<"$meta")"
-            echo "prerelease=$(jq -r .prerelease <<<"$meta")"
-          } >> "$GITHUB_OUTPUT"
+          echo "title=$(jq -r .title <<<"$meta")" >> "$GITHUB_OUTPUT"
 
       - name: Publish the release
         id: publish
@@ -139,17 +136,10 @@ jobs:
           TITLE: ${{ steps.notes.outputs.title }}
           TARGET_SHA: ${{ steps.target.outputs.sha }}
           DRAFT: ${{ inputs.draft }}
-          PRERELEASE_INPUT: ${{ inputs.prerelease }}
-          PRERELEASE_AUTO: ${{ steps.notes.outputs.prerelease }}
+          PRERELEASE: ${{ inputs.prerelease }}
           OVERWRITE: ${{ inputs.overwrite }}
         run: |
           set -euo pipefail
-
-          prerelease="$PRERELEASE_INPUT"
-          if [[ "$prerelease" == "auto" ]]; then
-            prerelease="$PRERELEASE_AUTO"
-            echo "prerelease=auto resolved to $prerelease from the title \"$TITLE\""
-          fi
 
           notes="$RUNNER_TEMP/release-notes.md"
 
@@ -158,18 +148,22 @@ jobs:
               echo "::error::A release already exists for $VERSION. Re-run with overwrite to rewrite its notes."
               exit 1
             fi
-            # A release's tag cannot be re-pointed by editing it. Say so rather
-            # than reporting a sha this run never actually applied.
-            echo "::notice::Rewriting the existing $VERSION release. Its tag keeps pointing where it already did; sha is ignored on an overwrite."
-            gh release edit "$VERSION" \
-              --title "$TITLE" \
-              --notes-file "$notes" \
-              --draft="$DRAFT" \
-              --prerelease="$prerelease"
+            # A published release's tag already exists and cannot be re-pointed.
+            # A draft's has not been created yet — it is cut when the draft is
+            # published — so sha still applies there, and saying otherwise would
+            # strand a draft on whatever commit its first run happened to pick.
+            edit=(--title "$TITLE" --notes-file "$notes" --draft="$DRAFT" --prerelease="$PRERELEASE")
+            if [[ "$(gh release view "$VERSION" --json isDraft --jq .isDraft)" == "true" ]]; then
+              edit+=(--target "$TARGET_SHA")
+              echo "::notice::Rewriting the existing $VERSION draft, pinned to $TARGET_SHA. Its tag is cut when the draft is published."
+            else
+              echo "::notice::Rewriting the existing $VERSION release. Its tag keeps pointing where it already did; sha is ignored once a release is published."
+            fi
+            gh release edit "$VERSION" "${edit[@]}"
           else
             args=(--target "$TARGET_SHA" --title "$TITLE" --notes-file "$notes")
             if [[ "$DRAFT" == "true" ]]; then args+=(--draft); fi
-            if [[ "$prerelease" == "true" ]]; then args+=(--prerelease); fi
+            if [[ "$PRERELEASE" == "true" ]]; then args+=(--prerelease); fi
             gh release create "$VERSION" "${args[@]}"
           fi
 

--- a/docs/how-do-we-release.md
+++ b/docs/how-do-we-release.md
@@ -15,7 +15,7 @@ Run **Actions → "Release: Publish" → Run workflow**:
 | `version` | The version, as `x.y.z` with no leading `v` (`0.6.0`). It becomes the tag, matching the existing `0.2.1` and `0.3.0`. |
 | `sha` | The commit to pin the release to. Leave blank for the current head of `main`. |
 | `draft` | Publish as a draft first, to read the notes before anyone else does. |
-| `prerelease` | `auto` marks anything the Change Log titles Alpha or Beta. |
+| `prerelease` | A build not meant for general use. Off by default, and it should stay off for anything that shipped — see below. |
 | `overwrite` | Rewrite the notes on a release that already exists, instead of failing. |
 
 The release body is that version's entry from the **in-app Change Log**
@@ -50,8 +50,17 @@ a commit from months ago. The one thing it cannot backdate is the release's own
 publication date, so the entry's `release-date` is carried into the top of the
 notes as a `_Released …_` line.
 
-`overwrite` cannot re-point an existing release's tag — GitHub does not allow
-it. Delete the release and the tag if a release ended up on the wrong commit.
+**Alpha and Beta are not pre-releases.** They are this project's maturity
+branding, and every release wearing one of those names went out to
+satisfactory-factories.app like any other. GitHub's pre-release flag means "not
+ready for general use", which would be a false claim about a build players have
+been using for months — and it also suppresses the "Latest" badge. It defaults
+to off, and only a build genuinely not meant for general use should turn it on.
+
+`overwrite` cannot re-point a **published** release's tag — GitHub does not
+allow it, so delete the release and the tag if one ended up on the wrong commit.
+A **draft** is different: its tag is not cut until the draft is published, so an
+overwrite does apply `sha` to a draft and says so in the run.
 
 The conversion is done by
 [`.github/scripts/changelog-release-notes.mjs`](../.github/scripts/changelog-release-notes.mjs),


### PR DESCRIPTION
The `prerelease` input defaulted to `auto`, which marked anything the Change Log titled Alpha or Beta.

That was wrong. Alpha and Beta are this project's maturity branding, not a statement that a build never shipped — v0.4, v0.5 and v0.6 all went out to satisfactory-factories.app, and players have been using them for months. GitHub's pre-release flag means "not ready for general use", so the guess was making a false claim about every release the workflow cut, and suppressing the "Latest" badge along with it.

## Changes

- **`prerelease` is now a plain boolean, off by default.** The heuristic is removed rather than inverted: a title cannot tell you whether a build was released, so the person cutting the release decides. `isPrerelease()` and the `prerelease` field in the script's JSON output go with it.

- **Fixes a false claim in the overwrite path.** It reported that `sha` is ignored on an overwrite, which is only true once a release is published — a draft's tag is not cut until the draft is published, so `sha` does still apply there. The workflow now passes `--target` when overwriting a draft, and its notice says which case it took. The old behaviour would strand a draft on whatever commit its first run happened to pick, while the run log insisted nothing could be done about it.

- **`docs/how-do-we-release.md`** explains both, so the next person does not reintroduce the guess.

## Already corrected on the live releases

The three existing releases have been fixed by re-running with `prerelease: false`, so this PR is about stopping it happening again:

| | Tag | State |
| --- | --- | --- |
| Alpha v0.4 | `0.4.0` → `2f2efc4` | published, not a pre-release |
| Beta v0.5 — The "Overclocked" Update | `0.5.0` → `23be3ae` | published, not a pre-release |
| Beta v0.6 — The "Groundwork" Update | `0.6.0` | still a draft, not a pre-release |

## Testing

Ran the workflow's real `run:` blocks against a stubbed `gh` across four cases: a new release with the flag off passes no `--prerelease`; with it on it does; an overwrite of a **published** release passes no `--target`; an overwrite of a **draft** passes `--target` and prints the draft-specific notice. The script still converts all three Change Log entries unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaR7PHwg5Xzj3XZbANGv31

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaR7PHwg5Xzj3XZbANGv31)_