### PR TITLE
fix(web): add a typed task when the field loses focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ Raw resources are no longer assumed. Ore, water, oil and gas are dug up by build
 
 - **Tasks can be dragged into any order**, by the grip handle on the left of each row, the same handle the sidebar's factory list uses. A task's position was fixed at the moment it was added, so the only way to reprioritise a list was to delete a task and retype it at the bottom. Completed tasks drag too.
 - **Done is now a checkbox** rather than a pair of buttons, and it has moved to the left of the task, next to the handle: an empty box while the task is open, filled green with a tick once it is done, matching the green struck-through title beside it. The old control was a blue button that turned into a grey one, which read as an action to take rather than a state to see at a glance.
+- **A typed task is added when you click away from the field**, not only when you press enter. Typing a task and then going back to the plan used to throw the text away silently, which is the one thing a notes field must never do. Enter still adds it, blank and whitespace-only entries are still ignored, and the title is trimmed.
 - Delete stays on the right and is now outlined rather than a solid red block, since it was the loudest thing in the card while being the action you least often want.
 
 ### Improved: Statistics say where a number came from

--- a/web/src/components/planner/PlannerFactoryTasks.spec.ts
+++ b/web/src/components/planner/PlannerFactoryTasks.spec.ts
@@ -89,4 +89,65 @@ describe('Component: PlannerFactoryTasks', () => {
 
     expect(factory.tasks.map(task => task.completed)).toEqual([false, false, false])
   })
+
+  describe('adding a task', () => {
+    const newTaskField = (subject: VueWrapper) => subject.find('.v-text-field input')
+
+    it('adds the task when the field loses focus', async () => {
+      const subject = mountSubject()
+      const field = newTaskField(subject)
+      await field.setValue('Delta')
+      await field.trigger('blur')
+
+      expect(factory.tasks.map(task => task.title)).toEqual(['Alpha', 'Bravo', 'Charlie', 'Delta'])
+      expect((field.element as HTMLInputElement).value).toBe('')
+    })
+
+    it('adds the task on enter', async () => {
+      const subject = mountSubject()
+      const field = newTaskField(subject)
+      await field.setValue('Delta')
+      await field.trigger('keyup.enter')
+
+      expect(factory.tasks.map(task => task.title)).toEqual(['Alpha', 'Bravo', 'Charlie', 'Delta'])
+    })
+
+    // Enter clears the field, so the blur that follows when the user clicks away must not
+    // add a second, empty task.
+    it('does not add the task twice when enter is followed by a blur', async () => {
+      const subject = mountSubject()
+      const field = newTaskField(subject)
+      await field.setValue('Delta')
+      await field.trigger('keyup.enter')
+      await field.trigger('blur')
+
+      expect(factory.tasks.map(task => task.title)).toEqual(['Alpha', 'Bravo', 'Charlie', 'Delta'])
+    })
+
+    it('ignores a blur with nothing typed', async () => {
+      const subject = mountSubject()
+      await newTaskField(subject).trigger('blur')
+
+      expect(factory.tasks.map(task => task.title)).toEqual(['Alpha', 'Bravo', 'Charlie'])
+    })
+
+    it('ignores a blur with only whitespace typed', async () => {
+      const subject = mountSubject()
+      const field = newTaskField(subject)
+      await field.setValue('   ')
+      await field.trigger('blur')
+
+      expect(factory.tasks.map(task => task.title)).toEqual(['Alpha', 'Bravo', 'Charlie'])
+      expect((field.element as HTMLInputElement).value).toBe('')
+    })
+
+    it('trims the title it stores', async () => {
+      const subject = mountSubject()
+      const field = newTaskField(subject)
+      await field.setValue('  Delta  ')
+      await field.trigger('blur')
+
+      expect(factory.tasks[3].title).toBe('Delta')
+    })
+  })
 })

--- a/web/src/components/planner/PlannerFactoryTasks.vue
+++ b/web/src/components/planner/PlannerFactoryTasks.vue
@@ -13,6 +13,7 @@
         outlined
         placeholder="Add a task..."
         :rules="[newTaskRules.length]"
+        @blur="addTask"
         @keyup.enter="addTask"
       />
       <p v-if="factory.tasks.length >= 40" class="text-red">You are only allowed up to 50 tasks.</p>
@@ -117,21 +118,27 @@
     },
   }
 
+  // Called on enter and on blur, so typing something and clicking away adds the task rather
+  // than silently throwing it away. Both paths land here with the field already cleared by a
+  // previous add, hence the empty check comes before anything that can nag the user.
   const addTask = () => {
+    const title = newTask.value.trim()
+    if (title.length === 0) {
+      newTask.value = ''
+      return
+    }
     if (props.factory.tasks.length >= 50) {
       alert('You have reached the maximum number of tasks allowed (50).')
       return
     }
-    if (newTask.value.length === 0) return
-    // Only add a new task if there isn't already an empty one
-    props.factory.tasks.push({ title: newTask.value, completed: false })
 
     // Prevent people from adding a stupidly long task
-    if (newTask.value.length > 200) {
+    if (title.length > 200) {
       alert('Task is too long. Please keep it under 200 characters.')
       return
     }
 
+    props.factory.tasks.push({ title, completed: false })
     newTask.value = ''
   }
 

--- a/web/src/pages/changelog.vue
+++ b/web/src/pages/changelog.vue
@@ -244,6 +244,7 @@
 
         <h2>👍 <i class="fas fa-tasks ml-1" /><span class="ml-2">Tasks</span></h2>
         <p><b>Tasks drag into any order</b>, by the grip handle on the left. Completed tasks drag too. The card has had a tidy-up while it was open.</p>
+        <p><b>A task you have typed is added when you click away</b>, not only when you press enter, so going back to the plan mid-thought no longer loses it.</p>
         <v-img
           alt="The factory tasks card with drag handles and checkboxes"
           max-width="1200"


### PR DESCRIPTION
Typing a task into the **New Task** field and then clicking away discarded the text — the task was only ever added on <kbd>Enter</kbd>. Losing what you typed is the one thing a notes field must never do, so blur now adds the task as well.

## What changed

- `@blur="addTask"` on the New Task field in `PlannerFactoryTasks.vue`, alongside the existing `@keyup.enter`.
- `addTask` is now safe to call from both paths:
  - It trims first and returns on an empty title, so the blur that follows an Enter-add (field already cleared) is a no-op rather than a second, empty task, and whitespace alone never becomes a task.
  - The trimmed title is what gets stored.
  - The over-length check now runs *before* the push rather than after it — previously an over-200 task was pushed and *then* the alert fired, leaving the too-long task in the list and the field uncleared.

## Tests

Six new cases in `PlannerFactoryTasks.spec.ts` under `adding a task`: adds on blur, adds on enter, no double-add when enter is followed by blur, ignores an empty blur, ignores a whitespace-only blur, and trims the stored title.

Full `web` suite passes (99 files, 1882 tests), `pnpm lint` and `vue-tsc --noEmit` clean.

## Changelog

Entry added to `CHANGELOG.md` under *Tasks: reorder by dragging* and a matching line in the in-app change log.

---
_Generated by [Claude Code](https://claude.ai/code/session_019iP7nsBcBfKVxTBbtEACff)_