### PR TITLE
feat(web): remove the global "Show Info" toggle and its explanatory text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ _In development._
 - **The Demo plan has a Portal Hub**: ten Main Portals, 2.5 GW, and 20 Singularity Cells a minute imported from a new Singularity Cells factory.
 - Satisfaction breakdowns list custom building upkeep separately from what recipes consume.
 
+### Interface
+
+- **The "Show Info" toggle is gone**, along with the explanatory paragraphs it hid throughout the planner. Nobody was clicking it, and the copy behind it hadn't kept pace with the app for several updates. The always-visible ⓘ tooltips elsewhere in the UI (Game Sync, upkeep, variable power, and so on) are unaffected.
+
 ## Beta v0.6 - The "Groundwork" Update
 
 _Released 19 August 2026._

--- a/web/src/components/planner/Planner.vue
+++ b/web/src/components/planner/Planner.vue
@@ -10,14 +10,12 @@
     <Teleport v-if="navigationReady" defer to="#navigationDrawer">
       <planner-sidebar-content
         :factories="getFactories()"
-        :help-text-shown="helpText"
         loaded-from="navigation"
         @clear-all="clearAll"
         @create-factory="createFactory"
         @hide-all="showHideAll('hide')"
         @import-world="importWorld"
         @show-all="showHideAll('show')"
-        @toggle-help-text="toggleHelp()"
         @update-factories="updateFactoriesList"
       />
     </Teleport>
@@ -35,14 +33,12 @@
         <v-container class="pa-0 sidebar-content">
           <planner-sidebar-content
             :factories="getFactories()"
-            :help-text-shown="helpText"
             loaded-from="planner"
             @clear-all="clearAll"
             @create-factory="createFactory"
             @hide-all="showHideAll('hide')"
             @import-world="importWorld"
             @show-all="showHideAll('show')"
-            @toggle-help-text="toggleHelp()"
             @update-factories="updateFactoriesList"
           />
         </v-container>
@@ -58,8 +54,8 @@
         <planner-factory-placeholder-list />
       </v-col>
       <v-col v-if="planVisible" class="border-s-lg-lg pa-3 main-content" @scroll.passive="onMainContentScroll">
-        <statistics v-if="getFactories().length !== 0" :factories="getFactories()" :help-text="helpText" />
-        <statistics-factory-summary v-if="getFactories().length !== 0" :factories="getFactories()" :help-text="helpText" />
+        <statistics v-if="getFactories().length !== 0" :factories="getFactories()" />
+        <statistics-factory-summary v-if="getFactories().length !== 0" :factories="getFactories()" />
         <template v-for="section in groupSections" :key="section.group?.id ?? 'ungrouped'">
           <!-- A plan that has never used groups is one Ungrouped section, and a band over the
                whole plan says nothing — so it only appears once there is something to divide. -->
@@ -92,7 +88,6 @@
             >
               <planner-factory
                 :factory="factory"
-                :help-text="helpText"
                 :total-factories="getFactories().length"
               />
             </div>
@@ -168,7 +163,6 @@
   const toggleSection = (section: FactoryGroupSection) => toggleCollapsed(section.group?.id ?? null)
 
   const worldRawResources = reactive<{ [key: string]: WorldRawResource }>({})
-  const helpText = ref(localStorage.getItem('helpText') === 'true')
 
   const planVisible = ref(false)
   const navigationReady = ref(false)
@@ -365,10 +359,6 @@
   // #############s
 
   // ==== WATCHES
-  watch(helpText, newValue => {
-    localStorage.setItem('helpText', JSON.stringify(newValue))
-  })
-
   watch(showSidebar, newValue => {
     localStorage.setItem('sidebarOpen', JSON.stringify(newValue))
     eventBus.emit('sidebarChanged', newValue)
@@ -606,10 +596,6 @@
 
   const showHideAll = (mode: 'show' | 'hide') => {
     getFactories().forEach(factory => factory.hidden = mode === 'hide')
-  }
-
-  const toggleHelp = () => {
-    helpText.value = !helpText.value
   }
 
   // `subsection` may name a row that isn't on screen (a status chip jumping to the product that

--- a/web/src/components/planner/PlannerFactory.spec.ts
+++ b/web/src/components/planner/PlannerFactory.spec.ts
@@ -25,7 +25,7 @@ describe('Component: PlannerFactory (collapsed view)', () => {
   const mountSubject = (): VueWrapper => {
     calculateFactories([factory], gameData)
     return mount(PlannerFactory, {
-      propsData: { factory, helpText: false, totalFactories: 1 },
+      propsData: { factory, totalFactories: 1 },
       global: {
         plugins: [vuetify],
         provide: {

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -194,21 +194,18 @@
           <products-and-power
             :id="`${factory.id}-products`"
             :factory="factory"
-            :help-text="helpText"
             :statuses="statuses"
           />
           <v-divider class="my-4 mx-n4" color="white" thickness="5px" />
           <factory-imports
             :id="`${factory.id}-imports`"
             :factory="factory"
-            :help-text="helpText"
             :statuses="statuses"
           />
           <v-divider class="my-4 mx-n4" color="white" thickness="5px" />
           <planner-factory-satisfaction
             :id="`${factory.id}-satisfaction`"
             :factory="factory"
-            :help-text="helpText"
             :statuses="statuses"
           />
           <v-divider class="my-4 mx-n4" color="white" thickness="5px" />
@@ -217,14 +214,12 @@
               <planner-factory-tasks
                 :id="`${factory.id}-tasks`"
                 :factory="factory"
-                :help-text="helpText"
               />
             </v-col>
             <v-col cols="12" md="6">
               <planner-factory-notes
                 :id="`${factory.id}-notes`"
                 :factory="factory"
-                :help-text="helpText"
               />
             </v-col>
           </v-row>
@@ -471,7 +466,6 @@
 
   const props = defineProps<{
     factory: Factory
-    helpText: boolean
     totalFactories: number;
   }>()
 

--- a/web/src/components/planner/PlannerFactoryNotes.vue
+++ b/web/src/components/planner/PlannerFactoryNotes.vue
@@ -25,7 +25,6 @@
 
   const props = defineProps <{
     factory: Factory;
-    helpText: boolean;
   }>()
 
   // Validation rule for the character limit

--- a/web/src/components/planner/PlannerFactorySatisfaction.vue
+++ b/web/src/components/planner/PlannerFactorySatisfaction.vue
@@ -29,7 +29,6 @@
       <v-col v-if="hasParts" class="pb-1" cols="12">
         <planner-factory-satisfaction-items
           :factory="factory"
-          :help-text="helpText"
           :show-surplus-outputs="hideInternalOutputs"
         />
       </v-col>
@@ -38,7 +37,6 @@
       <v-col cols="12">
         <planner-factory-satisfaction-buildings
           :factory="factory"
-          :help-text="helpText"
         />
       </v-col>
     </v-row>
@@ -69,7 +67,6 @@
 
   const props = defineProps<{
     factory: Factory;
-    helpText: boolean;
     statuses?: FactoryStatus[];
   }>()
 

--- a/web/src/components/planner/PlannerFactorySatisfactionBuildings.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionBuildings.vue
@@ -97,7 +97,6 @@
 
   const props = defineProps<{
     factory: Factory;
-    helpText: boolean;
   }>()
 
   const hasVariablePower = computed(() => {

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -522,7 +522,6 @@
 
   const props = defineProps<{
     factory: Factory;
-    helpText: boolean;
     showSurplusOutputs?: boolean;
   }>()
 

--- a/web/src/components/planner/PlannerFactoryTasks.spec.ts
+++ b/web/src/components/planner/PlannerFactoryTasks.spec.ts
@@ -12,7 +12,7 @@ describe('Component: PlannerFactoryTasks', () => {
 
   const mountSubject = () =>
     mount(PlannerFactoryTasks, {
-      propsData: { factory, helpText: false },
+      propsData: { factory },
       global: { plugins: [vuetify] },
     })
 

--- a/web/src/components/planner/PlannerFactoryTasks.vue
+++ b/web/src/components/planner/PlannerFactoryTasks.vue
@@ -84,7 +84,6 @@
 
   const props = defineProps <{
     factory: Factory;
-    helpText: boolean;
   }>()
 
   const newTask = ref('')

--- a/web/src/components/planner/PlannerGlobalActions.spec.ts
+++ b/web/src/components/planner/PlannerGlobalActions.spec.ts
@@ -18,7 +18,6 @@ describe('Component: PlannerGlobalActions clipboard', () => {
 
   const mountSubject = () =>
     mount(PlannerGlobalActions, {
-      propsData: { helpTextShown: false },
       global: {
         plugins: [vuetify],
         stubs: { Templates: true },

--- a/web/src/components/planner/PlannerGlobalActions.vue
+++ b/web/src/components/planner/PlannerGlobalActions.vue
@@ -30,17 +30,6 @@
           Expand all
         </v-btn>
       </tooltip>
-      <tooltip :text="helpTextShown ? 'Hide the explanatory notes dotted through the planner.' : 'Show an explanatory note on each section of the planner, saying what it is for.'">
-        <v-btn
-          class="ma-1"
-          color="blue"
-          prepend-icon="fas fa-info-circle"
-          variant="tonal"
-          @click="emit('toggle-help-text')"
-        >
-          {{ helpTextShown ? "Hide" : "Show" }} Info
-        </v-btn>
-      </tooltip>
       <!-- Flat while on, tonal while off: the label alone ("Full width" / "Normal width") says
            what the next click does, not what the planner is doing now, and this is the only
            button here that holds a state. -->
@@ -155,12 +144,9 @@
     return 'Recalculate every factory from scratch. Slow enough on a big plan that the browser will complain, so it asks first — only worth it if a number looks wrong.'
   })
 
-  defineProps<{ helpTextShown: boolean }>()
-
   const emit = defineEmits<{
     (event: 'hide-all'): void;
     (event: 'show-all'): void;
-    (event: 'toggle-help-text'): void;
     (event: 'import-world'): void;
     (event: 'clear-all'): void;
   }>()

--- a/web/src/components/planner/PlannerSidebarContent.vue
+++ b/web/src/components/planner/PlannerSidebarContent.vue
@@ -13,12 +13,10 @@
   <v-divider color="#ccc" thickness="2px" />
   <planner-global-actions
     class="py-2"
-    :help-text-shown="helpTextShown"
     @clear-all="emit('clearAll')"
     @hide-all="emit('hideAll')"
     @import-world="emit('importWorld')"
     @show-all="emit('showAll')"
-    @toggle-help-text="emit('toggleHelpText')"
   />
   <v-divider color="#ccc" thickness="2px" />
   <copyright />
@@ -31,7 +29,6 @@
   defineProps<{
     factories: Factory[],
     loadedFrom: 'planner' | 'navigation',
-    helpTextShown: boolean,
   }>()
 
   const emit = defineEmits<{
@@ -41,6 +38,5 @@
     (event: 'hideAll'): void;
     (event: 'showAll'): void;
     (event: 'importWorld'): void;
-    (event: 'toggleHelpText'): void;
   }>()
 </script>

--- a/web/src/components/planner/Statistics.vue
+++ b/web/src/components/planner/Statistics.vue
@@ -78,15 +78,15 @@
           </tooltip>
         </v-card-text>
         <v-card-text v-if="!hidden" class="text-body-1">
-          <statistics-power :factories="factories" :help-text="helpText" />
+          <statistics-power :factories="factories" />
           <v-divider class="my-4 mx-n4" color="white" thickness="5px" />
-          <statistics-resources :factories="factories" :help-text="helpText" />
+          <statistics-resources :factories="factories" />
           <v-divider class="my-4 mx-n4" color="white" thickness="5px" />
-          <statistics-items-difference :factories="factories" :help-text="helpText" />
+          <statistics-items-difference :factories="factories" />
           <v-divider class="my-4 mx-n4" color="white" thickness="5px" />
-          <statistics-shards-sloops :factories="factories" :help-text="helpText" />
+          <statistics-shards-sloops :factories="factories" />
           <v-divider class="my-4 mx-n4" color="white" thickness="5px" />
-          <statistics-buildings :factories="factories" :help-text="helpText" />
+          <statistics-buildings :factories="factories" />
         </v-card-text>
       </v-card>
     </v-col>
@@ -105,7 +105,6 @@
 
   const props = defineProps<{
     factories: Factory[];
-    helpText: boolean;
   }>()
 
   // Power strip shown while the statistics are collapsed. Its balance chip mirrors

--- a/web/src/components/planner/StatisticsBuildings.vue
+++ b/web/src/components/planner/StatisticsBuildings.vue
@@ -22,10 +22,6 @@
     >{{ hidden ? 'Show' : 'Hide' }}</v-btn>
   </div>
   <template v-if="!hidden">
-    <p v-show="helpText" class="mb-4">
-      <i class="fas fa-info-circle" /> Shows the amount buildings of each
-      type in all your factories, and which factories they stand in.
-    </p>
     <v-table v-if="totalBuildingsByType.length > 0" id="stats-buildings" class="stats-table" density="compact">
       <thead>
         <tr>
@@ -78,7 +74,6 @@
 
   const props = defineProps<{
     factories: Factory[];
-    helpText: boolean;
   }>()
 
   const totalBuildingsByType = computed(() => calculateTotalBuildingsByType(props.factories))

--- a/web/src/components/planner/StatisticsFactorySummary.vue
+++ b/web/src/components/planner/StatisticsFactorySummary.vue
@@ -293,11 +293,6 @@
           </v-col>
         </v-row>
         <v-card-text v-if="!hidden" class="text-body-1">
-          <p v-show="helpText" class="mb-4">
-            <i class="fas fa-info-circle" /> Showing an at-a-glance overview of each factory.
-            Hover over a chip for the full details.
-          </p>
-
           <!-- The counts in the header double as filters. Said out loud because a chip that is
                also a button looks exactly like a chip that is not. -->
           <p v-if="statusTally.length" class="filter-hint mb-4">
@@ -395,7 +390,6 @@
 
   const props = defineProps<{
     factories: Factory[];
-    helpText: boolean;
   }>()
 
   /**

--- a/web/src/components/planner/StatisticsItemsDifference.vue
+++ b/web/src/components/planner/StatisticsItemsDifference.vue
@@ -40,10 +40,6 @@
     >{{ hidden ? 'Show' : 'Hide' }}</v-btn>
   </div>
   <template v-if="!hidden">
-    <p v-show="helpText" class="mb-4">
-      <i class="fas fa-info-circle" /> Every item your plan makes or consumes, and whether it has
-      any spare. Red needs producing more of, green can be stored or sunk.
-    </p>
     <div class="d-flex flex-wrap align-center ga-2 mt-3 mb-3">
       <!-- Each filter wears the colour it selects, so the buttons read as the same language as
            the rows. Unselected is the same colour outlined rather than a neutral grey, which
@@ -151,7 +147,6 @@
 
   const props = defineProps<{
     factories: Factory[];
-    helpText: boolean;
   }>()
 
   // Every item the plan touches, balanced ones included — this section absorbed the old

--- a/web/src/components/planner/StatisticsPower.vue
+++ b/web/src/components/planner/StatisticsPower.vue
@@ -37,9 +37,6 @@
       </v-chip>
     </tooltip>
   </div>
-  <p v-show="helpText" class="mb-4">
-    <i class="fas fa-info-circle mr-2" />Shows world level power consumption and generation data.
-  </p>
   <v-alert
     id="stats-power-accuracy-note"
     class="mt-2 mb-2"
@@ -300,7 +297,6 @@
 
   const props = defineProps<{
     factories: Factory[];
-    helpText: boolean;
   }>()
 
   const totalPower = computed(() => calculateTotalPower(props.factories))

--- a/web/src/components/planner/StatisticsResources.vue
+++ b/web/src/components/planner/StatisticsResources.vue
@@ -22,10 +22,6 @@
     >{{ hidden ? 'Show' : 'Hide' }}</v-btn>
   </div>
   <template v-if="!hidden">
-    <p v-show="helpText" class="mb-4">
-      <i class="fas fa-info-circle" /> Shows how much of each raw resource your plan takes out of
-      the world: everything your factories mine, pump or extract.
-    </p>
     <v-table v-if="allFactoryRawResources.length > 0" id="stats-raw-resources" class="stats-table" density="compact">
       <thead>
         <tr>
@@ -82,7 +78,6 @@
 
   const props = defineProps<{
     factories: Factory[];
-    helpText: boolean;
   }>()
 
   // Everything the plan takes out of the world, per resource, with the factories doing the taking.

--- a/web/src/components/planner/StatisticsShardsSloops.vue
+++ b/web/src/components/planner/StatisticsShardsSloops.vue
@@ -29,9 +29,6 @@
     >{{ hidden ? 'Show' : 'Hide' }}</v-btn>
   </div>
   <template v-if="!hidden">
-    <p v-show="helpText" class="mb-4">
-      <i class="fas fa-info-circle" /> Shows which factories use Power Shards and Somersloops in their building groups.
-    </p>
     <v-row id="stats-shards-sloops" class="mt-1">
       <v-col
         v-for="section in sections"
@@ -93,7 +90,6 @@
 
   const props = defineProps<{
     factories: Factory[];
-    helpText: boolean;
   }>()
 
   const navigateToFactory = inject('navigateToFactory') as (id: string | number) => void

--- a/web/src/components/planner/imports/FactoryImports.vue
+++ b/web/src/components/planner/imports/FactoryImports.vue
@@ -7,12 +7,9 @@
       </h1>
       <factory-status-chips detailed size="small" :statuses="sectionStatuses" />
     </div>
-    <p v-show="helpText" class="text-body-2 mb-4">
-      <i class="fas fa-info-circle" /> Imports are the resources needed to produce the factory's products and ensure its satisfaction. To set up imports, you select another factory and choose one of its outputs. This creates a "request" for that output. The selected factory must fulfill this request, and you'll be notified if it cannot meet the demand. All available outputs are listed in the Outputs section of the factory you choose.
-    </p>
     <div v-if="Object.keys(factory.rawResources).length > 0 || Object.keys(factory.parts).length > 0">
       <raw-resources :factory="factory" />
-      <imports :factory="factory" :help-text="helpText" />
+      <imports :factory="factory" />
     </div>
     <p v-else class="text-body-1">Awaiting product selection.</p>
   </div>
@@ -28,7 +25,6 @@
 
   const props = defineProps<{
     factory: Factory;
-    helpText: boolean;
     statuses?: FactoryStatus[];
   }>()
 

--- a/web/src/components/planner/imports/Imports.vue
+++ b/web/src/components/planner/imports/Imports.vue
@@ -254,7 +254,6 @@
 
   const props = defineProps<{
     factory: Factory;
-    helpText: boolean;
   }>()
 
   const validToDisplay = computed(() => {

--- a/web/src/components/planner/products/BuildingGroups.spec.ts
+++ b/web/src/components/planner/products/BuildingGroups.spec.ts
@@ -31,7 +31,6 @@ const mountComponent = (factory: Factory, component: any) => {
   return mount(component, {
     propsData: {
       factory,
-      helpText: false,
     },
     global: {
       plugins: [vuetify],

--- a/web/src/components/planner/products/CustomBuilding.vue
+++ b/web/src/components/planner/products/CustomBuilding.vue
@@ -137,7 +137,6 @@
 
   const props = defineProps<{
     factory: Factory;
-    helpText: boolean;
   }>()
 
   // One remount counter per row, bumped when a typed quantity had to be corrected.

--- a/web/src/components/planner/products/PowerProducer.spec.ts
+++ b/web/src/components/planner/products/PowerProducer.spec.ts
@@ -23,7 +23,6 @@ const mountSubject = (factory: Factory) => {
   return mount(PowerProducer, {
     propsData: {
       factory,
-      helpText: false,
     },
     global: {
       plugins: [vuetify],
@@ -44,7 +43,7 @@ let fuelQuantity: any
 let powerAmount: any
 let buildingCount: any
 let factory: Factory
-let subject: VueWrapper<{ factory: Factory, helpText: boolean }>
+let subject: VueWrapper<{ factory: Factory }>
 
 const updateElements = (powerProducer: FactoryPowerProducer) => {
   // Elements
@@ -249,7 +248,7 @@ describe('Component: PowerProducer', () => {
 describe('Component: PowerProducer (augmenter building count)', () => {
   let augmenterFactory: Factory
   let augmenter: FactoryPowerProducer
-  let augmenterSubject: VueWrapper<{ factory: Factory, helpText: boolean }>
+  let augmenterSubject: VueWrapper<{ factory: Factory }>
 
   const countField = (): Element | null =>
     augmenterSubject.element.querySelector(`[id="${augmenterFactory.id}-${augmenter.id}-building-count"]`)

--- a/web/src/components/planner/products/PowerProducer.vue
+++ b/web/src/components/planner/products/PowerProducer.vue
@@ -313,7 +313,6 @@
 
   const props = defineProps<{
     factory: Factory;
-    helpText: boolean;
   }>()
 
   const deletePowerProducer = (index: number, factory: Factory) => {

--- a/web/src/components/planner/products/Product.spec.ts
+++ b/web/src/components/planner/products/Product.spec.ts
@@ -14,7 +14,6 @@ const mountSubject = (factory: Factory) => {
   return mount(Product, {
     propsData: {
       factory,
-      helpText: false,
     },
     global: {
       plugins: [vuetify],
@@ -30,7 +29,7 @@ const mountSubject = (factory: Factory) => {
 
 describe('Component: Product', () => {
   let factory = newFactory('test')
-  let subject: VueWrapper<{ factory: Factory, helpText: boolean }>
+  let subject: VueWrapper<{ factory: Factory }>
 
   beforeEach(() => {
     setActivePinia(createPinia())

--- a/web/src/components/planner/products/Product.vue
+++ b/web/src/components/planner/products/Product.vue
@@ -328,7 +328,6 @@
 
   const props = defineProps<{
     factory: Factory;
-    helpText: boolean;
   }>()
 
   // Takes the whole row amber, so a warning chip halfway down a long product list is attached to

--- a/web/src/components/planner/products/ProductsAndPower.vue
+++ b/web/src/components/planner/products/ProductsAndPower.vue
@@ -6,17 +6,7 @@
         <span class="ml-3">Products, Power &amp; Buildings</span>
       </h1>
     </div>
-    <p v-show="helpText" class="text-body-2 mb-4">
-      <i class="fas fa-info-circle" /> Products that are created within the factory. Products are first
-      used to fulfil recipes internally, and any surplus is then available for Export.<br>
-      e.g. if you add 200 Iron Rods and also 100 Screws, you'd have 100 surplus Rods remaining used as an
-      Export (and the Screws as a end product).<br>
-      An <v-chip color="green">Internal</v-chip> product is one that is used to produce other products. The surplus of which can also be used as an export.<br>
-      A <v-chip class="sf-chip status-note"><i class="fas fa-question-circle mr-1" />No demand</v-chip> product is one nothing asks for: not used internally, not exported. A future update will add support for sinking, so if you are sinking it, ignore this for now.<br>
-      A <v-chip class="sf-chip status-warning"><i class="fas fa-exclamation-triangle mr-1" />Potential blockage</v-chip> byproduct has nowhere to go, so it fills the machine's output and stalls the buildings making it. Blend it into a recipe that consumes it, export it, or sink it.<br>
-      <v-chip class="sf-chip custom-building">Custom Buildings</v-chip> are the ones that make nothing but still cost you: portals, train stations, radar towers, lights. They add their power draw to the factory, and the few that consume parts to run (a Main Portal's Singularity Cells) add that as a demand to satisfy like any other.
-    </p>
-    <product :factory="factory" :help-text="helpText" />
+    <product :factory="factory" />
     <v-btn
       color="primary mr-2 mt-n1"
       prepend-icon="fas fa-cube"
@@ -26,7 +16,7 @@
     >
       Add Product
     </v-btn>
-    <power-producer :factory="factory" :help-text="helpText" />
+    <power-producer :factory="factory" />
     <v-btn
       class="mr-2 mt-n1"
       :color="sfColors.powerGeneration.color"
@@ -37,7 +27,7 @@
     >
       Add Power Generator
     </v-btn>
-    <custom-building :factory="factory" :help-text="helpText" />
+    <custom-building :factory="factory" />
     <v-btn
       class="mr-2 mt-n1"
       :color="sfColors.building.color"
@@ -62,7 +52,6 @@
 
   const props = defineProps<{
     factory: Factory;
-    helpText: boolean;
     statuses?: FactoryStatus[];
   }>()
 


### PR DESCRIPTION
## Summary

- Removes the global "Show Info" toggle (`helpText`, persisted to `localStorage['helpText']`) — the button, its state, the `watch` that persisted it, and the `toggleHelp` handler in `Planner.vue`.
- Deletes the hardcoded explanatory `<p v-show="helpText">` paragraphs it gated in 8 leaf components (Statistics buildings/power/resources/shards-sloops/items-difference/factory-summary, Factory Imports, Products & Power) — the copy is removed outright, not migrated, since it hadn't been touched or read in several updates.
- Strips the `helpText`/`helpTextShown` prop from the ~15 more components it was forwarded through (several of which never even read it — dead pass-through).
- Leaves the separate, actively-used `tooltip-info` "ⓘ" hover-tooltip component untouched (Game Sync, upkeep, variable power, etc. — a different pattern, not part of this toggle).
- Updates the specs that referenced the removed props.
- Adds a CHANGELOG entry under Beta v0.7.

## Test plan

- [x] `pnpm exec vue-tsc --noEmit` in `web/` — passes
- [x] `pnpm exec vitest run` on all affected spec files (Planner, Statistics, Factory, PowerProducer, Product, BuildingGroups, etc.) — all passing
- [x] `pnpm lint` — clean, no unrelated changes from auto-fix
- [x] Manual click-through of the planner sidebar/statistics/factory sections to confirm no leftover empty gaps where the info paragraphs used to render

---
_Generated by [Claude Code](https://claude.ai/code/session_0152oZt1MSe2ufiCnwYAKCMP)_