### PR TITLE
fix(web): collapse Statistics and Global Factories Summary by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _In development._
 ### Interface
 
 - **The "Show Info" toggle is gone**, along with the explanatory paragraphs it hid throughout the planner. Nobody was clicking it, and the copy behind it hadn't kept pace with the app for several updates. The always-visible ⓘ tooltips elsewhere in the UI (Game Sync, upkeep, variable power, and so on) are unaffected.
+- **Statistics and the Global Factories Summary now start collapsed.** A fresh visitor, or anyone opening a demo plan, used to land on a page-length wall of stats above the factory cards themselves. Item production, power shards, raw resources and building summaries within Statistics now start collapsed too, matching the per-factory power breakdown, which already did. Each section remembers your choice once you toggle it.
 
 ## Beta v0.6 - The "Groundwork" Update
 

--- a/web/src/components/planner/Statistics.vue
+++ b/web/src/components/planner/Statistics.vue
@@ -115,11 +115,11 @@
     ? totalPower.value.totalPowerProduced - powerTarget.value
     : totalPower.value.totalPowerDifference)
 
-  // Default to not showing the stats on first ever load
-  const statisticsHidden = localStorage.getItem('statisticsHidden') ?? 'false'
+  // Default to hidden on first ever load — a fresh visitor (or a demo plan) should land on the
+  // factory cards, not a wall of statistics.
+  const statisticsHidden = localStorage.getItem('statisticsHidden') ?? 'true'
 
   // Initialize the 'hidden' refs based on the value in localStorage.
-  // Compare against the string — Boolean('false') is true, which hid the section for fresh visitors.
   const hidden = ref<boolean>(statisticsHidden === 'true')
 
   // Watch the 'hidden' ref and update localStorage whenever it changes

--- a/web/src/components/planner/StatisticsBuildings.vue
+++ b/web/src/components/planner/StatisticsBuildings.vue
@@ -83,8 +83,8 @@
 
   const navigateToFactory = inject('navigateToFactory') as (id: string | number) => void
 
-  // Section visibility, persisted. Compare against the string — Boolean('false') is true.
-  const hidden = ref<boolean>(localStorage.getItem('statisticsBuildingSummaryHidden') === 'true')
+  // Section visibility, persisted. Hidden by default until explicitly shown.
+  const hidden = ref<boolean>(localStorage.getItem('statisticsBuildingSummaryHidden') !== 'false')
   watch(hidden, value => {
     localStorage.setItem('statisticsBuildingSummaryHidden', value.toString())
   })

--- a/web/src/components/planner/StatisticsFactorySummary.vue
+++ b/web/src/components/planner/StatisticsFactorySummary.vue
@@ -401,7 +401,7 @@
    * group's breakdown re-filtered the planner's section and closing it made that section rebuild
    * every row.
    */
-  const hidden = ref<boolean>(localStorage.getItem('summaryHidden') === 'true')
+  const hidden = ref<boolean>(localStorage.getItem('summaryHidden') !== 'false')
   const expanded = ref<boolean>(false)
   // Whether the fullscreen panel has finished animating in. Its rows wait for this.
   const dialogOpened = ref<boolean>(false)

--- a/web/src/components/planner/StatisticsItemsDifference.vue
+++ b/web/src/components/planner/StatisticsItemsDifference.vue
@@ -200,8 +200,8 @@
 
   const navigateToFactory = inject('navigateToFactory') as (id: string | number) => void
 
-  // Section visibility, persisted. Compare against the string — Boolean('false') is true.
-  const hidden = ref<boolean>(localStorage.getItem('statisticsSurplusHidden') === 'true')
+  // Section visibility, persisted. Hidden by default until explicitly shown.
+  const hidden = ref<boolean>(localStorage.getItem('statisticsSurplusHidden') !== 'false')
   watch(hidden, value => {
     localStorage.setItem('statisticsSurplusHidden', value.toString())
   })

--- a/web/src/components/planner/StatisticsResources.vue
+++ b/web/src/components/planner/StatisticsResources.vue
@@ -85,8 +85,8 @@
 
   const navigateToFactory = inject('navigateToFactory') as (id: string | number) => void
 
-  // Section visibility, persisted. Compare against the string — Boolean('false') is true.
-  const hidden = ref<boolean>(localStorage.getItem('statisticsRawResourcesHidden') === 'true')
+  // Section visibility, persisted. Hidden by default until explicitly shown.
+  const hidden = ref<boolean>(localStorage.getItem('statisticsRawResourcesHidden') !== 'false')
   watch(hidden, value => {
     localStorage.setItem('statisticsRawResourcesHidden', value.toString())
   })

--- a/web/src/components/planner/StatisticsShardsSloops.vue
+++ b/web/src/components/planner/StatisticsShardsSloops.vue
@@ -124,8 +124,8 @@
   // Header at-a-glance totals — only for whichever of the two is actually in use.
   const summarySections = computed(() => sections.value.filter(section => section.total > 0))
 
-  // Section visibility, persisted. Compare against the string — Boolean('false') is true.
-  const hidden = ref<boolean>(localStorage.getItem('statisticsShardsSloopsHidden') === 'true')
+  // Section visibility, persisted. Hidden by default until explicitly shown.
+  const hidden = ref<boolean>(localStorage.getItem('statisticsShardsSloopsHidden') !== 'false')
   watch(hidden, value => {
     localStorage.setItem('statisticsShardsSloopsHidden', value.toString())
   })


### PR DESCRIPTION
## Summary

- Opening a demo plan (or any plan, for a first-time visitor) landed the reader on a page-length wall of statistics before they ever reached the factory cards. `Statistics` and `Global Factories Summary` both defaulted their `localStorage`-persisted `hidden` flag to `false` (expanded).
- Flipped both to default-collapsed, along with the sub-panels nested inside Statistics that have their own independent toggle: item production/surplus, power shards & sloops, raw resources, and building summary. This matches the per-factory power breakdown, which already defaulted to collapsed.
- Once a user (or plan) toggles a section, their choice is still remembered via `localStorage` as before — this only changes the value used when the key has never been set.
- Left the "Ungrouped" group's missing connector elbows out of scope per the request — that's a separate follow-up.

## Test plan

- [x] `pnpm exec vitest run` — full frontend suite (102 files / 1989 tests) passes
- [x] `pnpm exec vue-tsc --noEmit` — clean
- [x] `pnpm exec eslint` on the six changed components — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKrf5NXng1ZEoDzZhBXaQQ)_