### PR TITLE
fix(web): move Add Factory button to top of sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _In development._
 
 - **The sidebar can be scrolled on a phone again.** Picking a factory or a group up is the same gesture as scrolling the list, so touching a row to scroll dragged it instead. Drag is now offered only where the pointer is precise enough for it; the new **Arrange** dialog does the same job with buttons.
 - **An "Arrange" button opens a dialog for reordering the plan.** Groups against each other, factories within their group, and factories from one group into another, all with buttons. Groups can still be dragged there too, where there is a pointer precise enough to drag with.
+- **Add Factory moved to the top of the sidebar.** It used to sit below every group, so a plan with a lot of groups meant scrolling all the way down to add one more ungrouped factory — which then appeared back at the top. (#597)
 
 ### AWESOME Sinks and the Dimensional Depot
 

--- a/web/src/components/planner/PlannerFactoryList.vue
+++ b/web/src/components/planner/PlannerFactoryList.vue
@@ -152,45 +152,9 @@
       </v-card>
     </div>
   </div>
-  <div v-show="show" class="factory-list">
-    <!-- Ungrouped is pinned above the groups and is not itself draggable: it is synthesised,
-         not stored, so there is no group record to reorder. -->
-    <planner-sidebar-group
-      v-if="ungroupedSection"
-      :section="ungroupedSection"
-      :statuses="statuses"
-      @create-factory="createFactory"
-    />
-
-    <!-- Off entirely where the pointer is coarse: the drag gesture is the scroll gesture on a
-         touchscreen, so every attempt to scroll the tray reordered the plan instead. The Arrange
-         dialog below is what does this there. -->
-    <draggable
-      :disabled="!dragEnabled"
-      :group="{ name: 'sidebar-groups' }"
-      handle=".group-drag-handle"
-      item-key="id"
-      :model-value="groupSections"
-      @change="onGroupOrderChange"
-      @end="draggingGroup = false"
-      @start="draggingGroup = true"
-    >
-      <template #item="{ element }">
-        <planner-sidebar-group
-          :section="element"
-          :statuses="statuses"
-          @create-factory="createFactory"
-          @delete="requestGroupDelete"
-        />
-      </template>
-    </draggable>
-  </div>
-
-  <factory-group-create-dialog v-model="createGroupOpen" />
-  <factory-arrange-dialog v-model="arrangeOpen" />
-  <factory-group-bulk-dialog v-model="bulkGroupOpen" />
-  <factory-group-delete-dialog v-model="deleteGroupOpen" :group="groupPendingDelete" />
-
+  <!-- Add Factory sits above the groups tray, not below it: with a plan full of groups this
+       button used to be a scroll away, even though clicking it adds the new factory up here
+       at the top of the list — moved to sit beside the factory it creates. -->
   <v-row class="pa-0 ma-0">
     <v-col class="text-center d-flex flex-column align-center ga-2" :class="factories.length === 0 ? 'pt-0' : 'pt-n1'">
       <tooltip text="Add a new, empty factory to the plan, filed under no group.">
@@ -250,6 +214,45 @@
       </div>
     </v-col>
   </v-row>
+
+  <div v-show="show" class="factory-list">
+    <!-- Ungrouped is pinned above the groups and is not itself draggable: it is synthesised,
+         not stored, so there is no group record to reorder. -->
+    <planner-sidebar-group
+      v-if="ungroupedSection"
+      :section="ungroupedSection"
+      :statuses="statuses"
+      @create-factory="createFactory"
+    />
+
+    <!-- Off entirely where the pointer is coarse: the drag gesture is the scroll gesture on a
+         touchscreen, so every attempt to scroll the tray reordered the plan instead. The Arrange
+         dialog below is what does this there. -->
+    <draggable
+      :disabled="!dragEnabled"
+      :group="{ name: 'sidebar-groups' }"
+      handle=".group-drag-handle"
+      item-key="id"
+      :model-value="groupSections"
+      @change="onGroupOrderChange"
+      @end="draggingGroup = false"
+      @start="draggingGroup = true"
+    >
+      <template #item="{ element }">
+        <planner-sidebar-group
+          :section="element"
+          :statuses="statuses"
+          @create-factory="createFactory"
+          @delete="requestGroupDelete"
+        />
+      </template>
+    </draggable>
+  </div>
+
+  <factory-group-create-dialog v-model="createGroupOpen" />
+  <factory-arrange-dialog v-model="arrangeOpen" />
+  <factory-group-bulk-dialog v-model="bulkGroupOpen" />
+  <factory-group-delete-dialog v-model="deleteGroupOpen" :group="groupPendingDelete" />
 </template>
 
 <script setup lang="ts">

--- a/web/src/components/planner/PlannerFactoryList.vue
+++ b/web/src/components/planner/PlannerFactoryList.vue
@@ -1,4 +1,67 @@
 <template>
+  <!-- Add Factory sits above everything else, including the jump-links: with a plan full of
+       groups this button used to be a scroll away, even though clicking it adds the new
+       factory up here at the top of the list — moved to sit beside the factory it creates. -->
+  <v-row class="pa-0 ma-0">
+    <v-col class="text-center d-flex flex-column align-center ga-2" :class="factories.length === 0 ? 'pt-0' : 'pt-n1'">
+      <tooltip text="Add a new, empty factory to the plan, filed under no group.">
+        <v-btn
+          color="primary"
+          prepend-icon="fas fa-plus"
+          ripple
+          @click="createFactory()"
+        >
+          Add Factory
+        </v-btn>
+      </tooltip>
+      <!-- Group management sits on its own line under it: neither button is the thing you reach
+           for most, and side by side they competed with Add Factory for the same glance. -->
+      <div class="d-flex justify-center flex-wrap ga-2">
+        <tooltip text="Create a new group: a folder to file factories under, so a big plan stays navigable.">
+          <v-btn
+            class="create-group-btn"
+            color="secondary"
+            prepend-icon="fas fa-folder-plus"
+            ripple
+            size="small"
+            variant="outlined"
+            @click="createGroupOpen = true"
+          >
+            Group
+          </v-btn>
+        </tooltip>
+        <tooltip :text="factories.length === 0 ? 'Nothing to arrange yet — add a factory first.' : 'Reorder groups and factories, and move factories between groups, with buttons instead of dragging.'">
+          <v-btn
+            class="arrange-btn"
+            color="secondary"
+            :disabled="factories.length === 0"
+            prepend-icon="fas fa-sort"
+            ripple
+            size="small"
+            variant="outlined"
+            @click="arrangeOpen = true"
+          >
+            Arrange
+          </v-btn>
+        </tooltip>
+        <tooltip :text="factories.length === 0 ? 'Nothing to group yet — add a factory first.' : 'Rename, reorder and recolour every group at once, and move factories between them.'">
+          <v-btn
+            class="bulk-group-btn"
+            color="secondary"
+            :disabled="factories.length === 0"
+            prepend-icon="fas fa-object-group"
+            ripple
+            size="small"
+            variant="outlined"
+            @click="bulkGroupOpen = true"
+          >
+            Multi-Group Edit
+          </v-btn>
+        </tooltip>
+      </div>
+    </v-col>
+  </v-row>
+
   <div v-show="show && factories.length > 0" class="factory-list section-links">
     <!-- Statistics jump-link with an at-a-glance power summary. -->
     <div class="mb-1 rounded factory-card" :class="{ problem: powerDeficit, 'active-view': activeFactoryId === 'statistics' }">
@@ -152,68 +215,6 @@
       </v-card>
     </div>
   </div>
-  <!-- Add Factory sits above the groups tray, not below it: with a plan full of groups this
-       button used to be a scroll away, even though clicking it adds the new factory up here
-       at the top of the list — moved to sit beside the factory it creates. -->
-  <v-row class="pa-0 ma-0">
-    <v-col class="text-center d-flex flex-column align-center ga-2" :class="factories.length === 0 ? 'pt-0' : 'pt-n1'">
-      <tooltip text="Add a new, empty factory to the plan, filed under no group.">
-        <v-btn
-          color="primary"
-          prepend-icon="fas fa-plus"
-          ripple
-          @click="createFactory()"
-        >
-          Add Factory
-        </v-btn>
-      </tooltip>
-      <!-- Group management sits on its own line under it: neither button is the thing you reach
-           for most, and side by side they competed with Add Factory for the same glance. -->
-      <div class="d-flex justify-center flex-wrap ga-2">
-        <tooltip text="Create a new group: a folder to file factories under, so a big plan stays navigable.">
-          <v-btn
-            class="create-group-btn"
-            color="secondary"
-            prepend-icon="fas fa-folder-plus"
-            ripple
-            size="small"
-            variant="outlined"
-            @click="createGroupOpen = true"
-          >
-            Group
-          </v-btn>
-        </tooltip>
-        <tooltip :text="factories.length === 0 ? 'Nothing to arrange yet — add a factory first.' : 'Reorder groups and factories, and move factories between groups, with buttons instead of dragging.'">
-          <v-btn
-            class="arrange-btn"
-            color="secondary"
-            :disabled="factories.length === 0"
-            prepend-icon="fas fa-sort"
-            ripple
-            size="small"
-            variant="outlined"
-            @click="arrangeOpen = true"
-          >
-            Arrange
-          </v-btn>
-        </tooltip>
-        <tooltip :text="factories.length === 0 ? 'Nothing to group yet — add a factory first.' : 'Rename, reorder and recolour every group at once, and move factories between them.'">
-          <v-btn
-            class="bulk-group-btn"
-            color="secondary"
-            :disabled="factories.length === 0"
-            prepend-icon="fas fa-object-group"
-            ripple
-            size="small"
-            variant="outlined"
-            @click="bulkGroupOpen = true"
-          >
-            Multi-Group Edit
-          </v-btn>
-        </tooltip>
-      </div>
-    </v-col>
-  </v-row>
 
   <div v-show="show" class="factory-list">
     <!-- Ungrouped is pinned above the groups and is not itself draggable: it is synthesised,


### PR DESCRIPTION
## Summary

- Moves the **Add Factory** button (and the Group / Arrange / Multi-Group Edit controls) in the planner sidebar from below the group tray to above it.
- Previously, on a plan with several groups, adding a new ungrouped factory meant scrolling all the way to the bottom to click Add Factory — which then created the factory back at the top of the list. The controls now sit directly above the Ungrouped/group tray so the button and the factory it creates are in the same place.
- Added a Beta v0.7 changelog entry under "Sidebar: arrange the plan without dragging".

Closes #597

## Test plan

- [x] `vue-tsc --noEmit` passes
- [x] `eslint` passes on the changed file
- [x] `vitest run` (sidebar/planner-related suites) — 563 passed, 1 skipped
- [x] Manually verified in a headless browser against the demo plan: Add Factory, Group, Arrange and Multi-Group Edit now render above the Ungrouped/group list, with no scrolling required.
