### PR TITLE
feat(web): sidebar follows the scroll-spy indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _In development._
 
 - **The sidebar can be scrolled on a phone again.** Picking a factory or a group up is the same gesture as scrolling the list, so touching a row to scroll dragged it instead. Drag is now offered only where the pointer is precise enough for it; the new **Arrange** dialog does the same job with buttons.
 - **An "Arrange" button opens a dialog for reordering the plan.** Groups against each other, factories within their group, and factories from one group into another, all with buttons. Groups can still be dragged there too, where there is a pointer precise enough to drag with.
+- **The sidebar now follows the orange scroll-spy indicator.** Scroll the plan and the sidebar smoothly scrolls itself to keep the highlighted factory in view, instead of leaving it to drift off-screen. Closes #598.
 
 ### AWESOME Sinks and the Dimensional Depot
 

--- a/web/src/components/planner/Planner.vue
+++ b/web/src/components/planner/Planner.vue
@@ -441,6 +441,18 @@
     // Stay sticky on the previous entry rather than dropping the highlight.
   }
 
+  // Keeps the sidebar's own scroll position following the scroll-spy indicator: as the
+  // highlighted row changes, bring it back into the sidebar's view. `block: 'nearest'`
+  // moves only the sidebar's scroll container (its the only scrollable ancestor between
+  // the row and the page) and only as far as needed - a row already in view causes no
+  // motion at all, so this doesn't fight the user's own scrolling of the sidebar.
+  // `flush: 'post'` so the row's `.active-view` class has already been painted by the
+  // time this queries for it.
+  watch(activeFactoryId, () => {
+    document.querySelectorAll('.sidebar-content .factory-card.active-view, #navigationDrawer .factory-card.active-view')
+      .forEach(el => el.scrollIntoView({ behavior: 'smooth', block: 'nearest' }))
+  }, { flush: 'post' })
+
   const showPlan = () => {
     resyncWorldResources()
     planVisible.value = true


### PR DESCRIPTION
## Summary

Closes #598.

The planner sidebar already has a "scroll-spy" indicator — an orange bar on the left edge of the factory row currently in view as you scroll the planner list (`PlannerSidebarFactoryRow.vue`). That indicator was purely a reactive CSS class (`active-view`) driven by `activeFactoryId` in `Planner.vue`; nothing ever scrolled the sidebar's own scroll box to keep the highlighted row in view, so on a long plan the active row could scroll out of sight of the sidebar itself.

- Added a `watch(activeFactoryId, ...)` in `Planner.vue` (flushed `post`, after the row's class has painted) that calls `scrollIntoView({ behavior: 'smooth', block: 'nearest' })` on the currently highlighted row, in whichever sidebar is rendered (the docked desktop sidebar and/or the teleported mobile nav drawer).
- `block: 'nearest'` means the sidebar only moves the minimum amount needed to bring the row back into view — it doesn't fight a user who's deliberately scrolled the sidebar to look at something else, and doesn't cause visible motion when the row is already visible.

## Test plan

- [x] `pnpm lint` / `eslint` on the changed file — clean
- [x] `vue-tsc --noEmit` — clean
- [x] `cd web && pnpm test` — 110 files / 2157 tests pass
- [x] Manually verified end-to-end with a headless-browser script against the demo plan: scrolling the main planner list smoothly animates the sidebar's scroll position to keep the orange-highlighted factory row in view, in both directions (scroll down → sidebar follows down; scroll back to top → sidebar follows back to top).


---
_Generated by [Claude Code](https://claude.ai/code/session_0191un4X7fKPfyWUpNNWxENb)_