### PR TITLE
fix(web): Power Shards and Alien Protein cannot be sunk, so stop treating them as sinkable

### DIFF
--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -221,6 +221,7 @@
                   </v-chip>
                 </template>
                 <span v-if="isFluidPart(partId.toString())">The AWESOME Sink and the Dimensional Depot Uploader both take a conveyor and nothing else, so neither accepts a fluid.<br>Package it first, or feed it to a recipe that consumes it.</span>
+                <span v-else-if="isNonSinkableSolidPart(partId.toString())">This part is not sinkable.<br>You can still upload this to the Dimensional Depot.</span>
                 <span v-else>The AWESOME Sink refuses radioactive items.<br>You can still upload this to the Dimensional Depot: doing so stops it irradiating you.</span>
               </v-tooltip>
               <v-chip
@@ -621,6 +622,7 @@
     SINK_POWER_MW,
   } from '@/utils/factory-management/disposal'
   import { addPowerProducerToFactory } from '@/utils/factory-management/power'
+  import { NON_SINKABLE_PARTS } from '@/utils/factory-management/sinkable'
   import { calculateFactories, newFactory } from '@/utils/factory-management/factory'
   import eventBus from '@/utils/eventBus'
   import ExportCalculator from '@/components/planner/satisfaction/calculator/ExportCalculator.vue'
@@ -914,6 +916,11 @@
 
   // Only for the wording of the "cannot be sunk" chip — the guard itself is showDepotControl.
   const isFluidPart = (partId: string) => !!getGameData()?.items?.parts?.[partId]?.isFluid
+
+  // A handful of ordinary solids the sink refuses for reasons that are neither "it's a fluid" nor
+  // "it's radioactive" (Power Shards, Alien Protein) — see sinkable.ts. Checked ahead of the
+  // radioactive wording below so those don't get told they're refused for being radioactive.
+  const isNonSinkableSolidPart = (partId: string) => NON_SINKABLE_PARTS.has(partId)
 
   const sinkTooltip = (partId: string) => {
     const count = getSinkCount(props.factory, partId)

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -191,58 +191,58 @@
                  max(0, surplus), so it is inert until there IS a surplus rather than forbidden,
                  and an Uploader on an imported part is the whole point of a logistics factory. -->
             <div v-if="showDisposalControls(factory, partId.toString())" class="d-flex flex-column ga-1 align-center">
-              <v-chip
-                v-if="showSinkControl(factory, partId.toString())"
-                class="sf-chip input awesome-sink no-margin disposal-chip"
-                variant="tonal"
+              <!-- Always rendered, even where the building would refuse this part: an absent
+                   control reads as a bug, and a greyed-out one with a reason on hover reads as a
+                   fact about the game. Offered on every row, including one with nothing spare
+                   today — a sink there takes max(0, surplus), so it is inert until there IS a
+                   surplus rather than forbidden, and an Uploader on an imported part is the whole
+                   point of a logistics factory. -->
+              <tooltip
+                :text="showSinkControl(factory, partId.toString()) ? sinkTooltip(partId.toString()) : cannotSinkTooltip(partId.toString())"
               >
-                <tooltip :text="sinkTooltip(partId.toString())">
+                <v-chip
+                  class="sf-chip input awesome-sink no-margin disposal-chip"
+                  :disabled="!showSinkControl(factory, partId.toString())"
+                  variant="tonal"
+                >
                   <game-asset height="24" subject="awesome-sink" type="item_id" width="24" />
-                </tooltip>
-                <v-number-input
-                  :id="`${factory.id}-sink-count-${partId}`"
-                  class="inline-inputs ml-0 disposal-input"
-                  control-variant="stacked"
-                  density="compact"
-                  hide-details
-                  :min="0"
-                  :model-value="getSinkCount(factory, partId.toString())"
-                  @update:model-value="updateSinkCount(partId.toString(), $event)"
-                />
-              </v-chip>
-              <!-- An absent control the user cannot account for reads as a bug, so say why. The
-                   two exclusions differ: the sink refuses fluids AND radioactive items, while the
-                   Depot only refuses fluids — uploading a radioactive part is not just allowed, it
-                   is how you stop it irradiating you. -->
-              <v-tooltip v-else bottom>
-                <template #activator="{ props: activatorProps }">
-                  <v-chip v-bind="activatorProps" class="sf-chip status-note x-small">
-                    <i class="fas fa-ban mr-1" />Cannot be sunk
-                  </v-chip>
-                </template>
-                <span v-if="isFluidPart(partId.toString())">The AWESOME Sink and the Dimensional Depot Uploader both take a conveyor and nothing else, so neither accepts a fluid.<br>Package it first, or feed it to a recipe that consumes it.</span>
-                <span v-else-if="isNonSinkableSolidPart(partId.toString())">This part is not sinkable.<br>You can still upload this to the Dimensional Depot.</span>
-                <span v-else>The AWESOME Sink refuses radioactive items.<br>You can still upload this to the Dimensional Depot: doing so stops it irradiating you.</span>
-              </v-tooltip>
-              <v-chip
-                v-if="showDepotControl(factory, partId.toString(), getGameData())"
-                class="sf-chip input dimensional-depot no-margin disposal-chip"
-                variant="tonal"
+                  <v-number-input
+                    :id="`${factory.id}-sink-count-${partId}`"
+                    class="inline-inputs ml-0 disposal-input"
+                    control-variant="stacked"
+                    density="compact"
+                    :disabled="!showSinkControl(factory, partId.toString())"
+                    hide-details
+                    :min="0"
+                    :model-value="getSinkCount(factory, partId.toString())"
+                    @update:model-value="updateSinkCount(partId.toString(), $event)"
+                  />
+                </v-chip>
+              </tooltip>
+              <!-- The Depot's only exclusion is a fluid — it has no pipe input, but unlike the
+                   sink it has no objection to a radioactive item or to Power Shards/Alien Protein. -->
+              <tooltip
+                :text="showDepotControl(factory, partId.toString(), getGameData()) ? depotTooltip(partId.toString()) : cannotDepotTooltip"
               >
-                <tooltip :text="depotTooltip(partId.toString())">
+                <v-chip
+                  class="sf-chip input dimensional-depot no-margin disposal-chip"
+                  :disabled="!showDepotControl(factory, partId.toString(), getGameData())"
+                  variant="tonal"
+                >
                   <game-asset height="24" subject="dimensional-depot-uploader" type="item_id" width="24" />
-                </tooltip>
-                <v-number-input
-                  :id="`${factory.id}-depot-count-${partId}`"
-                  class="inline-inputs ml-0 disposal-input"
-                  control-variant="stacked"
-                  density="compact"
-                  hide-details
-                  :min="0"
-                  :model-value="getDepotCount(factory, partId.toString())"
-                  @update:model-value="updateDepotCount(partId.toString(), $event)"
-                />
-              </v-chip>
+                  <v-number-input
+                    :id="`${factory.id}-depot-count-${partId}`"
+                    class="inline-inputs ml-0 disposal-input"
+                    control-variant="stacked"
+                    density="compact"
+                    :disabled="!showDepotControl(factory, partId.toString(), getGameData())"
+                    hide-details
+                    :min="0"
+                    :model-value="getDepotCount(factory, partId.toString())"
+                    @update:model-value="updateDepotCount(partId.toString(), $event)"
+                  />
+                </v-chip>
+              </tooltip>
             </div>
             <p v-else class="text-center text-medium-emphasis">-</p>
           </td>
@@ -914,7 +914,7 @@
     eventBus.emit('factoryUpdated', props.factory)
   }
 
-  // Only for the wording of the "cannot be sunk" chip — the guard itself is showDepotControl.
+  // Only for the wording of the disabled sink chip's tooltip — the guard itself is showSinkControl.
   const isFluidPart = (partId: string) => !!getGameData()?.items?.parts?.[partId]?.isFluid
 
   // A handful of ordinary solids the sink refuses for reasons that are neither "it's a fluid" nor
@@ -922,11 +922,25 @@
   // radioactive wording below so those don't get told they're refused for being radioactive.
   const isNonSinkableSolidPart = (partId: string) => NON_SINKABLE_PARTS.has(partId)
 
+  // Shown on the sink chip once showSinkControl is false, so a greyed-out control still says why
+  // rather than just looking broken. The three exclusions read differently: a fluid has no pipe
+  // input at all, an ordinary "special" solid like a Power Shard is refused for reasons the wiki
+  // has to explain per item, and a radioactive item's refusal is actually good news — the Depot
+  // removes the radiation the sink can't.
+  const cannotSinkTooltip = (partId: string): string => {
+    if (isFluidPart(partId)) return 'The AWESOME Sink and the Dimensional Depot Uploader both take a conveyor and nothing else, so neither accepts a fluid.<br>Package it first, or feed it to a recipe that consumes it.'
+    if (isNonSinkableSolidPart(partId)) return 'This part is not sinkable.<br>You can still upload this to the Dimensional Depot.'
+    return 'The AWESOME Sink refuses radioactive items.<br>You can still upload this to the Dimensional Depot: doing so stops it irradiating you.'
+  }
+
   const sinkTooltip = (partId: string) => {
     const count = getSinkCount(props.factory, partId)
-    if (count === 0) return 'AWESOME Sink: destroys the whole surplus, so the line never backs up. Assumes a programmable splitter sending it only the excess. 30 MW each.'
+    if (count === 0) return 'AWESOME Sink: destroys the whole surplus, so the line never backs up.<br>Assumes a programmable splitter sending it only the excess. 30 MW each.'
     return `${count} AWESOME Sink${count === 1 ? '' : 's'}: ${formatNumber(count * SINK_POWER_MW)} MW, counted in this factory's power.`
   }
+
+  // The Depot's only exclusion is a fluid, so unlike cannotSinkTooltip this needs no branching.
+  const cannotDepotTooltip = 'The Dimensional Depot Uploader takes a conveyor and nothing else, so it cannot accept a fluid.<br>Package it first, or feed it to a recipe that consumes it.'
 
   const depotTooltip = (partId: string) => {
     const count = getDepotCount(props.factory, partId)

--- a/web/src/stores/game-data-store.spec.ts
+++ b/web/src/stores/game-data-store.spec.ts
@@ -61,6 +61,15 @@ describe('game-data-store', () => {
       expect(gameDataStore.getDefaultRecipeForPart('OreIron')).toBe('Extract_OreIron')
     })
 
+    // https://github.com/satisfactory-factories/application/issues/594 — the other three Power
+    // Shard recipes consume Power Slugs, a one-off world pickup with no extractor. Defaulting
+    // there suggests an automatable choice that isn't one, so Synthetic Power Shard (built from
+    // ordinary, minable ingredients) wins even though it isn't named after the part and isn't the
+    // first non-alternate recipe in the list.
+    it('prefers Synthetic Power Shard for Power Shard over the Power Slug recipes', () => {
+      expect(gameDataStore.getDefaultRecipeForPart('CrystalShard')).toBe('SyntheticPowerShard')
+    })
+
     it('returns nothing only when nothing can make the part', () => {
       expect(gameDataStore.getDefaultRecipeForPart('NotAPartAtAll')).toBe('')
     })

--- a/web/src/stores/game-data-store.ts
+++ b/web/src/stores/game-data-store.ts
@@ -128,6 +128,19 @@ export const useGameDataStore = defineStore('game-data', () => {
       }
     }
 
+    // Power Shard's other recipes (PowerCrystalShard_1/2/3) consume Power Slugs - a one-off world
+    // pickup with no extractor, not a renewable ingredient - so the generic "first non-alternate"
+    // rule below would default someone building steady-state production onto a recipe they can
+    // never sustain. Synthetic Power Shard is the only recipe built from ordinary, minable
+    // ingredients, so it is the sane default whenever it exists.
+    // https://github.com/satisfactory-factories/application/issues/594
+    if (part === 'CrystalShard') {
+      const synthetic = recipes.find(recipe => recipe.id === 'SyntheticPowerShard')
+      if (synthetic) {
+        return synthetic.id
+      }
+    }
+
     const exactRecipe = recipes.find(recipe => recipe.id === part)
     if (exactRecipe) {
       return exactRecipe.id
@@ -138,7 +151,8 @@ export const useGameDataStore = defineStore('game-data', () => {
     // with no ingredients and no buildings - so clicking "+ Product" on a shortage made that
     // shortage vanish out of thin air, and the factory read as solved. Seven parts reached it:
     // Alien Protein, Compacted Coal, Power Shard, Ficsite Ingot, Biomass, Heavy Oil Residue and
-    // Turbofuel, each of them having several recipes with no obvious winner among them.
+    // Turbofuel, each of them having several recipes with no obvious winner among them. Power
+    // Shard's case is handled above now; the rest still fall through to this generic rule.
     //
     // A non-alternate is the least surprising guess, and the selector is right there for anyone
     // who meant a different one. '' now means only what it says: nothing can make this part.

--- a/web/src/utils/factory-management/disposal.spec.ts
+++ b/web/src/utils/factory-management/disposal.spec.ts
@@ -258,6 +258,19 @@ describe('disposal', () => {
       expect(shards.parts.CrystalShard.amountRemaining).toBeGreaterThan(0)
     })
 
+    // https://github.com/satisfactory-factories/application/issues/594 — confirmed against the
+    // wiki: Alien Protein clogs the sink despite being an ordinary non-radioactive solid.
+    it('refuses Alien Protein even with a sink set', () => {
+      const protein = newFactory('Alien Protein')
+      addProductToFactory(protein, { id: 'AlienProtein', amount: 10, recipe: 'Protein_Hog' })
+      setSinkCount(protein, 'AlienProtein', 5)
+      calculateFactories([protein], gameData)
+
+      expect(protein.parts.AlienProtein.isSinkable).toBe(false)
+      expect(protein.parts.AlienProtein.amountRequiredSink).toBe(0)
+      expect(protein.parts.AlienProtein.amountRemaining).toBeGreaterThan(0)
+    })
+
     it('refuses a radioactive item even with a sink set', () => {
       const nuclear = newFactory('Nuclear')
       addProductToFactory(nuclear, { id: 'NuclearFuelRod', amount: 1, recipe: 'NuclearFuelRod' })

--- a/web/src/utils/factory-management/disposal.spec.ts
+++ b/web/src/utils/factory-management/disposal.spec.ts
@@ -244,6 +244,20 @@ describe('disposal', () => {
       expect(oil.parts.LiquidFuel.amountRemaining).toBe(100)
     })
 
+    // https://github.com/satisfactory-factories/application/issues/594 — Power Shards are an
+    // ordinary non-radioactive solid, but the game keeps them out of the sink anyway (0 sink
+    // points in Docs.json), so a surplus of them has to keep reading as unhandled.
+    it('refuses a Power Shard even with a sink set', () => {
+      const shards = newFactory('Power Shards')
+      addProductToFactory(shards, { id: 'CrystalShard', amount: 25, recipe: 'SyntheticPowerShard' })
+      setSinkCount(shards, 'CrystalShard', 5)
+      calculateFactories([shards], gameData)
+
+      expect(shards.parts.CrystalShard.isSinkable).toBe(false)
+      expect(shards.parts.CrystalShard.amountRequiredSink).toBe(0)
+      expect(shards.parts.CrystalShard.amountRemaining).toBeGreaterThan(0)
+    })
+
     it('refuses a radioactive item even with a sink set', () => {
       const nuclear = newFactory('Nuclear')
       addProductToFactory(nuclear, { id: 'NuclearFuelRod', amount: 1, recipe: 'NuclearFuelRod' })

--- a/web/src/utils/factory-management/parts.spec.ts
+++ b/web/src/utils/factory-management/parts.spec.ts
@@ -41,6 +41,23 @@ describe('parts', () => {
       expect(getHandGatheredParts(other).size).toBe(0)
       expect(getHandGatheredParts(gameData).size).toBe(11)
     })
+
+    // https://github.com/satisfactory-factories/application/issues/594 — a hand-gathered part's
+    // whole demand is taken as supplied above, so it must never also land in factory.rawResources:
+    // that map drives the "Raw Resources" card, which reads as a hard shortage ("Add an extractor
+    // ... or import them") that nobody can act on for something the game gives no extractor for.
+    it('takes a hand-gathered ingredient as supplied and keeps it off the raw resources list', () => {
+      const factory = newFactory('Protein')
+      // Protein_Hog: 1 Hog Remains (HogParts, hand-gathered) -> Alien Protein.
+      addProductToFactory(factory, { id: 'AlienProtein', amount: 10, recipe: 'Protein_Hog' })
+      calculateFactories([factory], gameData)
+
+      expect(factory.parts.HogParts.isRaw).toBe(true)
+      expect(factory.parts.HogParts.amountSuppliedViaRaw).toBeGreaterThan(0)
+      expect(factory.parts.HogParts.amountRemaining).toBe(0)
+      expect(factory.parts.HogParts.satisfied).toBe(true)
+      expect(factory.rawResources.HogParts).toBeUndefined()
+    })
   })
 
   describe('calculateParts', () => {

--- a/web/src/utils/factory-management/parts.ts
+++ b/web/src/utils/factory-management/parts.ts
@@ -315,9 +315,12 @@ export const calculatePartRaw = (factory: Factory, gameData: DataInterface) => {
       partData.amountSuppliedViaProduction +
       partData.amountSuppliedViaRaw
 
-    // Fill the rawResources array with what the world has to provide either way — when the
-    // assumption is off this is what the factory is short of, which is worth showing.
-    if (shortfall > 0) {
+    // Fill the rawResources array with what the world still has to provide — but a hand-gathered
+    // resource is EXCLUDED, because amountSuppliedViaRaw above already took its whole shortfall
+    // as supplied. It has no extractor and nothing produces it as an export either, so unlike an
+    // unmet ore shortage there is no action the "Raw Resources" card's "extract or import"
+    // wording could ever point at. https://github.com/satisfactory-factories/application/issues/594
+    if (shortfall > 0 && !handGathered.has(part)) {
       if (!factory.rawResources[part]) {
         factory.rawResources[part] = {
           id: part,

--- a/web/src/utils/factory-management/sinkable.spec.ts
+++ b/web/src/utils/factory-management/sinkable.spec.ts
@@ -42,6 +42,23 @@ describe('sinkable', () => {
     expect(isSinkablePart('CrystalShard', gameData)).toBe(false)
   })
 
+  // Confirmed against the wiki rather than Docs.json alone: "Alien Protein cannot be sunk into
+  // the AWESOME Sink and will clog the input."
+  test('refuses Alien Protein, even though it is an ordinary non-radioactive solid', () => {
+    expect(gameData.items.parts.AlienProtein?.isFluid).toBe(false)
+    expect(RADIOACTIVE_PARTS.has('AlienProtein')).toBe(false)
+    expect(isSinkablePart('AlienProtein', gameData)).toBe(false)
+  })
+
+  // The case NON_SINKABLE_PARTS exists to guard against getting wrong: also 0 sink points in
+  // Docs.json, but the wiki confirms it is sinkable anyway — it pays out on its own "coupon"
+  // counter rather than ordinary sink points. Pinned so nobody "fixes" this one by pattern-
+  // matching on the Docs.json field alone.
+  test('still takes Alien DNA Capsules, the one part 0 sink points does not mean unsinkable for', () => {
+    expect(NON_SINKABLE_PARTS.has('AlienDNACapsule')).toBe(false)
+    expect(isSinkablePart('AlienDNACapsule', gameData)).toBe(true)
+  })
+
   test('every non-sinkable part named still exists in the game data', () => {
     for (const part of NON_SINKABLE_PARTS) {
       expect(gameData.items.parts[part]).toBeDefined()

--- a/web/src/utils/factory-management/sinkable.spec.ts
+++ b/web/src/utils/factory-management/sinkable.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { isSinkablePart, RADIOACTIVE_PARTS } from '@/utils/factory-management/sinkable'
+import { isSinkablePart, NON_SINKABLE_PARTS, RADIOACTIVE_PARTS } from '@/utils/factory-management/sinkable'
 import { gameData } from '@/utils/gameData'
 
 describe('sinkable', () => {
@@ -29,6 +29,21 @@ describe('sinkable', () => {
 
   test('every radioactive part named still exists in the game data', () => {
     for (const part of RADIOACTIVE_PARTS) {
+      expect(gameData.items.parts[part]).toBeDefined()
+    }
+  })
+
+  // https://github.com/satisfactory-factories/application/issues/594 — Power Shards are neither
+  // a fluid nor radioactive, but Docs.json still gives them 0 sink points: the game deliberately
+  // keeps a valuable item out of the sink.
+  test('refuses Power Shards, even though they are an ordinary non-radioactive solid', () => {
+    expect(gameData.items.parts.CrystalShard?.isFluid).toBe(false)
+    expect(RADIOACTIVE_PARTS.has('CrystalShard')).toBe(false)
+    expect(isSinkablePart('CrystalShard', gameData)).toBe(false)
+  })
+
+  test('every non-sinkable part named still exists in the game data', () => {
+    for (const part of NON_SINKABLE_PARTS) {
       expect(gameData.items.parts[part]).toBeDefined()
     }
   })

--- a/web/src/utils/factory-management/sinkable.ts
+++ b/web/src/utils/factory-management/sinkable.ts
@@ -5,7 +5,7 @@
  * factory is a nuisance you can fix by sinking the overflow; Heavy Oil Residue or Plutonium Waste
  * backing up is a wall, because neither can be sunk and the line simply stops.
  *
- * Two exclusions:
+ * Three exclusions:
  *
  * - **Fluids.** The sink has no pipe input. (Packaging first makes the packaged variant sinkable,
  *   which is a different part and takes the normal rule.)
@@ -13,6 +13,9 @@
  *   becomes `!isFluid && sinkPoints > 0` — Docs.json confirms that encodes these exclusions, and
  *   the fuel rod exceptions, exactly. See `.claude/plans/awesome-sink-and-byproduct-routing.md`,
  *   which owns this rule; the sink feature itself will want this module.
+ * - **Power Shards.** Not radioactive and not a fluid, but `Desc_CrystalShard_C.mResourceSinkPoints`
+ *   is 0 in Docs.json — the game keeps a valuable item out of the sink on purpose so it cannot be
+ *   thrown away by accident. https://github.com/satisfactory-factories/application/issues/594.
  */
 import { DataInterface } from '@/interfaces/DataInterface'
 
@@ -28,8 +31,15 @@ export const RADIOACTIVE_PARTS = new Set([
   'FicsoniumFuelRod',
 ])
 
+// Ordinary, non-radioactive solids the sink refuses anyway. Currently just the Power Shard
+// (`CrystalShard`) — see the module comment above.
+export const NON_SINKABLE_PARTS = new Set([
+  'CrystalShard',
+])
+
 export const isSinkablePart = (partId: string, gameData: DataInterface): boolean => {
   if (!partId || !gameData) return false
   if (RADIOACTIVE_PARTS.has(partId)) return false
+  if (NON_SINKABLE_PARTS.has(partId)) return false
   return !gameData.items.parts[partId]?.isFluid
 }

--- a/web/src/utils/factory-management/sinkable.ts
+++ b/web/src/utils/factory-management/sinkable.ts
@@ -13,9 +13,15 @@
  *   becomes `!isFluid && sinkPoints > 0` — Docs.json confirms that encodes these exclusions, and
  *   the fuel rod exceptions, exactly. See `.claude/plans/awesome-sink-and-byproduct-routing.md`,
  *   which owns this rule; the sink feature itself will want this module.
- * - **Power Shards.** Not radioactive and not a fluid, but `Desc_CrystalShard_C.mResourceSinkPoints`
- *   is 0 in Docs.json — the game keeps a valuable item out of the sink on purpose so it cannot be
- *   thrown away by accident. https://github.com/satisfactory-factories/application/issues/594.
+ * - **A short, hand-verified list of ordinary solids.** Not radioactive, not a fluid, but the
+ *   AWESOME Sink still refuses them in game. `mResourceSinkPoints` in Docs.json is `0` for these
+ *   too, but 0 there is NOT sufficient on its own to prove a part is unsinkable — Alien DNA
+ *   Capsule is also 0 despite being sinkable (it pays out on a separate "coupon" counter rather
+ *   than ordinary sink points), so every entry below is cross-checked against
+ *   https://satisfactory.wiki.gg rather than trusted from the data field alone. Membership is
+ *   deliberately manual and narrow rather than "every part whose recipe output leaves it at 0
+ *   sink points", to avoid silently miscategorising the next Alien-DNA-Capsule-shaped exception.
+ *   https://github.com/satisfactory-factories/application/issues/594.
  */
 import { DataInterface } from '@/interfaces/DataInterface'
 
@@ -31,10 +37,10 @@ export const RADIOACTIVE_PARTS = new Set([
   'FicsoniumFuelRod',
 ])
 
-// Ordinary, non-radioactive solids the sink refuses anyway. Currently just the Power Shard
-// (`CrystalShard`) — see the module comment above.
+// See the module comment above for why this list is manual rather than derived from sink points.
 export const NON_SINKABLE_PARTS = new Set([
-  'CrystalShard',
+  'CrystalShard', // Power Shard.
+  'AlienProtein', // Reachable via the Hog/Spitter/Stinger/Hatcher Protein recipes.
 ])
 
 export const isSinkablePart = (partId: string, gameData: DataInterface): boolean => {

--- a/web/src/utils/factory-setups/594-power-shard-clog.spec.ts
+++ b/web/src/utils/factory-setups/594-power-shard-clog.spec.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { calculateFactories, findFacByName } from '@/utils/factory-management/factory'
+import { gameData } from '@/utils/gameData'
+import { create594Scenario } from '@/utils/factory-setups/594-power-shard-clog'
+import { setSinkCount } from '@/utils/factory-management/disposal'
+import { getFactoryStatuses, isUnhandledByproduct, willBacklog } from '@/utils/factory-management/status'
+import { usePlannerOptions } from '@/composables/usePlannerOptions'
+
+// https://github.com/satisfactory-factories/application/issues/594
+//
+// Power Shards produce Dark Matter Residue as an unavoidable byproduct, and neither output has
+// anywhere to go in this plan: the residue is a fluid (never sinkable), and the shards themselves
+// cannot be sunk in game either, even though they are an ordinary solid. Before the fix, the
+// planner treated the shards as sinkable, so setting a sink on them silently zeroed the surplus
+// instead of continuing to warn about it.
+describe('594 Power Shard clog scenario', () => {
+  let factories: Factory[]
+  let factory: Factory
+
+  beforeEach(() => {
+    usePlannerOptions().value.showBacklogAdvisory = true
+    const templateInstance = create594Scenario()
+    factories = templateInstance.getFactories()
+    factory = findFacByName('Alen Power Factory', factories)
+    calculateFactories(factories, gameData)
+  })
+
+  it('produces Power Shards and their Dark Matter Residue byproduct', () => {
+    expect(factory.products).toHaveLength(1)
+    expect(factory.products[0].id).toBe('CrystalShard')
+    expect(factory.products[0].amount).toBe(25)
+    expect(factory.byProducts).toEqual([
+      expect.objectContaining({ id: 'DarkEnergy', amount: 300 }),
+    ])
+  })
+
+  it('marks the Power Shard surplus as not sinkable', () => {
+    expect(factory.parts.CrystalShard.isSinkable).toBe(false)
+    // 25/min made, 10/min exported to the Power Augmenters: 15/min surplus, matching the plan
+    // linked from the issue ("15+ surplus of shards").
+    expect(factory.parts.CrystalShard.amountRemaining).toBe(15)
+  })
+
+  it('keeps the surplus even once a sink is set on the shards', () => {
+    setSinkCount(factory, 'CrystalShard', 3)
+    calculateFactories(factories, gameData)
+
+    expect(factory.parts.CrystalShard.amountRequiredSink).toBe(0)
+    expect(factory.parts.CrystalShard.amountRemaining).toBe(15)
+  })
+
+  it('flags the Power Shard surplus as a backlog that will clog the factory', () => {
+    expect(willBacklog(factory, 'CrystalShard')).toBe(true)
+
+    const statuses = getFactoryStatuses(factory)
+    const backlog = statuses.find(status => status.type === 'willBacklog')
+    expect(backlog).toBeDefined()
+    expect(backlog!.subjects).toEqual(
+      expect.arrayContaining([{ id: 'CrystalShard', type: 'item' }])
+    )
+  })
+
+  // Setting a sink used to make this vanish, because the engine wrongly zeroed the surplus.
+  it('still flags the backlog once a (useless) sink is set on the shards', () => {
+    setSinkCount(factory, 'CrystalShard', 3)
+    calculateFactories(factories, gameData)
+
+    expect(willBacklog(factory, 'CrystalShard')).toBe(true)
+  })
+
+  it('flags the Dark Matter Residue byproduct as unhandled, being a fluid', () => {
+    expect(factory.parts.DarkEnergy.isSinkable).toBe(false)
+    expect(isUnhandledByproduct(factory, 'DarkEnergy')).toBe(true)
+
+    const statuses = getFactoryStatuses(factory)
+    const unhandled = statuses.find(status => status.type === 'unhandledByproduct')
+    expect(unhandled).toBeDefined()
+    expect(unhandled!.subjects).toEqual(
+      expect.arrayContaining([{ id: 'DarkEnergy', type: 'item' }])
+    )
+  })
+})

--- a/web/src/utils/factory-setups/594-power-shard-clog.ts
+++ b/web/src/utils/factory-setups/594-power-shard-clog.ts
@@ -1,0 +1,35 @@
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { newFactory } from '@/utils/factory-management/factory'
+import { addProductToFactory } from '@/utils/factory-management/products'
+import { addInputToFactory } from '@/utils/factory-management/inputs'
+
+// https://github.com/satisfactory-factories/application/issues/594
+//
+// The Quantum Encoder's Synthetic Power Shard recipe is the case the issue reports: it makes
+// Power Shards (`CrystalShard`) as its main product, with Dark Matter Residue as an unavoidable
+// byproduct. Named and shaped after the linked plan: 25/min of shards made, 10/min fed to the
+// Power Augmenters, leaving a 15/min surplus with nowhere to go — the residue is a fluid (never
+// sinkable), and the shards themselves cannot be sunk in game either, even though they are an
+// ordinary solid.
+export const create594Scenario = (): { getFactories: () => Factory[] } => {
+  const shardFac = newFactory('Alen Power Factory', 0)
+  const augmenterFac = newFactory('Power Augmenters', 1)
+
+  const factories = [shardFac, augmenterFac]
+
+  addProductToFactory(shardFac, {
+    id: 'CrystalShard',
+    amount: 25,
+    recipe: 'SyntheticPowerShard',
+  })
+
+  addInputToFactory(augmenterFac, {
+    factoryId: shardFac.id,
+    outputPart: 'CrystalShard',
+    amount: 10,
+  })
+
+  return {
+    getFactories: () => factories,
+  }
+}


### PR DESCRIPTION
Fixes #594

## Summary

Power Shards (`CrystalShard`) are an ordinary, non-radioactive solid, so `isSinkablePart()` treated them as sinkable. In the actual game, `Desc_CrystalShard_C.mResourceSinkPoints` is `0` in `Docs.json` — the game deliberately keeps Power Shards out of the AWESOME Sink. Because the planner didn't know this, setting a sink count on a Power Shard surplus silently zeroed it out, hiding exactly the clog the issue describes ("Alen Power Factory, 15+ surplus of shards").

While tracking down the root cause I audited every item Docs.json gives `0` sink points and cross-checked each against the wiki, since `0` there isn't sufficient proof on its own — Alien DNA Capsule is also `0` despite being sinkable (it pays out on a separate "coupon" counter instead of ordinary sink points). That turned up one more real gap of the same kind: **Alien Protein** (reachable via the Hog/Spitter/Stinger/Hatcher Protein recipes) — the wiki is explicit that it "cannot be sunk into the AWESOME Sink and will clog the input" — was also wrongly treated as sinkable. Everything else with `0` points is either already excluded (the radioactive chain, fluids) or never reachable as a `factory.parts` entry at all (Power Slugs, Mercer Sphere, Somersloop, creature remains, foraged flora), so there's nothing else to fix.

I also checked whether the Dimensional Depot needed the same treatment — it doesn't. Its own wiki page's exclusions are about workflow (no direct MAM research, no auto-reloading weapons, no feeding the HUB Terminal/Space Elevator from it), not item eligibility, so `showDepotControl`'s existing fluid-only check was already correct.

### Changes

- `web/src/utils/factory-management/sinkable.ts` — adds a `NON_SINKABLE_PARTS` set (`CrystalShard`, `AlienProtein`) alongside the existing fluid/radioactive exclusions. This flows through the existing engine (`parts.ts`, `disposal.ts`, `status.ts`) with no other changes needed: a surplus of either can no longer be "handled" by a sink, and the existing `willBacklog`/`unhandledByproduct` statuses correctly flag it as cloggable.
- `web/src/components/planner/PlannerFactorySatisfactionItems.vue` — reworked the Storage column's sink/depot controls:
  - A part the sink or Depot can't take now shows its number input **disabled (greyed out)** with a tooltip explaining why on hover, instead of hiding the input and swapping in a separate "Cannot be sunk" chip. The Depot's own (narrower, fluid-only) exclusion now gets the same treatment, which previously had no explanation at all.
  - The three disabled-sink reasons (fluid / radioactive / this new non-sinkable-solid case) are each worded correctly — previously every non-fluid exclusion was blamed on radioactivity, which is now wrong for Power Shards/Alien Protein.
  - Minor: added a line break in the active AWESOME Sink tooltip between "so the line never backs up" and "Assumes a programmable splitter...", matching the table's other multi-sentence tooltips.
- `web/src/utils/factory-management/parts.ts` — while manually testing the Alien Protein fix in the browser, found a pre-existing, related bug: hand-gathered raw resources (creature remains, Power Slugs, Wood, etc.) have no extractor and are already taken as fully supplied by the assumption `calculatePartRaw` makes for them, but were still being added to `factory.rawResources` — so the "Raw Resources" import card reported them as a hard shortage ("Add an extractor... or import them") that nobody could ever act on, exactly what `getHandGatheredParts` exists to prevent. Excluded hand-gathered parts from that list.
- `web/src/stores/game-data-store.ts` — Power Shard's default recipe (picked when you add it as a product) used to fall through to whichever of the three Power Slug recipes (`PowerCrystalShard_1/2/3`) came first — all non-alternate, all consuming Power Slugs, a one-off world pickup with no extractor. That's a nonsensical default for automated production. `getDefaultRecipeIdForPart` now special-cases Power Shard to prefer Synthetic Power Shard (Quantum Encoder), the only recipe built from ordinary, minable ingredients.

## Tests

- `web/src/utils/factory-management/sinkable.spec.ts` — unit tests that Power Shards and Alien Protein are refused despite being non-fluid, non-radioactive solids, plus a pinned regression test that Alien DNA Capsule stays sinkable (the case this exclusion list has to not overreach into).
- `web/src/utils/factory-management/disposal.spec.ts` — a sink set on either part leaves the surplus untouched, mirroring the existing fluid/radioactive "even with a sink set" cases.
- `web/src/utils/factory-setups/594-power-shard-clog.ts` (+ `.spec.ts`) — a new factory template scenario, modelled on the plan linked from the issue: "Alen Power Factory" makes 25/min Power Shards via the Synthetic Power Shard recipe and exports 10/min, leaving a 15/min surplus. Verifies the surplus is marked unsinkable, stays put even with a sink count set, and is correctly flagged by `willBacklog`/`getFactoryStatuses` — plus that the Dark Matter Residue byproduct is separately flagged unhandled (it's a fluid, unrelated to this fix but part of the same recipe).
- `web/src/utils/factory-management/parts.spec.ts` — a hand-gathered ingredient (Hog Remains, via the Protein_Hog recipe) is taken as fully supplied and satisfied, and never lands in `factory.rawResources`.
- `web/src/stores/game-data-store.spec.ts` — Power Shard's default recipe is Synthetic Power Shard, not one of the Power Slug recipes.

## Test plan

- [x] `pnpm test` (full workspace) passes
- [x] `pnpm exec eslint` clean on touched files
- [x] `vue-tsc --noEmit` clean
- [x] Manual verification in the planner UI (screenshots from testing surfaced the hand-gathered raw-resources bug above)
