### PR TITLE
fix(web): fix checklist checkbox reactivity across products, imports and exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,10 +117,14 @@ Dimensional Depot Uploaders you have put on that item's surplus.
 
 ### Fixes
 
-- **Checklist mode: the tick on an export chip under Satisfaction is clickable again** (#592). It sat
-  inside the chip's own clickable area, so the chip's click handler and ripple layer could win the
-  click before it ever reached the checkbox; it's now a sibling of the chip instead, matching how
-  the Checklist card above it already builds the same control.
+- **Checklist mode: ticks on the Products, Imports and export-chip checkboxes are reliable again**
+  (#592, #593). The export tick sat inside the chip's own clickable area, so the chip's click
+  handler and ripple layer could win the click before it ever reached the checkbox; it's now a
+  sibling of the chip instead, matching how the Checklist card above it already builds the same
+  control. Separately, all three checkboxes could lose a race against the browser's own
+  "revert to pre-click state" step when a click was cancelled — the state change landed, but the
+  box itself (and anywhere else that same tick is drawn) could stay visually unticked. Every
+  checklist checkbox now keys its `<input>` on the checked value itself, which sidesteps that race.
 
 ## Beta v0.6 - The "Groundwork" Update
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,13 @@ Dimensional Depot Uploaders you have put on that item's surplus.
 - **The "Show Info" toggle is gone**, along with the explanatory paragraphs it hid throughout the planner. Nobody was clicking it, and the copy behind it hadn't kept pace with the app for several updates. The always-visible ⓘ tooltips elsewhere in the UI (Game Sync, upkeep, variable power, and so on) are unaffected.
 - **Statistics and the Global Factories Summary now start collapsed.** A fresh visitor, or anyone opening a demo plan, used to land on a page-length wall of stats above the factory cards themselves. Item production, power shards, raw resources and building summaries within Statistics now start collapsed too, matching the per-factory power breakdown, which already did. Each section remembers your choice once you toggle it.
 
+### Fixes
+
+- **Checklist mode: the tick on an export chip under Satisfaction is clickable again** (#592). It sat
+  inside the chip's own clickable area, so the chip's click handler and ripple layer could win the
+  click before it ever reached the checkbox; it's now a sibling of the chip instead, matching how
+  the Checklist card above it already builds the same control.
+
 ## Beta v0.6 - The "Groundwork" Update
 
 _Released 19 August 2026._

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -481,37 +481,52 @@
             </p>
             <div v-else>
               <div>
-                <v-chip
+                <!-- The checkbox sits outside the v-chip rather than inside it: nested inside a
+                     clickable chip, its clicks were swallowed by the chip's own click handler and
+                     ripple/overlay layer before ever reaching the input (#592). Mirrors the
+                     sibling layout PlannerFactoryChecklist.vue uses for the same checkbox — that
+                     file's own per-value `:key` on the input is mirrored below too: without it,
+                     a `preventDefault()`-cancelled checkbox click can lose a race against the
+                     browser's own revert-to-pre-click-state step, leaving the tick visually
+                     unchanged even though the underlying state did flip. Keying the input on the
+                     checked value forces Vue to mount a fresh element at the new value instead of
+                     patching the (possibly just-reverted) old one. -->
+                <div
                   v-for="(request) in getPartExportRequests(factory, partId.toString())"
                   :key="`${partId}-${request.requestingFactoryId}`"
-                  class="sf-chip sf-chip-clickable small factory"
-                  :color="isRequestSelected(factory, request.requestingFactoryId.toString(), partId.toString()) ? 'primary' : ''"
-                  :style="isRequestSelected(factory, request.requestingFactoryId.toString(), partId.toString()) ? 'border-color: rgb(0, 123, 255) !important' : ''"
-                  @click="initCalculator(factory, partId.toString(), request.requestingFactoryId)"
+                  class="d-inline-flex align-center"
                 >
                   <input
                     v-if="factory.checklistEnabled"
+                    :key="`${request.requestingFactoryId}-${partId}-${isChecklistExportComplete(factory, request.requestingFactoryId, partId.toString())}`"
                     :checked="isChecklistExportComplete(factory, request.requestingFactoryId, partId.toString())"
                     class="checklist-tick"
                     :class="{ desynced: isChecklistExportDesynced(factory, request.requestingFactoryId, partId.toString(), request.amount) }"
                     :title="isChecklistExportDesynced(factory, request.requestingFactoryId, partId.toString(), request.amount) ? 'Built amount no longer matches the plan — click to re-confirm' : 'Mark this export as built'"
                     type="checkbox"
-                    @click.prevent.stop="toggleChecklistExport(factory, request.requestingFactoryId, partId.toString(), request.amount)"
+                    @click.prevent="toggleChecklistExport(factory, request.requestingFactoryId, partId.toString(), request.amount)"
                   >
-                  <factory-icon-display :icon="findFactory(request.requestingFactoryId).icon" size="20" />
-                  <span class="ml-2">
-                    <b>{{ findFactory(request.requestingFactoryId).name }}</b>: {{ formatNumber(request.amount) }}/min
-                  </span>
-                  <v-btn
-                    class="chip-jump-btn ml-2"
-                    color="primary"
-                    icon="fas fa-eye"
-                    size="x-small"
-                    title="Jump to the import taking this export"
-                    variant="flat"
-                    @click.stop="navigateToImport(request.requestingFactoryId, partId.toString())"
-                  />
-                </v-chip>
+                  <v-chip
+                    class="sf-chip sf-chip-clickable small factory"
+                    :color="isRequestSelected(factory, request.requestingFactoryId.toString(), partId.toString()) ? 'primary' : ''"
+                    :style="isRequestSelected(factory, request.requestingFactoryId.toString(), partId.toString()) ? 'border-color: rgb(0, 123, 255) !important' : ''"
+                    @click="initCalculator(factory, partId.toString(), request.requestingFactoryId)"
+                  >
+                    <factory-icon-display :icon="findFactory(request.requestingFactoryId).icon" size="20" />
+                    <span class="ml-2">
+                      <b>{{ findFactory(request.requestingFactoryId).name }}</b>: {{ formatNumber(request.amount) }}/min
+                    </span>
+                    <v-btn
+                      class="chip-jump-btn ml-2"
+                      color="primary"
+                      icon="fas fa-eye"
+                      size="x-small"
+                      title="Jump to the import taking this export"
+                      variant="flat"
+                      @click.stop="navigateToImport(request.requestingFactoryId, partId.toString())"
+                    />
+                  </v-chip>
+                </div>
               </div>
             </div>
           </td>

--- a/web/src/components/planner/checklist-reactivity.spec.ts
+++ b/web/src/components/planner/checklist-reactivity.spec.ts
@@ -1,0 +1,263 @@
+// Regression coverage for #592/#593: a checklist tick has to (a) update itself the moment it's
+// clicked, and (b) stay in sync with the other place the same tick is drawn — the per-item
+// checkbox on the Products/Imports/Satisfaction row, and the summary checkbox in the top-of-card
+// Checklist panel (PlannerFactoryChecklist.vue) — in both directions.
+//
+// A `@click.prevent`-controlled native checkbox can lose a race against the browser's own
+// "revert to pre-click state" step (part of canceling a checkbox's default action), leaving the
+// tick visually stuck even though the underlying state did flip. Every checklist checkbox in this
+// codebase now keys its `<input>` on the checked value itself, forcing Vue to mount a fresh
+// element at the new value instead of patching a possibly-just-reverted one; see the comment
+// beside each `:key` for the mechanism.
+//
+// jsdom's own checkbox click-then-revert timing does not reliably match a real browser's (verified
+// separately against real Chromium via Puppeteer), so these tests drive the click through Vue's
+// handler with `trigger('click')` — which exercises the click handler and the resulting reactive
+// re-render, the part that IS meaningfully testable here — rather than asserting on the exact
+// native revert race, which isn't.
+import vuetify from '@/plugins/vuetify'
+import { createPinia, setActivePinia } from 'pinia'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { reactive } from 'vue'
+import Product from './products/Product.vue'
+import Imports from './imports/Imports.vue'
+import PlannerFactorySatisfactionItems from './PlannerFactorySatisfactionItems.vue'
+import PlannerFactoryChecklist from './PlannerFactoryChecklist.vue'
+import { calculateFactories, calculateFactory, newFactory } from '@/utils/factory-management/factory'
+import { addProductToFactory } from '@/utils/factory-management/products'
+import { addInputToFactory } from '@/utils/factory-management/inputs'
+import { useGameDataStore } from '@/stores/game-data-store'
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+
+const gameData = useGameDataStore().getGameData()
+
+// Fresh query every time on purpose: a checked-value-keyed checkbox is swapped for a new DOM
+// node on toggle, so a wrapper reference captured before the click can go stale and silently
+// keep pointing at the discarded node. A real viewer only ever sees the current DOM, so tests
+// have to re-find the element after every state change too.
+const findTick = (wrapper: ReturnType<typeof mount>) => wrapper.find('input.checklist-tick')
+
+// PlannerFactoryChecklist.vue renders one `.checklist-group` per item type (Products, Power
+// Producers, Imports, Exports) — a factory under test can easily have more than one (an export
+// chip needs a product to export in the first place), so picking "the first checklist-group" is
+// not safe. Find the one titled `groupTitle` and return its tick.
+const findTickInGroup = (wrapper: ReturnType<typeof mount>, groupTitle: string) => {
+  const group = wrapper.findAll('.checklist-group')
+    .find(g => g.find('.checklist-group-title').text() === groupTitle)
+  if (!group) {
+    throw new Error(`No "${groupTitle}" checklist-group found. Groups present: ${
+      wrapper.findAll('.checklist-group-title').map(t => t.text()).join(', ')}`)
+  }
+  return group.find('input.checklist-tick')
+}
+
+const isChecked = (tick: ReturnType<typeof findTick>) => (tick.element as HTMLInputElement).checked
+
+describe('checklist checkbox reactivity', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('Products', () => {
+    const mountBoth = (factory: Factory) => {
+      const global = {
+        plugins: [vuetify],
+        provide: {
+          getBuildingDisplayName: (x: any) => x,
+          updateFactory: () => { calculateFactory(factory, [factory], gameData) },
+          findFactory: () => factory,
+          navigateToFactory: () => {},
+        },
+      }
+      const product = mount(Product, { propsData: { factory }, global })
+      const checklist = mount(PlannerFactoryChecklist, { propsData: { factory }, global })
+      return { product, checklist }
+    }
+
+    const buildFactory = () => {
+      const factory = reactive(newFactory('Product test', 0, 1)) as Factory
+      addProductToFactory(factory, { id: 'IronIngot', amount: 30, recipe: 'IngotIron' })
+      calculateFactory(factory, [factory], gameData)
+      factory.checklistEnabled = true
+      return factory
+    }
+
+    it('ticking the product row updates its own checkbox', async () => {
+      const factory = buildFactory()
+      const { product } = mountBoth(factory)
+
+      expect(isChecked(findTick(product))).toBe(false)
+      await findTick(product).trigger('click')
+
+      expect(factory.products[0].completed).toBe(true)
+      expect(isChecked(findTick(product))).toBe(true)
+    })
+
+    it('ticking the product row syncs to the Checklist panel', async () => {
+      const factory = buildFactory()
+      const { product, checklist } = mountBoth(factory)
+
+      await findTick(product).trigger('click')
+      await checklist.vm.$nextTick()
+
+      expect(isChecked(findTickInGroup(checklist, 'Products'))).toBe(true)
+    })
+
+    it('ticking the Checklist panel syncs to the product row', async () => {
+      const factory = buildFactory()
+      const { product, checklist } = mountBoth(factory)
+
+      await findTickInGroup(checklist, 'Products').trigger('click')
+      await product.vm.$nextTick()
+
+      expect(factory.products[0].completed).toBe(true)
+      expect(isChecked(findTick(product))).toBe(true)
+    })
+
+    it('un-ticking round-trips cleanly in both directions', async () => {
+      const factory = buildFactory()
+      const { product, checklist } = mountBoth(factory)
+
+      await findTick(product).trigger('click') // check
+      await findTick(product).trigger('click') // uncheck
+      await checklist.vm.$nextTick()
+
+      expect(factory.products[0].completed).toBe(false)
+      expect(isChecked(findTick(product))).toBe(false)
+      expect(isChecked(findTickInGroup(checklist, 'Products'))).toBe(false)
+    })
+  })
+
+  describe('Imports', () => {
+    const mountBoth = (factory: Factory) => {
+      const global = {
+        plugins: [vuetify],
+        provide: {
+          updateFactory: () => { calculateFactory(factory, [factory], gameData) },
+          findFactory: () => factory,
+          navigateToFactory: () => {},
+        },
+      }
+      const imports = mount(Imports, { propsData: { factory }, global })
+      const checklist = mount(PlannerFactoryChecklist, { propsData: { factory }, global })
+      return { imports, checklist }
+    }
+
+    const buildFactory = () => {
+      const factory = reactive(newFactory('Imports test', 0, 1)) as Factory
+      // A dangling input (no real supplying factory) gets pruned by calculateFactories'
+      // flushInvalidRequests pass, so the import needs a genuine producer to resolve against.
+      const producer = reactive(newFactory('Iron Ingots', 0, 2)) as Factory
+      addProductToFactory(producer, { id: 'IronIngot', amount: 1000, recipe: 'IngotIron' })
+      addProductToFactory(factory, { id: 'IronPlate', amount: 100, recipe: 'IronPlate' })
+      addInputToFactory(factory, { factoryId: producer.id, outputPart: 'IronIngot', amount: 200 })
+      calculateFactories([producer, factory], gameData)
+      factory.checklistEnabled = true
+      return factory
+    }
+
+    it('ticking the import row updates its own checkbox', async () => {
+      const factory = buildFactory()
+      const { imports } = mountBoth(factory)
+
+      expect(isChecked(findTick(imports))).toBe(false)
+      await findTick(imports).trigger('click')
+
+      expect(factory.inputs[0].completed).toBe(true)
+      expect(isChecked(findTick(imports))).toBe(true)
+    })
+
+    it('ticking the import row syncs to the Checklist panel', async () => {
+      const factory = buildFactory()
+      const { imports, checklist } = mountBoth(factory)
+
+      await findTick(imports).trigger('click')
+      await checklist.vm.$nextTick()
+
+      expect(isChecked(findTickInGroup(checklist, 'Imports'))).toBe(true)
+    })
+
+    it('ticking the Checklist panel syncs to the import row', async () => {
+      const factory = buildFactory()
+      const { imports, checklist } = mountBoth(factory)
+
+      await findTickInGroup(checklist, 'Imports').trigger('click')
+      await imports.vm.$nextTick()
+
+      expect(factory.inputs[0].completed).toBe(true)
+      expect(isChecked(findTick(imports))).toBe(true)
+    })
+  })
+
+  describe('Exports', () => {
+    const mountBoth = (producer: Factory, consumer: Factory) => {
+      const factories = [producer, consumer]
+      const global = {
+        plugins: [vuetify],
+        provide: {
+          updateFactory: () => {},
+          findFactory: (id: string | number) => factories.find(f => f.id === Number(id)) as Factory,
+          navigateToFactory: () => {},
+        },
+      }
+      const satisfaction = mount(PlannerFactorySatisfactionItems, { propsData: { factory: producer }, global })
+      const checklist = mount(PlannerFactoryChecklist, { propsData: { factory: producer }, global })
+      return { satisfaction, checklist }
+    }
+
+    const buildFactories = () => {
+      const producer = reactive(newFactory('Iron Ingots', 0, 1)) as Factory
+      const consumer = reactive(newFactory('Iron Plates', 0, 2)) as Factory
+      addProductToFactory(producer, { id: 'IronIngot', amount: 1000, recipe: 'IngotIron' })
+      addProductToFactory(consumer, { id: 'IronPlate', amount: 500, recipe: 'IronPlate' })
+      addInputToFactory(consumer, { factoryId: producer.id, outputPart: 'IronIngot', amount: 500 })
+      calculateFactories([producer, consumer], gameData)
+      producer.checklistEnabled = true
+      return { producer, consumer }
+    }
+
+    it('ticking the export chip checkbox updates its own checkbox', async () => {
+      const { producer, consumer } = buildFactories()
+      const { satisfaction } = mountBoth(producer, consumer)
+
+      expect(isChecked(findTick(satisfaction))).toBe(false)
+      await findTick(satisfaction).trigger('click')
+
+      expect(producer.checklistExports['2:IronIngot']).toBe(true)
+      expect(isChecked(findTick(satisfaction))).toBe(true)
+    })
+
+    it('ticking the export chip checkbox syncs to the Checklist panel', async () => {
+      const { producer, consumer } = buildFactories()
+      const { satisfaction, checklist } = mountBoth(producer, consumer)
+
+      await findTick(satisfaction).trigger('click')
+      await checklist.vm.$nextTick()
+
+      expect(isChecked(findTickInGroup(checklist, 'Exports'))).toBe(true)
+    })
+
+    it('ticking the Checklist panel syncs to the export chip checkbox', async () => {
+      const { producer, consumer } = buildFactories()
+      const { satisfaction, checklist } = mountBoth(producer, consumer)
+
+      await findTickInGroup(checklist, 'Exports').trigger('click')
+      await satisfaction.vm.$nextTick()
+
+      expect(producer.checklistExports['2:IronIngot']).toBe(true)
+      expect(isChecked(findTick(satisfaction))).toBe(true)
+    })
+
+    it('clicking the export chip checkbox does not also open the Export Calculator', async () => {
+      // #592: the checkbox used to live inside the chip's own clickable area, so a click meant
+      // for the tick could also fire the chip's own @click (which opens the calculator tray).
+      const { producer, consumer } = buildFactories()
+      const { satisfaction } = mountBoth(producer, consumer)
+
+      await findTick(satisfaction).trigger('click')
+
+      expect(satisfaction.find('.calculator-row').exists()).toBe(false)
+    })
+  })
+})

--- a/web/src/components/planner/imports/Imports.vue
+++ b/web/src/components/planner/imports/Imports.vue
@@ -24,7 +24,14 @@
         class="status-anchor selectors d-flex flex-column flex-md-row ga-3 px-4 py-2 border-b-md no-bottom"
       >
         <div v-if="factory.checklistEnabled" class="input-row d-flex align-center">
+          <!-- Keyed on the checked value itself (mirrors PlannerFactoryChecklist.vue and
+               PlannerFactorySatisfactionItems.vue's export tick, #592/#593): a `preventDefault()`-
+               cancelled checkbox click can lose a race against the browser's own revert-to-pre-
+               click step, leaving the tick visually stuck even though the underlying state did
+               flip. Keying on the value forces Vue to mount a fresh element at the new value
+               instead of patching the (possibly just-reverted) old one. -->
           <input
+            :key="`${input.factoryId}-${input.outputPart}-${!!input.completed}`"
             :checked="!!input.completed"
             class="checklist-tick"
             :class="{ desynced: isInputChecklistDesynced(input) }"

--- a/web/src/components/planner/products/Product.vue
+++ b/web/src/components/planner/products/Product.vue
@@ -42,7 +42,14 @@
     </div>
     <div class="selectors mt-3 mb-2 d-flex flex-column flex-md-row ga-3">
       <div v-if="factory.checklistEnabled" class="input-row d-flex align-center">
+        <!-- Keyed on the checked value itself (mirrors PlannerFactoryChecklist.vue and
+             PlannerFactorySatisfactionItems.vue's export tick, #592/#593): a `preventDefault()`-
+             cancelled checkbox click can lose a race against the browser's own revert-to-pre-click
+             step, leaving the tick visually stuck even though the underlying state did flip. Keying
+             on the value forces Vue to mount a fresh element at the new value instead of patching
+             the (possibly just-reverted) old one. -->
         <input
+          :key="`${product.id}-${!!product.completed}`"
           :checked="!!product.completed"
           class="checklist-tick"
           :class="{ desynced: isProductChecklistDesynced(product) }"

--- a/web/testing/browser/checklist-checkbox.e2e.mjs
+++ b/web/testing/browser/checklist-checkbox.e2e.mjs
@@ -1,0 +1,264 @@
+// Browser-level regression tests for checklist-mode checkboxes (#592, #593).
+//
+// Two things can't be caught by the (jsdom-backed) unit suite and need a real browser:
+//  - hit-testing: a checkbox nested inside another clickable element (a chip with its own
+//    @click and Vuetify ripple layer) can have its clicks intercepted before they ever reach
+//    the input — jsdom's `trigger('click')` dispatches straight onto the target node and
+//    never exercises real coordinate-based hit-testing, so it can't see this at all.
+//  - the native checkbox click race: a `@click.prevent`-cancelled checkbox click makes the
+//    browser revert the checkbox to its pre-click state as part of canceling the default
+//    action; a naive `:checked` binding can lose that race and never (visually) apply the
+//    real toggle. jsdom's own timing for this does not reliably match a real browser's.
+//
+// Drives the real planner (demo plan) and, for each of Products, Imports and the Exports
+// chip under Satisfaction: real-clicks the checklist tick with actual mouse coordinates,
+// confirms it (a) ends up in the opposite of its prior state and stays there, and (b) that
+// change is reflected in the other place the same tick is drawn (the top-of-card Checklist
+// panel) — in both directions. The Exports case additionally confirms the click doesn't also
+// open the Export Calculator, which is what nesting the tick inside the chip used to do.
+//
+// Run: start the dev server (`pnpm dev:web`, note the port), then from web/:
+//   node testing/browser/checklist-checkbox.e2e.mjs            # against port 3000
+//   PORT=3005 node testing/browser/checklist-checkbox.e2e.mjs  # other port
+// Never run the dev server on port 3001 — vitest's global-setup gameData server binds it.
+// CHROMIUM=/path/to/chromium overrides the browser binary.
+import puppeteer from 'puppeteer-core'
+
+const PORT = process.env.PORT ?? '3000'
+const CHROMIUM = process.env.CHROMIUM ?? '/usr/bin/chromium'
+const BASE = `http://localhost:${PORT}`
+const results = []
+const fail = msg => { results.push(`✗ FAIL: ${msg}`) }
+const pass = msg => { results.push(`✓ ${msg}`) }
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+const browser = await puppeteer.launch({
+  executablePath: CHROMIUM,
+  headless: 'new',
+  args: [
+    '--no-sandbox',
+    '--disable-background-timer-throttling',
+    '--disable-renderer-backgrounding',
+    '--disable-backgrounding-occluded-windows',
+    '--window-size=1600,1200',
+  ],
+})
+
+// Real-clicks the checkbox found by `findFn` (a function serialized and re-run in-page, so it
+// must be self-contained) via actual mouse coordinates, then polls until its `.checked` matches
+// `expected` (or times out). `findFn` is re-run fresh on every poll — never hold a DOM reference
+// across a click, since a checked-value-keyed checkbox is a brand new node afterward.
+const realClickAndAwait = async (page, findFn, expected) => {
+  const box = await page.evaluate(fn => {
+    // eslint-disable-next-line no-eval
+    const input = eval(`(${fn})`)()
+    if (!input) return null
+    input.scrollIntoView({ block: 'center' })
+    const rect = input.getBoundingClientRect()
+    return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
+  }, findFn.toString())
+  if (!box) return 'NOT_FOUND'
+  await sleep(200)
+  await page.mouse.click(box.x, box.y)
+  let checked
+  for (let i = 0; i < 10; i++) {
+    await sleep(300)
+    checked = await page.evaluate(fn => {
+      // eslint-disable-next-line no-eval
+      const input = eval(`(${fn})`)()
+      return input ? input.checked : 'MISSING'
+    }, findFn.toString())
+    if (checked === expected) break
+  }
+  return checked
+}
+
+try {
+  const page = await browser.newPage()
+  await page.setViewport({ width: 1600, height: 1200 })
+  page.on('dialog', d => d.accept())
+  const pageErrors = []
+  page.on('pageerror', e => pageErrors.push(String(e)))
+
+  await page.evaluateOnNewDocument(() => {
+    localStorage.setItem('dismissed-introduction', 'true')
+    localStorage.setItem('seenV51Splash', 'true')
+    localStorage.setItem('seenV6Splash', 'true')
+    localStorage.setItem('buildingGroupTutorialOpened', 'true')
+  })
+
+  // Warm the dev server first: on a cold vite instance the initial dynamic imports can
+  // time out mid-transform and pollute the pageerror log with recoverable noise.
+  await page.goto(BASE, { waitUntil: 'networkidle2' }).catch(() => {})
+  await sleep(1000)
+  await page.goto(`${BASE}/?setupDemo=true`, { waitUntil: 'networkidle2' })
+  await sleep(2000)
+  await page.waitForSelector('.main-content .v-card[id]', { timeout: 15000 })
+
+  // Enable checklist mode on every factory card.
+  const toggleIds = await page.evaluate(() =>
+    [...document.querySelectorAll('input[id$="-checklist-toggle"]')].map(el => el.id))
+  for (const id of toggleIds) {
+    await page.evaluate(toggleId => {
+      document.getElementById(toggleId)?.closest('.v-switch')?.querySelector('.v-selection-control__input')?.click()
+    }, id)
+  }
+  await sleep(1500)
+  if (toggleIds.length > 0) pass(`checklist mode enabled on ${toggleIds.length} factory card(s)`)
+  else fail('no checklist toggles found — demo plan may not have loaded')
+
+  // ---- Products ----
+  {
+    const target = await page.evaluate(() => {
+      const cards = [...document.querySelectorAll('.main-content .v-card[id]')]
+      for (const card of cards) {
+        const items = [...card.querySelectorAll('.factory-item')]
+        for (const item of items) {
+          const input = item.querySelector('input.checklist-tick')
+          if (input) {
+            const select = item.querySelector('input[type="text"]')
+            return { cardId: card.id, itemLabel: select ? select.value : null, before: input.checked }
+          }
+        }
+      }
+      return null
+    })
+    if (!target) {
+      fail('Products: no product checkbox found to test')
+    } else {
+      const expected = !target.before
+      const find = /* re-run in-page */ () => {
+        // eslint-disable-next-line no-undef
+        const card = document.getElementById(TARGET.cardId)
+        const items = [...card.querySelectorAll('.factory-item')]
+        for (const item of items) {
+          const select = item.querySelector('input[type="text"]')
+          // eslint-disable-next-line no-undef
+          if (select?.value === TARGET.itemLabel) return item.querySelector('input.checklist-tick')
+        }
+        return null
+      }
+      await page.evaluate(t => { window.TARGET = t }, target)
+      const after = await realClickAndAwait(page, find, expected)
+      if (after === expected) pass(`Products: real click toggled the row's own checkbox to ${expected}`)
+      else fail(`Products: row checkbox ended at ${after}, expected ${expected}`)
+
+      const syncedToChecklist = await page.evaluate(t => {
+        const card = document.getElementById(t.cardId)
+        const group = [...card.querySelectorAll('.checklist-group')]
+          .find(g => g.querySelector('.checklist-group-title')?.textContent.trim() === 'Products')
+        if (!group) return 'NO_GROUP'
+        const row = [...group.querySelectorAll('.checklist-row')].find(r => r.textContent.includes(t.itemLabel))
+        return row ? row.querySelector('input.checklist-tick')?.checked : 'ROW_NOT_FOUND'
+      }, target)
+      if (syncedToChecklist === expected) pass(`Products: Checklist panel reflects the same product as ${expected}`)
+      else fail(`Products: Checklist panel shows ${syncedToChecklist}, expected ${expected}`)
+
+      // Reverse direction: toggle it back via the Checklist panel, confirm the product row follows.
+      const backExpected = target.before
+      const findViaChecklist = () => {
+        // eslint-disable-next-line no-undef
+        const card = document.getElementById(TARGET.cardId)
+        const group = [...card.querySelectorAll('.checklist-group')]
+          .find(g => g.querySelector('.checklist-group-title')?.textContent.trim() === 'Products')
+        // eslint-disable-next-line no-undef
+        const row = [...group.querySelectorAll('.checklist-row')].find(r => r.textContent.includes(TARGET.itemLabel))
+        return row ? row.querySelector('input.checklist-tick') : null
+      }
+      const backResult = await realClickAndAwait(page, findViaChecklist, backExpected)
+      const productRowBack = await page.evaluate(t => {
+        const card = document.getElementById(t.cardId)
+        const items = [...card.querySelectorAll('.factory-item')]
+        for (const item of items) {
+          const select = item.querySelector('input[type="text"]')
+          if (select?.value === t.itemLabel) return item.querySelector('input.checklist-tick')?.checked
+        }
+        return 'NOT_FOUND'
+      }, target)
+      if (backResult === backExpected && productRowBack === backExpected) {
+        pass('Products: Checklist panel -> product row sync works in reverse too')
+      } else {
+        fail(`Products: reverse sync failed (checklist=${backResult}, row=${productRowBack}, expected ${backExpected})`)
+      }
+    }
+  }
+
+  // ---- Imports ----
+  {
+    const target = await page.evaluate(() => {
+      const cards = [...document.querySelectorAll('.main-content .v-card[id]')]
+      for (const card of cards) {
+        const rows = [...card.querySelectorAll('.status-anchor.selectors')]
+        for (const row of rows) {
+          const input = row.querySelector('input.checklist-tick')
+          if (input) return { cardId: card.id, rowId: row.id, before: input.checked }
+        }
+      }
+      return null
+    })
+    if (!target) {
+      fail('Imports: no import checkbox found to test')
+    } else {
+      const expected = !target.before
+      await page.evaluate(t => { window.TARGET = t }, target)
+      const find = () => {
+        // eslint-disable-next-line no-undef
+        return document.getElementById(TARGET.rowId)?.querySelector('input.checklist-tick')
+      }
+      const after = await realClickAndAwait(page, find, expected)
+      if (after === expected) pass(`Imports: real click toggled the row's own checkbox to ${expected}`)
+      else fail(`Imports: row checkbox ended at ${after}, expected ${expected}`)
+
+      const syncedToChecklist = await page.evaluate(t => {
+        const card = document.getElementById(t.cardId)
+        const group = [...card.querySelectorAll('.checklist-group')]
+          .find(g => g.querySelector('.checklist-group-title')?.textContent.trim() === 'Imports')
+        if (!group) return 'NO_GROUP'
+        const ticks = [...group.querySelectorAll('input.checklist-tick')]
+        return ticks.length === 1 ? ticks[0].checked : ticks.some(i => i.checked)
+      }, target)
+      if (syncedToChecklist === expected) pass(`Imports: Checklist panel reflects the same import as ${expected}`)
+      else fail(`Imports: Checklist panel shows ${syncedToChecklist}, expected ${expected}`)
+    }
+  }
+
+  // ---- Exports (the export chip under a factory's Satisfaction table) ----
+  {
+    const target = await page.evaluate(() => {
+      const rows = [...document.querySelectorAll('tr[id*="-satisfaction-item-"]')]
+      for (const row of rows) {
+        const input = row.querySelector('input.checklist-tick')
+        if (input) return { rowId: row.id, before: input.checked }
+      }
+      return null
+    })
+    if (!target) {
+      fail('Exports: no export chip checkbox found to test')
+    } else {
+      const expected = !target.before
+      await page.evaluate(t => { window.TARGET = t }, target)
+      const find = () => {
+        // eslint-disable-next-line no-undef
+        return document.getElementById(TARGET.rowId)?.querySelector('input.checklist-tick')
+      }
+      const after = await realClickAndAwait(page, find, expected)
+      if (after === expected) pass(`Exports: real click toggled the export chip's own checkbox to ${expected}`)
+      else fail(`Exports: chip checkbox ended at ${after}, expected ${expected}`)
+
+      const calculatorOpened = await page.evaluate(() => !!document.querySelector('.calculator-row'))
+      if (!calculatorOpened) pass('Exports: clicking the tick did not also open the Export Calculator')
+      else fail('Exports: clicking the tick leaked through and opened the Export Calculator')
+    }
+  }
+
+  const realErrors = pageErrors.filter(e => !e.includes('Failed to fetch dynamically imported module'))
+  if (realErrors.length) fail(`page errors: ${realErrors.slice(0, 5).join(' | ')}`)
+  else pass('no page errors during entire run')
+} finally {
+  await browser.close()
+}
+
+console.log(results.join('\n'))
+const failed = results.filter(r => r.includes('FAIL')).length
+console.log(failed ? `\n${failed} FAILURES` : '\nALL BROWSER TESTS PASSED')
+process.exit(failed ? 1 : 0)


### PR DESCRIPTION
## Summary

- Fixes #592 — the checklist tick on an export chip under a factory's Satisfaction table wasn't clickable.
- Fixes #593 — checkboxing products/imports updated the underlying state but didn't visually sync between the item row and the top-of-card Checklist panel.
- Both bugs share a root cause, so this PR fixes it everywhere it appears rather than just in the one reported spot:
  1. **Hit-testing (#592 only).** The export checkbox's `<input>` lived *inside* the export chip's own clickable `v-chip` (which opens the Export Calculator on click and carries Vuetify's ripple/state layer). The chip's own click handling could intercept the click before it reached the checkbox. Moved the checkbox to be a **sibling** of the chip instead, matching the layout `PlannerFactoryChecklist.vue` already uses for the same control.
  2. **A native-checkbox click race (#592 and #593).** Even once a click reaches the checkbox, a `@click.prevent`-controlled checkbox can lose a race against the browser's own "revert checkbox to its pre-click state" behavior that runs as part of canceling a checkbox's default action — the underlying state flips correctly, but the box (and anywhere else that same tick is drawn) can stay visually unticked. `PlannerFactoryChecklist.vue`'s own checkboxes already avoided this by keying the `<input>` on the checked value itself (forcing Vue to mount a fresh element at the new value rather than patch the old, possibly-just-reverted one) — `Product.vue`, `Imports.vue` and the Satisfaction export chip were all missing that key. Added it to all three.

## Tests added

- `web/src/components/planner/checklist-reactivity.spec.ts` — Vitest/`@vue/test-utils` component tests for all three checkbox types (Products, Imports, Exports), covering both sync directions (item row → Checklist panel, and Checklist panel → item row), plus a regression test that clicking the export tick doesn't also open the Export Calculator.
- `web/testing/browser/checklist-checkbox.e2e.mjs` — a new Puppeteer-driven real-browser test (following the existing `reactivity.e2e.mjs` pattern). jsdom's checkbox click/revert timing doesn't reliably match a real browser's, and jsdom can't hit-test a checkbox nested inside another clickable element the way #592's original bug required — so the exact regressions this PR fixes can only be caught with a real browser. Verified this script goes red against the pre-fix code and green against the fix.

## Test plan

- [x] `pnpm exec eslint` on all changed files — clean
- [x] `pnpm exec vue-tsc --noEmit` — clean
- [x] `pnpm test` (full workspace suite: web, backend, parsing) — all passing (2168 web tests, 26 backend, 80 parsing)
- [x] Manually drove the planner in a real (headless) browser via the new `checklist-checkbox.e2e.mjs`: enabled checklist mode, real-mouse-clicked each of the Products/Imports/Exports checkboxes, confirmed each toggles and stays toggled, confirmed the change syncs to the Checklist panel and back, and confirmed the export click no longer leaks through to open the Export Calculator
- [x] Confirmed both new tests actually catch the regressions: temporarily reverted to the pre-fix component code and re-ran `checklist-checkbox.e2e.mjs`, which failed on the Products and Exports checks as expected, then confirmed it passes again with the fix restored