### PR TITLE
feat(repo): add a preview API for preview deployments

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -4,6 +4,7 @@
 - [Satisfactory Factories project](project-satisfactory-factories.md) — logistics planner for the game; my architecture docs live in `docs/architecture/`
 - [Renovate catalog lockfile mismatch](renovate-catalog-lockfile-mismatch.md) — why `sharedWorkspaceLockfile` must stay true; Renovate only ever commits the root lockfile
 - [Backend deploy & prod drift](backend-deploy-and-prod-drift.md) — before assuming the API is deployable from `main`, or reading a green Actions run as a successful deploy
+- [Preview API environment](preview-api-environment.md) — the second API previews point at; shared, port 3002, and nothing puts it back on `main`
 - [Building groups](building-groups-branch-status.md) — how overclocking/somersloops work and their gotchas; shipped, the branch it was built on is dead
 - [Calc engine gotchas](calc-engine-gotchas.md) — double-pass recalc, load-bearing step order, migration patches, and other traps
 - [Tab sync v2 rework](project-tab-sync-v2.md) — in-flight multi-tab sync on branch `tab-sync-v2`; rendering rework deferred to its own plan

--- a/.claude/memory/preview-api-environment.md
+++ b/.claude/memory/preview-api-environment.md
@@ -1,0 +1,63 @@
+---
+name: preview-api-environment
+description: "There is a second API for previews on the same box — one shared instance, port 3002, its own database; the traps are the memory cap, the Mongo authSource, and the fact that nothing puts it back on main"
+metadata: 
+  node_type: memory
+  type: project
+  volatility: normal
+  lastVerified: 2026-08-31
+  originSessionId: 4fbd7ea0-08a1-4d42-8ce2-3729f8ab8246
+  modified: 2026-08-31T03:21:16.895Z
+---
+
+Since **2026-08-31** every Vercel preview points at a **preview API** at
+`api-preview.satisfactory-factories.app` rather than the live one, closing issue #189.
+It is a second compose stack on the same box as production, deliberately sharing almost
+everything with it:
+
+| | production | preview |
+| --- | --- | --- |
+| port / compose dir | 3001, `/root/docker` | 3002, `/root/docker-preview` |
+| image tag | `backend-latest` | `backend-preview` |
+| database | `factory_planner` | `factory_planner_preview`, **same mongod** |
+| built from | `main` on merge | whatever branch was last pointed at it |
+
+`docs/deployment.md` has the full description — read it rather than re-deriving. What is
+worth carrying in advance:
+
+- **There is exactly one preview API, and it is shared.** A branch that changes the wire
+  protocol breaks every other open preview while it is loaded. That is a deliberate trade
+  (backend changes are rare, a container per PR is a lot of machinery), not an oversight.
+- **Nothing puts it back on `main`.** Whatever was deployed last stays deployed for good.
+  Re-run "Backend: Deploy Preview" from the Actions tab against `main` when finished.
+- **A branch gets on it by carrying the `deploy-preview-api` label**, which redeploys on
+  every push to that PR, or by running the workflow by hand.
+
+Three things that cost time to find, all verified on the box:
+
+1. **The 768m `mem_limit` is load-bearing.** `main`'s API is `ts-node backend.ts`, which
+   compiles on boot, and V8 sizes its heap from the cgroup limit — at 512m it OOM-killed on
+   every start (exit 134, "Ineffective mark-compacts near heap limit") and merely looked
+   like a restart loop. The box has 2GB total.
+2. **Preview's Mongo URI needs `?authSource=admin`; production's does not.** The root user
+   was created against production's database, so pointing at a different database name
+   fails with `AuthenticationFailed` until the URI says where to authenticate. First thing
+   to check if preview reports `"database":{"state":"disconnected"}` and production is fine.
+3. **No second secret was needed.** The preview hook's URL is derived from `WEBHOOK_URL` by
+   swapping its last path segment, and `deploy-webhook.yml` refuses to run if rebuilding the
+   *production* hook's URL that way stops reproducing the secret exactly. So a malformed
+   assumption fails loudly instead of POSTing somewhere unintended.
+
+**Why:** the interesting part is what did **not** need building. The webhooks infrastructure
+was already generic — `deploy.sh` takes the compose directory and service list as arguments,
+and `update.sh` is piped over SSH rather than living on the box — so the entire server-side
+addition was one hook entry, and the shared deploy lock serialises preview against production
+for free. Anyone sizing up a second environment here should look at what those scripts already
+take as parameters before writing anything. See [[backend-deploy-and-prod-drift]] for why the
+box's copies of things are the ones that matter.
+
+**How to apply:** the preview stack's compose file is hand-mirrored as
+`backend/docker-compose-preview.yml` and synced by nothing, exactly like production's. Preview
+data is disposable — nothing backs it up and nothing prunes it. `VITE_API_URL` in Vercel's
+**Preview** environment is the single switch that decides where a preview build points; if
+previews ever start writing to live accounts again, look there first.

--- a/.github/workflows/deploy-backend-preview.yml
+++ b/.github/workflows/deploy-backend-preview.yml
@@ -1,0 +1,110 @@
+name: "Backend: Deploy Preview"
+
+# Ships a branch's API to the preview environment:
+#
+#   https://api-preview.satisfactory-factories.app
+#
+# Same three steps as "Backend: Deploy", pointed at the other half of the box —
+# the `backend-preview` image tag, the `satisfactory-factories-preview` hook, the
+# `/root/docker-preview` compose stack on port 3002, and its own Mongo database.
+# See docs/deployment.md for the whole picture.
+#
+# There are two ways in, and they answer different needs:
+#
+#   * Add the `deploy-preview-api` label to a PR. Every push to that PR then
+#     redeploys the preview API from its head commit, which is what you want
+#     while actively building against a backend change.
+#   * Run it by hand from the Actions tab, picking any branch. Use this to put
+#     the preview API back on `main` when you are finished — nothing does that
+#     automatically, and whatever was deployed last stays deployed.
+#
+# THE PREVIEW API IS SHARED. There is one of it, and every Vercel preview points
+# at it. Loading a branch that changes the wire protocol therefore breaks every
+# other open preview until it is put back. That is a deliberate trade — the
+# alternative is a container per PR, and almost all work here is frontend-only.
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: read
+
+# Same reasoning as production: never cancel a run that is already publishing or
+# calling the webhook, because a cancelled publish can leave the moving tag
+# pointing at a half-pushed manifest. Queue behind instead.
+concurrency:
+  group: deploy-backend-preview
+  cancel-in-progress: false
+
+jobs:
+  # A fork PR carries no secrets, so the publish step would fail at the registry
+  # login. Gate on the head repo rather than letting it fail confusingly.
+  gate:
+    name: Should deploy
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.check.outputs.go }}
+    steps:
+      - id: check
+        # Evaluated as one GitHub expression and handed to the shell as a plain
+        # string, rather than interpolated into shell syntax — a `${{ }}` that
+        # expands into the middle of an `if` is how these gates go subtly wrong.
+        env:
+          GO: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'deploy-preview-api')) }}
+        run: |
+          echo "go=$GO" >> "$GITHUB_OUTPUT"
+          [ "$GO" = "true" ] || echo "Not deploying: this needs the \`deploy-preview-api\` label, on a branch in this repository rather than a fork." >> "$GITHUB_STEP_SUMMARY"
+
+  checks:
+    name: Checks
+    needs: gate
+    if: needs.gate.outputs.go == 'true'
+    uses: ./.github/workflows/build-backend.yml
+
+  publish:
+    name: Publish preview image
+    needs: [gate, checks]
+    if: needs.gate.outputs.go == 'true'
+    uses: ./.github/workflows/publish-backend.yml
+    with:
+      push: true
+      moving-tag: backend-preview
+      # Empty on workflow_dispatch, which already checks out the chosen branch.
+      ref: ${{ github.event.pull_request.head.sha || '' }}
+    secrets: inherit
+
+  deploy:
+    name: Deploy
+    needs: [gate, publish]
+    if: needs.gate.outputs.go == 'true'
+    uses: ./.github/workflows/deploy-webhook.yml
+    with:
+      hook: satisfactory-factories-preview
+    secrets: inherit
+
+  verify:
+    name: Verify preview API
+    needs: [gate, deploy]
+    if: needs.gate.outputs.go == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # The hook already blocks on the container's healthcheck, so this is the
+      # end-to-end half: it proves the tunnel in front of the box is still
+      # pointed at a serving container, which the box-side check cannot see.
+      - name: Health check through the public hostname
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            body=$(curl -sS --max-time 15 https://api-preview.satisfactory-factories.app/health) && \
+              echo "$body" | grep -q '"status":"ok"' && {
+                echo "Preview API is serving:"
+                echo "$body"
+                echo "Preview API is serving \`$body\`" >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              }
+            echo "Attempt $attempt: not ready yet."
+            sleep 10
+          done
+          echo "::error::api-preview.satisfactory-factories.app never returned a healthy /health. The image published and the box reported success, so look at the tunnel or the container: ssh sf 'docker logs sf-backend-preview'"
+          exit 1

--- a/.github/workflows/deploy-webhook.yml
+++ b/.github/workflows/deploy-webhook.yml
@@ -13,6 +13,16 @@ name: "Backend: Trigger Deployment Webhook"
 #   WEBHOOK_SECRET  the shared HMAC secret
 on:
   workflow_call:
+    inputs:
+      # Which hook on the webhooks server to poke. Every hook there is the same
+      # URL with a different last path segment, so the preview hook is derived
+      # from WEBHOOK_URL rather than stored as a second secret — see the
+      # derivation below, which refuses to run if that assumption stops holding.
+      hook:
+        description: 'Hook id to call (satisfactory-factories or satisfactory-factories-preview)'
+        type: string
+        required: false
+        default: satisfactory-factories
 
 permissions:
   contents: read
@@ -33,8 +43,21 @@ jobs:
         env:
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
           WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+          HOOK: ${{ inputs.hook }}
         run: |
-          body='{"application":"satisfactory-factories"}'
+          # WEBHOOK_URL is the production hook's full URL. Rebuild it from its own
+          # base and the default hook id: if that does not reproduce the secret
+          # byte for byte, this derivation is wrong and the preview URL would
+          # point somewhere unintended, so stop rather than POST blind. The URL is
+          # never echoed — this repo is public and the host is not.
+          base="${WEBHOOK_URL%/*}"
+          if [ "$base/satisfactory-factories" != "$WEBHOOK_URL" ]; then
+            echo "::error::WEBHOOK_URL does not end in '/satisfactory-factories', so the hook URL cannot be derived. Fix the secret's shape or give the preview hook its own secret."
+            exit 1
+          fi
+          url="$base/${HOOK}"
+
+          body="{\"application\":\"${HOOK}\"}"
           signature=$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -r | cut -d' ' -f1)
 
           # The hook answers 200 or 500 carrying the deploy's own output, so this
@@ -46,4 +69,4 @@ jobs:
             --header "X-Hub-Signature-256: sha256=$signature" \
             --header "X-Hub-SHA: $GITHUB_SHA" \
             --data "$body" \
-            "$WEBHOOK_URL"
+            "$url"

--- a/.github/workflows/publish-backend.yml
+++ b/.github/workflows/publish-backend.yml
@@ -14,6 +14,23 @@ on:
         type: boolean
         required: false
         default: false
+      # The moving tag the box's compose file pulls. Production's is
+      # backend-latest; the preview stack pulls backend-preview. The SHA tag
+      # below is unconditional and identical in both cases, so a preview build
+      # is rollback-addressable exactly like a production one.
+      moving-tag:
+        description: 'The moving Docker tag to publish (backend-latest or backend-preview)'
+        type: string
+        required: false
+        default: backend-latest
+      # Preview deploys build the PR's head commit, not the merge commit a
+      # pull_request event checks out by default, so the image matches the
+      # frontend Vercel built from the same head.
+      ref:
+        description: 'Git ref to build (defaults to the triggering ref)'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -28,6 +45,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      # The SHA tag has to name the commit that was actually built. github.sha is
+      # the MERGE commit on a pull_request event, which is not what a preview
+      # deploy checks out, so a rollback to that tag would fetch code that was
+      # never published. Read it back off the checkout instead.
+      - id: built
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v4
 
@@ -54,13 +80,14 @@ jobs:
           file: backend/Dockerfile
           platforms: linux/amd64
           push: ${{ inputs.push }}
-          # Two tags per build. `backend-latest` is the moving one that the
-          # server's compose file pulls; the SHA-pinned one exists so a bad
-          # deploy can be rolled back to an exact commit without a rebuild.
+          # Two tags per build. The moving one is what the server's compose file
+          # pulls — `backend-latest` for production, `backend-preview` for the
+          # preview stack; the SHA-pinned one exists so a bad deploy can be
+          # rolled back to an exact commit without a rebuild.
           # The `backend-` prefix leaves the repo free to hold other components
           # later, and matches the tag the GHCR image already used.
           tags: |
-            maelstromeous/satisfactory-factories:backend-latest
-            maelstromeous/satisfactory-factories:backend-${{ github.sha }}
+            maelstromeous/satisfactory-factories:${{ inputs.moving-tag }}
+            maelstromeous/satisfactory-factories:backend-${{ steps.built.outputs.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,9 @@ This is the core of the app. Everything else is UI around it.
 
 ### Backend (`backend/backend.ts`)
 
-Single-file Express app. Routes: `/register`, `/login`, `/validate-token` (JWT), `/save` + `/load` (authenticated plan sync), `/share` + `/share/:id` (shareable plans, rate-limited), `/hello` (liveness) and `/health` (liveness + a Mongo ping, 503 when the database is unreachable — this is what uptime monitoring points at). Mongoose models in `backend/models/`. API base URL is selected in `web/src/config/config.ts` by `VITE_ENV`.
+Single-file Express app. Routes: `/register`, `/login`, `/validate-token` (JWT), `/save` + `/load` (authenticated plan sync), `/share` + `/share/:id` (shareable plans, rate-limited), `/hello` (liveness) and `/health` (liveness + a Mongo ping, 503 when the database is unreachable — this is what uptime monitoring points at). Mongoose models in `backend/models/`. API base URL is selected in `web/src/config/config.ts`: `VITE_API_URL` wins if set, otherwise `VITE_ENV` picks between localhost and production.
+
+There is a **preview API** at `api-preview.satisfactory-factories.app` that every Vercel preview build points at, so no preview can touch live data. It is one shared instance — put a branch on it with the `deploy-preview-api` label, and put it back on `main` by hand afterwards, because nothing does that automatically. See `docs/deployment.md`.
 
 ### Game data versioning (important, easy to get wrong)
 

--- a/backend/backend.ts
+++ b/backend/backend.ts
@@ -23,6 +23,7 @@ import {
   minimumClientVersion
 } from "./utils/client-version";
 import { appVersion } from "./utils/app-version";
+import { isAllowedOrigin, parseExtraOrigins } from "./utils/cors";
 
 dotenv.config();
 
@@ -81,9 +82,15 @@ app.use(Express.urlencoded({ limit: '20mb', extended: true }));
 app.set('trust proxy', 1); // Trust first proxy
 app.use(apiRateLimit);
 
+// Read once at boot. Empty in production, which leaves CORS exactly as it was; the preview
+// API sets it, because Vercel gives each preview deployment a fresh hostname.
+const EXTRA_ORIGINS = parseExtraOrigins(process.env.CORS_EXTRA_ORIGINS);
+
 // Add CORS middleware
 app.use(cors({
-  origin: ['http://localhost:3000', 'https://api.satisfactory-factories.app'], // Replace with your allowed origins, e.g., 'http://localhost:3000' or specific domains
+  // A request with no Origin header is not a browser cross-origin call, and gets the same
+  // treatment the previous array form gave it: allowed through, with nothing reflected back.
+  origin: (origin, callback) => callback(null, origin === undefined || isAllowedOrigin(origin, EXTRA_ORIGINS)),
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   // X-Planner-Version has to be allowed or the browser's preflight blocks every request from
   // the planner, and the outdated marker has to be exposed or scripts cannot read it.

--- a/backend/docker-compose-preview.yml
+++ b/backend/docker-compose-preview.yml
@@ -1,0 +1,48 @@
+# The preview API. Lives on the box at /root/docker-preview/docker-compose.yml —
+# this copy is a hand-maintained mirror, exactly like docker-compose-server.yml,
+# and nothing syncs it. Change one, change the other.
+#
+# What makes this different from production:
+#   - it pulls the `backend-preview` tag, published by "Backend: Deploy Preview"
+#     from whichever branch was asked for, rather than `backend-latest` from main
+#   - it listens on 3002, because 3001 is production's and both run on one box
+#   - it has no mongo service. It reuses production's mongod with a DIFFERENT
+#     DATABASE NAME, so the data is separate while the memory cost is not paid
+#     twice. That is why the network below is external.
+services:
+  backend:
+    image: maelstromeous/satisfactory-factories:backend-preview
+    restart: always
+    container_name: sf-backend-preview
+    networks:
+      - backend
+    env_file:
+      - sf-preview.env
+    # 3002 on both sides. The app takes its port from PORT in sf-preview.env, so
+    # this is still the "no translation anywhere" rule production follows — the
+    # number is simply 3002 instead of 3001, all the way through. The Cloudflare
+    # tunnel for api-preview.satisfactory-factories.app resolves to this port.
+    ports:
+      - "3002:3002"
+    command: pnpm start
+    # Preview must never be able to starve production. Do not lower this: main's
+    # API runs `ts-node backend.ts`, which compiles the whole app on boot and
+    # needs well over 512MB of V8 heap — at 512m it OOM-killed on every start
+    # (exit 134, "Ineffective mark-compacts near heap limit"). V8 sizes its heap
+    # from the cgroup limit, so the cap is what decides this, not the app.
+    # PR #620's API runs compiled dist/ and is much lighter, but the cap has to
+    # suit whichever branch is loaded.
+    mem_limit: 768m
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3002/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+networks:
+  # Production's network, joined rather than created — this is how the preview
+  # container reaches the `sf-db` container without a second mongod.
+  backend:
+    name: sf-backend
+    external: true

--- a/backend/utils/cors.spec.ts
+++ b/backend/utils/cors.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAllowedOrigin, parseExtraOrigins, STATIC_ORIGINS } from './cors';
+
+describe('parseExtraOrigins', () => {
+  it('returns nothing when the variable is unset, which is production', () => {
+    expect(parseExtraOrigins(undefined)).toEqual([]);
+    expect(parseExtraOrigins('')).toEqual([]);
+  });
+
+  it('splits on commas and tolerates the spacing a human would type', () => {
+    expect(parseExtraOrigins(' *.vercel.app , https://example.com ,, ')).toEqual([
+      '*.vercel.app',
+      'https://example.com'
+    ]);
+  });
+});
+
+describe('isAllowedOrigin', () => {
+  it('allows the static origins with no configuration at all', () => {
+    for (const origin of STATIC_ORIGINS) {
+      expect(isAllowedOrigin(origin, [])).toBe(true);
+    }
+  });
+
+  it('refuses anything else when nothing extra is configured', () => {
+    expect(isAllowedOrigin('https://satisfactory-factories.app', [])).toBe(false);
+    expect(isAllowedOrigin('https://sf-abc123.vercel.app', [])).toBe(false);
+  });
+
+  it('allows an exact extra origin', () => {
+    expect(isAllowedOrigin('https://example.com', ['https://example.com'])).toBe(true);
+    expect(isAllowedOrigin('https://example.com.evil.net', ['https://example.com'])).toBe(false);
+  });
+
+  it('allows any subdomain of a wildcard entry', () => {
+    const extra = ['*.vercel.app'];
+    expect(isAllowedOrigin('https://sf-abc123.vercel.app', extra)).toBe(true);
+    expect(isAllowedOrigin('https://a.b.vercel.app', extra)).toBe(true);
+  });
+
+  it('does not let a wildcard match the bare domain or a lookalike', () => {
+    const extra = ['*.vercel.app'];
+    expect(isAllowedOrigin('https://vercel.app', extra)).toBe(false);
+    expect(isAllowedOrigin('https://notvercel.app', extra)).toBe(false);
+    expect(isAllowedOrigin('https://vercel.app.evil.net', extra)).toBe(false);
+  });
+
+  it('matches the hostname, not the raw string', () => {
+    const extra = ['*.vercel.app'];
+    // The whole reason the check parses the URL: both of these end in '.vercel.app'.
+    expect(isAllowedOrigin('https://evil.com/#.vercel.app', extra)).toBe(false);
+    expect(isAllowedOrigin('https://evil.com/?x=.vercel.app', extra)).toBe(false);
+  });
+
+  it('refuses an unparseable origin rather than throwing', () => {
+    expect(isAllowedOrigin('not-a-url', ['*.vercel.app'])).toBe(false);
+  });
+});

--- a/backend/utils/cors.ts
+++ b/backend/utils/cors.ts
@@ -1,0 +1,30 @@
+// Which origins this deployment answers cross-origin calls from. Kept pure and away from
+// Express so it can be unit tested — see cors.spec.ts.
+//
+// Production leaves CORS_EXTRA_ORIGINS unset and keeps exactly the static list. The preview
+// API sets it, because Vercel gives every preview deployment a fresh hostname and there is no
+// list to enumerate in advance.
+
+// The origins every deployment allows, whatever the environment says.
+export const STATIC_ORIGINS = ['http://localhost:3000', 'https://api.satisfactory-factories.app'];
+
+// Comma-separated. An entry starting with `*.` matches any subdomain of the rest of it, so
+// `*.vercel.app` covers every preview deployment; anything else is an exact origin match.
+export const parseExtraOrigins = (raw: string | undefined): string[] =>
+  (raw ?? '').split(',').map(entry => entry.trim()).filter(Boolean);
+
+export const isAllowedOrigin = (origin: string, extra: string[]): boolean => {
+  if (STATIC_ORIGINS.includes(origin)) return true;
+
+  return extra.some(entry => {
+    if (!entry.startsWith('*.')) return entry === origin;
+
+    // Match on the parsed hostname rather than the raw string. Substring matching here would
+    // accept 'https://evil.com/#.vercel.app', and a wildcard is exactly where that gets tried.
+    try {
+      return new URL(origin).hostname.endsWith(entry.slice(1));
+    } catch {
+      return false;
+    }
+  });
+};

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,8 +4,10 @@ How a merge to `main` becomes a running API, what can go wrong, and how to tell
 whether a deploy actually landed.
 
 For the release philosophy across all three packages see
-[how-do-we-release.md](./how-do-we-release.md). This document is only about
-`backend/`. The web app deploys itself via Vercel and needs none of this.
+[how-do-we-release.md](./how-do-we-release.md). This document is about `backend/`:
+the production API, and the [preview API](#the-preview-api) beside it. The web app
+deploys itself via Vercel and needs none of this, beyond the one environment
+variable that tells a preview build which API to talk to.
 
 ---
 
@@ -183,6 +185,111 @@ surfaces the case where the box's compose file has no healthcheck at all — in
 that situation `--wait` quietly degrades to "is it running", and most of the
 guarantee in point 2 is gone without anything saying so.
 
+## The preview API
+
+There is a second API on the same box, at
+**https://api-preview.satisfactory-factories.app**, and **every Vercel preview
+build points at it**. That is the whole reason it exists: before it, a preview
+deployment talked to the live API, so any PR touching the backend — or touching
+how the frontend talks to it — could only be tested by shipping it to production
+first, and any preview could write to real accounts. See issue #189.
+
+| | production | preview |
+| --- | --- | --- |
+| hostname | `api.satisfactory-factories.app` | `api-preview.satisfactory-factories.app` |
+| port on the box | 3001 | 3002 |
+| compose dir | `/root/docker` | `/root/docker-preview` |
+| container | `sf-backend` | `sf-backend-preview` |
+| image tag | `backend-latest` | `backend-preview` |
+| database | `factory_planner` | `factory_planner_preview` |
+| built from | `main`, on merge | whatever branch you point it at |
+| repo mirror | `backend/docker-compose-server.yml` | `backend/docker-compose-preview.yml` |
+| workflow | `deploy-backend.yml` | `deploy-backend-preview.yml` |
+| hook | `satisfactory-factories` | `satisfactory-factories-preview` |
+
+Everything else is shared, deliberately. It runs on the same box, behind the same
+tunnel, through the same webhook server, and against the **same mongod** — just a
+different database on it, so the data is separate without paying for a second
+Mongo on a 2GB box. It also takes the same lock as a production deploy, so the two
+can never interleave.
+
+### Putting a branch on it
+
+Two ways in, for two different moments:
+
+- **Label the PR `deploy-preview-api`.** Every push to that PR then redeploys the
+  preview API from its head commit. This is what you want while actively building
+  against a backend change.
+- **Run "Backend: Deploy Preview" from the Actions tab**, picking any branch. This
+  is how you put it *back* on `main` when you are done.
+
+**Nothing puts it back on its own.** Whatever was deployed last stays deployed,
+indefinitely.
+
+### The shared-instance trade
+
+There is one preview API, and every preview points at it. So a branch that
+changes the wire protocol breaks every *other* open preview for as long as it is
+loaded. That is accepted rather than solved: almost all work here is frontend,
+the backend changes maybe twice a year, and a container per PR is a great deal of
+machinery to carry for that. If it does become a problem, the shape of the answer
+is a container per PR on a wildcard hostname, which is what issue #189 originally
+asked for.
+
+Concretely: while PR #620 is loaded, other previews will fail against it, because
+it gates every route on a protocol version header they do not send.
+
+### How the frontend finds it
+
+`VITE_API_URL` overrides everything in `web/src/config/config.ts`. Vercel sets it
+on the **Preview** environment only; production leaves it unset and falls through
+to the live API, and local dev falls through to `localhost:3001` as before. There
+is no branch logic in the code — a build points wherever its environment says.
+
+### CORS
+
+A Vercel preview gets a fresh hostname per deployment, so there is no list to
+enumerate. The preview API takes `CORS_EXTRA_ORIGINS` from its env file instead: a
+comma-separated list where an entry may start with `*.` to match any subdomain.
+It is unset in production, which leaves production's CORS exactly as it was.
+
+The matcher parses the origin and compares hostnames rather than doing a string
+suffix test, because `https://evil.com/#.vercel.app` ends in `.vercel.app` too.
+See `backend/utils/cors.spec.ts`.
+
+### Verifying it
+
+```bash
+curl -s https://api-preview.satisfactory-factories.app/health
+# {"status":"ok","uptime":624,"database":{"status":"ok","state":"connected",...}}
+
+ssh sf 'docker ps --format "{{.Names}}\t{{.Image}}\t{{.Status}}"'
+# sf-backend-preview  maelstromeous/satisfactory-factories:backend-preview  Up 10 minutes (healthy)
+```
+
+`/root/deploy.log` on the box carries preview and production deploys interleaved;
+the `Deploy requested` line names the compose directory the run was for.
+
+### Things that will catch you here
+
+- **The memory cap is load-bearing.** `mem_limit` is 768m. `main`'s API runs
+  `ts-node backend.ts`, which compiles on boot; V8 sizes its heap from the cgroup
+  limit, so at 512m it OOM-killed on every single start — exit 134, "Ineffective
+  mark-compacts near heap limit", and a container that looks like it is merely
+  restarting. Do not lower it to make room for something.
+- **The preview Mongo URI needs `?authSource=admin` and production's does not.**
+  The root user was created against production's database, so authenticating
+  against a *different* database name fails with `AuthenticationFailed` unless the
+  URI says where to authenticate. This is the first thing to check if preview
+  reports `"database":{"state":"disconnected"}` while production is fine.
+- **`/root/docker-preview/docker-compose.yml` is hand-mirrored**, exactly like
+  production's, and nothing syncs it. Its mirror here is
+  `backend/docker-compose-preview.yml`.
+- **The preview JWT secret is its own**, generated on the box and never shared
+  with production, so a token minted by preview is worthless against the live API.
+- **Preview data is disposable.** Nothing backs up `factory_planner_preview`, and
+  nothing prunes it either.
+
 ## Verifying a deploy
 
 ```bash
@@ -280,6 +387,17 @@ Repository secrets (Settings → Secrets and variables → Actions):
 > The webhook secret is **shared across every project** on that server. A repo
 > that can trigger this deploy can trigger the others too.
 
+In Vercel (Settings -> Environment Variables), one-off:
+
+| Variable | Environment | Value |
+| --- | --- | --- |
+| `VITE_API_URL` | **Preview** only | `https://api-preview.satisfactory-factories.app` |
+
+Leave it unset for Production and Development. Unset means the build falls through
+to the live API, which is the old behaviour and the thing the preview API exists to
+stop — so if previews start writing to real accounts again, this variable is the
+first place to look.
+
 On the box (`ssh sf`), one-off, and not done by any deploy:
 
 - `/root/docker/docker-compose.yml` must match `backend/docker-compose-server.yml`
@@ -291,3 +409,13 @@ On the box (`ssh sf`), one-off, and not done by any deploy:
 - `/root/update.sh` must match `backend/update.sh`, mode `755`.
 - The webhooks box's deploy key must be in `/root/.ssh/authorized_keys`
   (fingerprint `SHA256:Y69lglv47Mp3dkMh9a/CL1u9PmYldx4u+NTDb0QiFDs`).
+- For the preview API: `/root/docker-preview/docker-compose.yml` must match
+  `backend/docker-compose-preview.yml`, and `/root/docker-preview/sf-preview.env`
+  must exist beside it, mode 600. It carries the same Mongo credentials as
+  production with `factory_planner_preview` as the database and
+  `?authSource=admin` appended, its own generated `JWT_SECRET`, `PORT=3002`,
+  `ENVIRONMENT=preview`, and `CORS_EXTRA_ORIGINS`.
+- The `satisfactory-factories-preview` hook must be loaded on the webhooks box
+  (`cd /root/webhooks && ./sync.sh`). It needs no new secret here: the preview
+  hook's URL is derived from `WEBHOOK_URL` by swapping the last path segment, and
+  the workflow refuses to run if that derivation stops reproducing the secret.

--- a/web/src/config/config.ts
+++ b/web/src/config/config.ts
@@ -1,8 +1,8 @@
 // VITE_API_URL overrides everything, and is how a build is pointed somewhere other than the
 // two defaults. Vercel sets it to the preview API for the Preview environment, so no preview
 // deployment can read or write live plans; production leaves it unset. See docs/deployment.md.
-const apiUrl = import.meta.env.VITE_API_URL
-  || (import.meta.env.VITE_ENV === 'dev' ? 'http://localhost:3001' : 'https://api.satisfactory-factories.app')
+const apiUrl = import.meta.env.VITE_API_URL ||
+  (import.meta.env.VITE_ENV === 'dev' ? 'http://localhost:3001' : 'https://api.satisfactory-factories.app')
 
 export const config = {
   apiUrl,

--- a/web/src/config/config.ts
+++ b/web/src/config/config.ts
@@ -1,5 +1,11 @@
+// VITE_API_URL overrides everything, and is how a build is pointed somewhere other than the
+// two defaults. Vercel sets it to the preview API for the Preview environment, so no preview
+// deployment can read or write live plans; production leaves it unset. See docs/deployment.md.
+const apiUrl = import.meta.env.VITE_API_URL
+  || (import.meta.env.VITE_ENV === 'dev' ? 'http://localhost:3001' : 'https://api.satisfactory-factories.app')
+
 export const config = {
-  apiUrl: import.meta.env.VITE_ENV === 'dev' ? 'http://localhost:3001' : 'https://api.satisfactory-factories.app',
+  apiUrl,
   // This build's version, from the repo root package.json. Sent on every API request so the
   // backend can refuse writes from a tab too old to know the current save shape. Nothing to do
   // with `plannerVersion` below, which is a property of a plan rather than of the app.

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -3,6 +3,9 @@
 interface ImportMetaEnv {
   // Stamped in by vite.config.mts from the repo root package.json.
   readonly VITE_APP_VERSION: string
+  // Set by Vercel on the Preview environment only, pointing at the preview API.
+  // Absent in production and in local dev, where config.ts falls back.
+  readonly VITE_API_URL?: string
 }
 
 declare module '*.vue' {


### PR DESCRIPTION
# ⚠️ Four manual steps, in this order

The preview API is **already up and serving** — I built the stack on the box by hand so the plumbing could be proven before the automation existed. What is not yet wired is the automatic redeploy and the frontend pointing at it. None of this is safe to skip.

**1. Merge [Maelstromeous/webhooks#25](https://github.com/Maelstromeous/webhooks/pull/25), then run `./sync.sh` on the webhooks box.** That PR adds the `satisfactory-factories-preview` hook. I could not merge it myself — the harness blocked the merge. Until it lands and syncs, the new hook 404s and "Backend: Deploy Preview" fails at its last step. No new secret is involved.

```bash
ssh webhooks 'cd /root/webhooks && ./sync.sh'
```

**2. Add `VITE_API_URL` in Vercel**, Settings → Environment Variables:

| Variable | Environment | Value |
| --- | --- | --- |
| `VITE_API_URL` | **Preview** only | `https://api-preview.satisfactory-factories.app` |

Leave it unset for Production and Development. **Until this is set, previews keep talking to the live API** — the deploy is safe without it, it simply does not deliver the point of the change.

**3. After merging, run "Backend: Deploy Preview" once against `main`.** The preview API is currently running an image I seeded by hand from the *existing* `backend-latest`, so it does not yet have the `CORS_EXTRA_ORIGINS` support in this PR — Vercel preview origins will be blocked until it is rebuilt. Merging this does not redeploy it on its own, and deliberately so: an automatic redeploy on every merge to `main` would clobber a branch someone had loaded for testing.

**4. Nothing puts the preview API back on `main` either.** Whatever branch was deployed last stays deployed for good. Re-run "Backend: Deploy Preview" against `main` from the Actions tab when you have finished with a branch.

There is no migration and no production behaviour change here. Production keeps `backend-latest`, port 3001, its own database, its own hook, and its CORS list is byte-identical because `CORS_EXTRA_ORIGINS` is unset there.

---

## What this is

Closes #189.

Every Vercel preview has always talked to the live API. That is fine while the work is frontend-only, which it nearly always is, but it means two things: a PR that changes the backend cannot be tested without shipping it to production first, and any preview build can read and write real accounts.

There is now a second API beside production on the same box:

| | production | preview |
| --- | --- | --- |
| hostname | `api.satisfactory-factories.app` | `api-preview.satisfactory-factories.app` |
| port | 3001 | 3002 |
| compose dir | `/root/docker` | `/root/docker-preview` |
| image tag | `backend-latest` | `backend-preview` |
| database | `factory_planner` | `factory_planner_preview`, **same mongod** |
| built from | `main`, on merge | whatever branch you point at it |
| hook | `satisfactory-factories` | `satisfactory-factories-preview` |

Everything else is shared on purpose: same box, same tunnel, same webhook server, same mongod under a different database name, and the same deploy lock — so a preview deploy and a production deploy can never interleave.

## How little of this is new

The interesting part is what did **not** need building. The webhooks infrastructure was already generic: `deploy.sh` takes the compose directory and the service list as arguments, and `update.sh` is piped over SSH rather than living on the target box. So the entire server-side addition is one hook entry, and the shared lock came free.

On this side it is two inputs, both defaulting to today's values:

- `publish-backend.yml` gains `moving-tag` (`backend-latest` → `backend-preview`) and `ref`.
- `deploy-webhook.yml` gains `hook`.

**No new secret.** The preview hook's URL is derived from `WEBHOOK_URL` by swapping its last path segment. Rather than trust that, the workflow rebuilds the *production* hook's URL the same way and refuses to run if the result is not byte-identical to the secret — so a wrong assumption fails loudly instead of POSTing somewhere unintended. The URL is never echoed.

## Putting a branch on it

- **Label a PR `deploy-preview-api`** (label created) and every push to it redeploys the preview API from its head commit.
- **Or run the workflow by hand** against any branch, which is how you put it back on `main`.

## The shared-instance trade

There is one preview API and every preview points at it, so a branch that changes the wire protocol breaks every other open preview while it is loaded. That is accepted rather than solved. The backend changes about twice a year, and a container per PR is a lot of machinery to carry for that; the shape of the answer, if it ever becomes a problem, is a container per PR on a wildcard hostname.

Concretely: while #620 is loaded, other previews will fail against it, since it gates every route on a version header they do not send.

## CORS

A Vercel preview gets a fresh hostname per deployment, so there is nothing to enumerate. The origin list moves to `backend/utils/cors.ts` and reads `CORS_EXTRA_ORIGINS`, a comma-separated list where an entry may start with `*.` to match any subdomain. Production leaves it unset.

It compares parsed hostnames rather than doing a string suffix test, because `https://evil.com/#.vercel.app` also ends in `.vercel.app`. That case is in `cors.spec.ts`.

## Three things that cost real time, all now written down

- **The 768m memory cap is load-bearing.** `main`'s API is `ts-node backend.ts`, which compiles on boot, and V8 sizes its heap from the cgroup limit. At 512m it OOM-killed on every start (exit 134, "Ineffective mark-compacts near heap limit") and looked like an ordinary restart loop.
- **Preview's Mongo URI needs `?authSource=admin` and production's does not.** The root user was created against production's database, so pointing at a different database name fails with `AuthenticationFailed` until the URI says where to authenticate.
- **The SHA image tag has to name the commit actually built.** `github.sha` is the *merge* commit on a `pull_request` event, so a rollback to that tag would have fetched code that was never published. It now reads the SHA back off the checkout.

## Validation

Done against the live box:

- `curl https://api-preview.satisfactory-factories.app/health` → `200`, `database.state: connected`, through the real tunnel
- `listDatabases` shows `factory_planner_preview` at 32KB beside `factory_planner` at 42MB — preview is on its own empty database
- The box-side deploy path was exercised with the exact script the hook pipes over SSH (`update.sh /root/docker-preview backend`). It correctly **failed loudly** — the `backend-preview` tag is not in Docker Hub until CI publishes it — rather than reporting success, and left the running container untouched
- Production `/health` returned `200` externally throughout, before and after
- backend: 35 tests pass (26 before, 9 new for the origin matcher), `tsc` clean, lint clean apart from three pre-existing `any` warnings
- web: full Vitest suite passes, `vue-tsc --noEmit` clean
- all ten workflow files parse

## Separate problem found on the way, not fixed here

**Production's container healthcheck has been failing since the box was rebooted, and users are not affected.** `docker exec sf-backend` fetching its own `/health` returns **429** consistently, with `retry-after: 1830`, while the same endpoint returns `200` externally and `200` from another container over the docker network — so only the loopback rate-limit bucket is saturated. Nothing on the box appears to be polling it.

It matters because `docker compose up -d --wait` blocks on that healthcheck, so **the next production backend deploy will fail at the wait step** even though the image is fine. Nothing in `main` has a 30-minute window, which suggests the running image disagrees with `main` again. The preview stack is unaffected — it healthchecks 3002 and reports healthy. Left alone deliberately: it is a production bug that predates this branch and does not belong in a preview-API PR.

## Follow-up for #620

Once steps 1 and 2 are done, labelling #620 with `deploy-preview-api` will put it on the preview API. It will also need the same CORS treatment in its own `backend/src/config/cors.ts` — its `WEB_ORIGINS` is a fixed list and will reject every Vercel preview origin. It does not inherit this branch's change, because that file is part of its rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
