### PR TITLE
fix(backend): exempt loopback from the /health rate limit

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -40,3 +40,4 @@
 - [Building group balance tolerance](building-group-balance-tolerance.md) — balanced is a percentage of the item's demand with a ceiling, and changing it has to force a recalc
 - [Input debounce window](input-debounce-window.md) — the timer does reset per keystroke; the 250ms window is just shorter than typing, and reverse-solving inputs compound partial values
 - [Stale branch: cherry-pick, don't merge](stale-branch-cherry-pick-not-merge.md) — squash merges make a merge-forward conflict on 70 files where a cherry-pick conflicts on 2
+- [Clock step freezes rate limits](clock-step-freezes-rate-limits.md) — a backwards clock step at boot can 429 the backend container unhealthy; looks like prod drift, is not

--- a/.claude/memory/clock-step-freezes-rate-limits.md
+++ b/.claude/memory/clock-step-freezes-rate-limits.md
@@ -21,9 +21,15 @@ healthcheck alone exhausted the loopback bucket in five minutes and the containe
 with a `retry-after` counting down to a reset an hour away. It self-healed the moment the wall
 clock passed that reset.
 
-**Why it matters:** `update.sh` runs `docker compose up -d --wait`, which blocks on this
-healthcheck, so a deploy attempted inside that window reports `DEPLOY FAILED` on a perfectly good
-image.
+**Why it matters:** the container reports `unhealthy` for as long as the clock offset lasts, which
+is what monitoring and anything healthcheck-gated sees. The deploy risk is narrower than it first
+looks, and worth stating precisely, because `update.sh` runs `docker compose up -d --wait`:
+
+- A deploy publishing a **new** image digest recreates the container, which opens fresh windows
+  against the corrected clock, so it succeeds. This is why the 2026-08-31 10:24 deploy went green.
+- A deploy whose image digest is **unchanged** does not recreate the container, so `--wait` blocks
+  on the stuck healthcheck until it times out and reports `DEPLOY FAILED` on a healthy image.
+- A deploy landing before NTP steps the clock gets a newly created container stuck the same way.
 
 **How to apply:**
 

--- a/.claude/memory/clock-step-freezes-rate-limits.md
+++ b/.claude/memory/clock-step-freezes-rate-limits.md
@@ -1,6 +1,6 @@
 ---
 name: clock-step-freezes-rate-limits
-description: "A backwards clock step at boot parks express-rate-limit windows in the future, so the 30s Docker healthcheck alone can 429 the backend container unhealthy — this looks exactly like prod drift and is not"
+description: "A backwards clock step parks an express-rate-limit window in the future, so the 30s Docker healthcheck alone can 429 the backend container unhealthy — this looks exactly like prod drift and is not"
 metadata:
   node_type: memory
   type: project
@@ -8,45 +8,62 @@ metadata:
   lastVerified: 2026-08-31
 ---
 
-`express-rate-limit`'s MemoryStore expires a window on wall-clock time
-(`client.resetTime.getTime() <= Date.now()`), not a monotonic timer. If the system clock is
-stepped **backwards** after the process starts, every window opened before the step has a
-`resetTime` that `Date.now()` will not reach for as long as the step was large. The window never
-closes, hits accumulate forever, and the key 429s permanently.
+`express-rate-limit`'s MemoryStore expires a window on wall-clock time, verified in the installed
+8.6.2 source: `if (client.resetTime.getTime() <= now) this.resetClient(client, now)`, and
+`resetClient` sets `now + windowMs`. Nothing monotonic is involved. Step the clock **backwards**
+and any window already open has a `resetTime` that `Date.now()` will not reach until real time
+catches up. The window never closes, hits accumulate, and that key 429s until it does.
+
+**The ordering is the part that is easy to get backwards.** The window has to be open *before* the
+step. A process that is started and left alone until after the step is fine; the damage needs a
+request to land first. The key must also stay warm: MemoryStore rotates two maps on a
+`setInterval(windowMs)` timer, so an idle key is eventually dropped, while a regularly polled one
+is carried forward with its frozen `resetTime` and its accumulated count intact. A 30s healthcheck
+is exactly the access pattern that keeps it alive.
 
 Seen on the production API box on 2026-08-31: the box booted with its clock about an hour ahead,
-timesyncd stepped it back ~33 seconds later, and the container had already served its first
-`/health` probe. `healthRateLimit` is `max: 10` per 60s and Docker probes every 30s, so the
-healthcheck alone exhausted the loopback bucket in five minutes and the container sat `unhealthy`
-with a `retry-after` counting down to a reset an hour away. It self-healed the moment the wall
-clock passed that reset.
+the container started and served a `/health` probe, and timesyncd stepped the clock back ~33
+seconds after start. `healthRateLimit` is `max: 10` per 60s and Docker probes every 30s, so the
+healthcheck alone exhausted the loopback bucket in about five minutes. The container then sat
+`unhealthy` with a `retry-after` counting down to a reset an hour away. It self-healed the moment
+the wall clock passed that reset, with no restart and no code change.
 
 **Why it matters:** the container reports `unhealthy` for as long as the clock offset lasts, which
-is what monitoring and anything healthcheck-gated sees. The deploy risk is narrower than it first
-looks, and worth stating precisely, because `update.sh` runs `docker compose up -d --wait`:
+is what monitoring and anything healthcheck-gated sees. The deploy risk is narrower than it looks:
 
 - A deploy publishing a **new** image digest recreates the container, which opens fresh windows
   against the corrected clock, so it succeeds. This is why the 2026-08-31 10:24 deploy went green.
-- A deploy whose image digest is **unchanged** does not recreate the container, so `--wait` blocks
-  on the stuck healthcheck until it times out and reports `DEPLOY FAILED` on a healthy image.
-- A deploy landing before NTP steps the clock gets a newly created container stuck the same way.
+- A deploy whose image digest is **unchanged** does not recreate the container, so `--wait` has to
+  reckon with the existing unhealthy one. Whether that blocks forever, exits, or times out is
+  **unverified** — no `--wait-timeout` is passed, and the deploy path on the box was not confirmed
+  (the repo's `update.sh` is a hand-maintained mirror and was not found running on the host).
+- A container created before the step is only stuck if it also serves a request before the step.
 
 **How to apply:**
 
-- **A `retry-after` that matches no configured window is the tell.** `healthRateLimit` is 60s;
-  anything reporting minutes means a frozen window, not a saturated one. Check
-  `docker inspect <container> --format '{{.State.StartedAt}}'` against `date -u`: a start time in
-  the *future* is the clock step, and `who -b` vs `uptime -s` disagreeing confirms it.
+- **A `retry-after` that matches no configured window is the tell.** `healthRateLimit` is 60s, so
+  anything reporting minutes is a frozen window, not a saturated one. Sample it twice: a value
+  falling 1 per second is a countdown to one fixed instant. Then check
+  `docker inspect <container> --format '{{.State.StartedAt}}'` against `date -u` — a start time in
+  the *future* is the step — and `who -b` against `uptime -s`, which disagree by the offset.
 - **Do not read this as prod drift.** It presents identically to
-  [[backend-deploy-and-prod-drift]] — running image apparently disagreeing with `main` — and on
-  2026-08-31 it was not: `docker exec <container> cat /app/backend/backend.ts` diffed clean
-  against `main`. Diff the running source before believing the drift story.
-- **The bucket is per key, so only the hammered key shows it.** Loopback 429s while the same
-  endpoint answers 200 externally, because tunnel traffic keys by `X-Forwarded-For` and each
-  client has a near-empty window. That asymmetry is a symptom, not evidence that something is
-  polling loopback. Nothing was.
-- **The fix is to exempt loopback from `healthRateLimit`,** which is on `main` as
-  `utils/loopback.ts`. It keys off `req.socket.remoteAddress`, never `req.ip`, because
-  `trust proxy` makes `req.ip` header-derived and therefore claimable. Verified on the box that
-  host-port traffic reaches the container as the docker gateway address rather than `127.0.0.1`,
-  so the exemption really does cover only the container's own healthcheck.
+  [[backend-deploy-and-prod-drift]], and on 2026-08-31 it was not:
+  `docker exec <container> cat /app/backend/backend.ts` diffed clean against `main`. Diff the
+  running source before believing the drift story.
+- **Prove what is consuming the bucket with the failing streak, not with `ss`.** A snapshot cannot
+  see short-lived connections, so it never rules a poller out. The arithmetic does: probes since
+  start minus `FailingStreak` came to exactly `max`, meaning the healthcheck was the only client on
+  that key. Any extra caller would have made the failures outnumber the probes it accounts for.
+- **Healthy now does not mean fixed.** Both the window expiring and the container being replaced
+  clear the symptom without changing a line. Confirm by reading `healthRateLimit` out of the
+  *running* container, then hitting `/health` over loopback more than `max` times: still 429ing
+  means the defect is dormant, and a sane `retry-after` under 60s is what distinguishes dormant
+  from active.
+- **The `/health` fix does not cover the other limiters.** `utils/loopback.ts` exempts loopback
+  from `healthRateLimit` only. `apiRateLimit`, `shareRateLimit` and `versionRateLimit` sit on the
+  same MemoryStore and a client key active across a step can still freeze. That is accepted rather
+  than solved: it self-heals when real time catches up, and no user was affected.
+- **Key off `req.socket.remoteAddress`, never `req.ip`.** `trust proxy` makes `req.ip`
+  header-derived and therefore claimable. Verified on the box that host-port traffic reaches the
+  container as the docker gateway address rather than `127.0.0.1`, so the exemption covers only
+  the container's own healthcheck.

--- a/.claude/memory/clock-step-freezes-rate-limits.md
+++ b/.claude/memory/clock-step-freezes-rate-limits.md
@@ -63,6 +63,16 @@ is what monitoring and anything healthcheck-gated sees. The deploy risk is narro
   from `healthRateLimit` only. `apiRateLimit`, `shareRateLimit` and `versionRateLimit` sit on the
   same MemoryStore and a client key active across a step can still freeze. That is accepted rather
   than solved: it self-heals when real time catches up, and no user was affected.
+- **The NestJS rewrite does not inherit this, for a reason worth knowing.** PR #620 replaces
+  `backend.ts` with `@nestjs/throttler`, keeping `/health` at 10 per 60s and adding no loopback
+  exemption, so it looks like the same setup. It is not. Throttler drains the hit count with
+  `setTimeout(..., ttl)` per hit, and Node timers are monotonic, so a clock step cannot stop the
+  count falling. `expiresAt` is wall-clock but only feeds the reported retry-after. The residual
+  hazard is `blockExpiresAt`: once a key is actually blocked, unblocking waits on `Date.now()`, so
+  a backwards step there would extend the block. Reaching that needs more than 10 hits in 60s,
+  which a 30s probe cannot do. Do not port `utils/loopback.ts` into the Nest config expecting it
+  to fix this; it would be belt-and-braces, not a fix.
+
 - **Key off `req.socket.remoteAddress`, never `req.ip`.** `trust proxy` makes `req.ip`
   header-derived and therefore claimable. Verified on the box that host-port traffic reaches the
   container as the docker gateway address rather than `127.0.0.1`, so the exemption covers only

--- a/.claude/memory/clock-step-freezes-rate-limits.md
+++ b/.claude/memory/clock-step-freezes-rate-limits.md
@@ -1,0 +1,46 @@
+---
+name: clock-step-freezes-rate-limits
+description: "A backwards clock step at boot parks express-rate-limit windows in the future, so the 30s Docker healthcheck alone can 429 the backend container unhealthy — this looks exactly like prod drift and is not"
+metadata:
+  node_type: memory
+  type: project
+  volatility: durable
+  lastVerified: 2026-08-31
+---
+
+`express-rate-limit`'s MemoryStore expires a window on wall-clock time
+(`client.resetTime.getTime() <= Date.now()`), not a monotonic timer. If the system clock is
+stepped **backwards** after the process starts, every window opened before the step has a
+`resetTime` that `Date.now()` will not reach for as long as the step was large. The window never
+closes, hits accumulate forever, and the key 429s permanently.
+
+Seen on the production API box on 2026-08-31: the box booted with its clock about an hour ahead,
+timesyncd stepped it back ~33 seconds later, and the container had already served its first
+`/health` probe. `healthRateLimit` is `max: 10` per 60s and Docker probes every 30s, so the
+healthcheck alone exhausted the loopback bucket in five minutes and the container sat `unhealthy`
+with a `retry-after` counting down to a reset an hour away. It self-healed the moment the wall
+clock passed that reset.
+
+**Why it matters:** `update.sh` runs `docker compose up -d --wait`, which blocks on this
+healthcheck, so a deploy attempted inside that window reports `DEPLOY FAILED` on a perfectly good
+image.
+
+**How to apply:**
+
+- **A `retry-after` that matches no configured window is the tell.** `healthRateLimit` is 60s;
+  anything reporting minutes means a frozen window, not a saturated one. Check
+  `docker inspect <container> --format '{{.State.StartedAt}}'` against `date -u`: a start time in
+  the *future* is the clock step, and `who -b` vs `uptime -s` disagreeing confirms it.
+- **Do not read this as prod drift.** It presents identically to
+  [[backend-deploy-and-prod-drift]] — running image apparently disagreeing with `main` — and on
+  2026-08-31 it was not: `docker exec <container> cat /app/backend/backend.ts` diffed clean
+  against `main`. Diff the running source before believing the drift story.
+- **The bucket is per key, so only the hammered key shows it.** Loopback 429s while the same
+  endpoint answers 200 externally, because tunnel traffic keys by `X-Forwarded-For` and each
+  client has a near-empty window. That asymmetry is a symptom, not evidence that something is
+  polling loopback. Nothing was.
+- **The fix is to exempt loopback from `healthRateLimit`,** which is on `main` as
+  `utils/loopback.ts`. It keys off `req.socket.remoteAddress`, never `req.ip`, because
+  `trust proxy` makes `req.ip` header-derived and therefore claimable. Verified on the box that
+  host-port traffic reaches the container as the docker gateway address rather than `127.0.0.1`,
+  so the exemption really does cover only the container's own healthcheck.

--- a/backend/backend.ts
+++ b/backend/backend.ts
@@ -24,6 +24,7 @@ import {
 } from "./utils/client-version";
 import { appVersion } from "./utils/app-version";
 import { isAllowedOrigin, parseExtraOrigins } from "./utils/cors";
+import { isLoopbackRequest } from "./utils/loopback";
 
 dotenv.config();
 
@@ -61,11 +62,16 @@ const shareRateLimit = rateLimit({
   windowMs: 5 * 60 * 1000, // 5 minutes
   max: 5
 });
-// updown.io probes from three sources and Docker probes every 30s, each on its
-// own IP bucket, so 10 a minute is generous.
+// updown.io probes from three sources, each on its own IP bucket, so 10 a minute is generous.
+//
+// The container's own healthcheck is exempted. It reaches /health over loopback, which nothing
+// outside the container can, and `up --wait` blocks on it: rate-limiting it can only ever turn a
+// healthy deploy into a failed one. A clock step backwards on 2026-08-31 parked this window's
+// reset an hour in the future, and the 30s healthcheck alone then 429'd the container unhealthy.
 const healthRateLimit = rateLimit({
   windowMs: 60 * 1000,
-  max: 10
+  max: 10,
+  skip: isLoopbackRequest
 });
 // The planner polls /version once a minute per visible tab, and several tabs
 // can share one address. Generous enough for that, small enough to be worth

--- a/backend/utils/loopback.spec.ts
+++ b/backend/utils/loopback.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { isLoopbackRequest } from './loopback';
+
+describe('isLoopbackRequest', () => {
+  it.each([
+    ['127.0.0.1'],
+    ['::1'],
+    ['::ffff:127.0.0.1'],
+    ['::FFFF:127.0.0.1']
+  ])('treats %s as loopback', (address) => {
+    expect(isLoopbackRequest({ socket: { remoteAddress: address } })).toBe(true);
+  });
+
+  it.each([
+    ['172.18.0.4'],
+    ['10.0.0.1'],
+    ['1.2.3.4'],
+    ['127.0.0.2'],
+    ['2a00:1450:4009:81f::200e']
+  ])('does not treat %s as loopback', (address) => {
+    expect(isLoopbackRequest({ socket: { remoteAddress: address } })).toBe(false);
+  });
+
+  it('is false when the socket has no address', () => {
+    expect(isLoopbackRequest({ socket: { remoteAddress: undefined } })).toBe(false);
+    expect(isLoopbackRequest({ socket: null })).toBe(false);
+    expect(isLoopbackRequest({})).toBe(false);
+  });
+
+  it('strips a zone index rather than failing on an unexpected form', () => {
+    expect(isLoopbackRequest({ socket: { remoteAddress: '::1%lo0' } })).toBe(true);
+  });
+});

--- a/backend/utils/loopback.ts
+++ b/backend/utils/loopback.ts
@@ -1,0 +1,21 @@
+// Whether a request arrived over the container's own loopback interface, used to exempt the
+// Docker healthcheck from /health's rate limit — see backend.ts.
+//
+// Kept away from Express so it can be unit tested — see loopback.spec.ts.
+
+// Read from the socket rather than req.ip: `trust proxy` makes req.ip derive from
+// X-Forwarded-For, so a header could otherwise claim to be loopback. The socket peer cannot.
+// Node's dual-stack listener reports IPv4 peers in the ::ffff: mapped form.
+const LOOPBACK_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+export interface RequestWithSocket {
+  socket?: { remoteAddress?: string } | null
+}
+
+export const isLoopbackRequest = (req: RequestWithSocket): boolean => {
+  const address = req.socket?.remoteAddress;
+  if (!address) return false;
+  // A zone index (fe80::1%eth0) never appears on loopback, but strip it rather than fail closed
+  // on a form we did not expect.
+  return LOOPBACK_ADDRESSES.has(address.split('%')[0].toLowerCase());
+};


### PR DESCRIPTION
## Nothing to do by hand

No env vars, no secrets, no migration. This ships with the next backend image build and deploy.

## What broke

The API box rebooted with its clock roughly an hour ahead. `systemd-timesyncd` stepped it back about 33 seconds later, by which point the container had already served its first `/health` probe.

`express-rate-limit` expires a window on wall-clock time (`client.resetTime.getTime() <= Date.now()`), not a monotonic timer. So that first window was given a reset an hour in the future that `Date.now()` could not reach. The window never closed and hits accumulated forever.

`healthRateLimit` is `max: 10` per 60s and Docker probes every 30s, so the healthcheck alone exhausted the loopback bucket in five minutes. The container then sat `unhealthy` with a failing streak in the 80s, serving `429` with a `retry-after` counting down to a reset an hour away.

Users were never affected: tunnel traffic keys by `X-Forwarded-For`, so every real client had its own near-empty window.

This is **not** deployment drift. `docker exec` of the running `backend.ts` diffed clean against `main`, byte for byte. It presents identically to drift, which is the trap worth recording.

## Why it matters

The container reports `unhealthy` for as long as the clock offset lasts, which is what monitoring and anything healthcheck-gated sees. The deploy risk is narrower than it first looks:

- A deploy publishing a **new** image digest recreates the container, which opens fresh windows against the corrected clock, so it succeeds.
- A deploy whose image digest is **unchanged** does not recreate the container, so `--wait` has to reckon with the existing unhealthy one. Whether that blocks indefinitely, exits, or times out is unverified: no `--wait-timeout` is passed, and the deploy path actually running on the box was not confirmed.
- A container created before the clock step is only stuck if it also serves a request before the step.

## Ordering, and what this fix does not cover

Two corrections from review, both worth stating because they are easy to get backwards:

The window has to be **open before** the step. A container that serves no request until after the clock is corrected is unaffected. The key must also stay warm: MemoryStore rotates two maps on a `setInterval(windowMs)` timer, so an idle key is eventually dropped, while a regularly polled one is carried forward with its frozen `resetTime` and accumulated count. A 30s healthcheck is exactly that access pattern.

This change fixes `healthRateLimit` only. `apiRateLimit`, `shareRateLimit` and `versionRateLimit` sit on the same MemoryStore and a client key active across a step can still freeze. That is accepted rather than solved here: it self-heals when real time catches up, and no user was affected.

## The change

`healthRateLimit` now skips requests arriving over the container's own loopback interface. Nothing outside the container can reach `127.0.0.1` in its network namespace, and `up --wait` blocks on that probe, so rate-limiting it can only ever turn a healthy deploy into a failed one.

The predicate keys off `req.socket.remoteAddress`, never `req.ip`. `trust proxy` makes `req.ip` derive from `X-Forwarded-For`, which a caller can set; the kernel-reported TCP peer cannot be claimed by a header.

## The container being healthy today does not mean this is fixed

Worth spelling out, because it is easy to read the current green state as "no fix needed". Two things cleared the incident, and neither is a code change:

1. The wall clock passed the frozen reset at about 03:49:46, roughly an hour after boot.
2. The container was replaced entirely at 10:25:14 by the deploy from #621, which starts a fresh process against a now-correct clock.

The deployed image still has `healthRateLimit` as plain `windowMs: 60 * 1000, max: 10` with no skip. Twelve loopback `/health` requests against that running container return `200` nine times and then `429`, and the resulting failed probe pushed the Docker failing streak to 1 before the window closed and it recovered. The limiter still counts the healthcheck; the only thing that changed is that a sane clock lets the window expire, so the 30s probe (2 hits a minute) stays under the cap.

The difference is visible in one header. During the incident `retry-after` was 1830, then 990, then 728, counting down to a reset an hour away. Today it is 36, inside the 60s window. Same limiter, different clock.

So the bug is dormant, not fixed. It re-arms on any boot where the clock starts ahead and is stepped back before the first probe lands, which is exactly what `who -b` (03:48) and `uptime -s` (02:48) still record this morning's boot doing.

## Validation

- 37 backend tests pass, `tsc --noEmit` clean, `eslint` 0 errors.
- A live Express harness using the installed `express-rate-limit`: 15/15 `200` on loopback with the skip, `429` after 10 without it.
- Checked on the box that host-port traffic reaches the container as the docker gateway address rather than `127.0.0.1`, so the exemption covers only the container's own probe and nothing else.
- Confirmed the frozen window self-heals once the wall clock passes the stale reset. It did, with no restart.

## Reviewed

Put through an adversarial Codex review at the build gate. Codex agreed the exemption is sound and that the tests would fail if the predicate were removed. Its one objection is about pre-existing topology rather than this diff, and is captured separately rather than fixed here.

Background for the next person who hits this: `.claude/memory/clock-step-freezes-rate-limits.md`.
