### PR TITLE
feat: permanent usage metrics, and the dashboards in the repo

### DIFF
--- a/.claude/plans/planner-usage-metrics-v2.md
+++ b/.claude/plans/planner-usage-metrics-v2.md
@@ -1,0 +1,284 @@
+# Planner usage metrics, round two
+
+Extends the metrics module shipped in #627 with **permanent, server-derived** statistics.
+
+The metrics in #627 answer "what is happening right now". Half come from the browser heartbeat
+and expire 15 minutes after a tab closes, so a dashboard viewed at 3am reads zero. That is
+correct and it is not what is wanted for questions about the service as a whole. Everything
+below reads from Mongo, does not expire, and survives a restart.
+
+> **Revision 3.** Reviewed twice by Codex, RETHINK both times.
+>
+> Revision 1's central mechanism, a persisted counter incremented "in the same transaction
+> path" as a room op, was impossible: this backend has no transactions and Mongo runs
+> standalone. Revision 2 removed it rather than working around it.
+>
+> Revision 2 then had two real bugs and a gap, all found by the second review and all fixed
+> here: `$set` on `lastActiveAt` could move the timestamp **backwards**, the backfill did not
+> filter to `kind: 'op'` so it contradicted its own definition of "active", and the dashboard
+> generator was not in the repository at all. See the response table at the end.
+
+## Tasks
+
+- [ ] Expose `sf_room_revisions` as a **gauge** summing `Room.revision` over live rooms; no new writes anywhere
+- [ ] Add `lastActiveAt: Date` and `editCount: number` to the `User` schema
+- [ ] Record both in **one** update per accepted op, `$max` on the date and `$inc` on the count, in its own try/catch after commit
+- [ ] Backfill `lastActiveAt` at boot from the newest `room_activity` row per actor **filtered to `kind: 'op'`**, using `$max`
+- [ ] Add `sf_active_accounts{window}` for 1h, 24h, 7d, 14d, 30d as `countDocuments({ lastActiveAt: { $gt: now - w } })`
+- [ ] Add `sf_room_factories{room_id,owner}`, top 20, deterministic tie-break, owner resolved to a username
+- [ ] Add `sf_user_edits{username}` and `sf_user_factories{username}`, top 20, same tie-break and resolution
+- [ ] Reset each top-N gauge before repopulating on a successful refresh, and leave it untouched on a failed one
+- [ ] Split the metrics cache into a cheap group and an expensive group with separate TTLs, and add per-group in-flight coalescing
+- [ ] Add an index on `{ lastActiveAt: -1 }`
+- [ ] **Commit the dashboard generator and both dashboard JSON files to the repo**, so the applied dashboards can be regenerated, diffed and reviewed
+- [ ] Rename the "Memberships" panel to "Plan Access" and add a "Collaborators" panel
+- [ ] Relabel existing panels so heartbeat-derived and database-derived are visually distinct
+- [ ] Add dashboard panels for cumulative edits, edits per 24h, active accounts, and the three top-20 tables
+- [ ] Backend specs for every new gauge, the top-N cap and its tie-break, the deleted-user fallback, the backfill's op filter and idempotency, `$max` monotonicity, and the cache coalescing
+- [ ] Update `backend/README.md`'s route table and state the host-port exposure honestly in `docs/deployment.md`
+
+## What is being asked for
+
+| # | Question | Answer |
+| --- | --- | --- |
+| 1 | How many factories are we monitoring | `sf_room_factories_total`, already shipped |
+| 2 | How many plans are we monitoring | `sf_rooms_total`, already shipped |
+| 3 | Biggest plans by factory count | `sf_room_factories{room_id,owner}` |
+| 4 | Busiest users | `sf_user_edits{username}` |
+| 5 | Users with most factories | `sf_user_factories{username}` |
+| 6 | Active accounts, 24h/7d/14d/30d | `sf_active_accounts{window}` |
+| 7 | Active within 1h, over time | `sf_active_accounts{window="1h"}` |
+| 8 | "Memberships" means nothing | Rename to Plan Access, add Collaborators |
+| 9 | Local tabs active, 15 min expiry | `sf_client_tabs{kind="local"}`, already shipped |
+| 10 | Edits over time, 24h and cumulative | `sf_room_revisions` gauge |
+
+## Edits (#10): a gauge, and no new writes
+
+`Room.revision` already counts accepted edits exactly. Verified on preview: `sum(revision)` is
+84 and `room_activity` holds 84 rows of `kind: 'op'`.
+
+**Sum it at scrape time and expose it as a gauge.** No persisted counter, no seed, no marker,
+no extra write on the op path. Findings 1, 2 and 10 of the review are not mitigated by this,
+they are removed: there is nothing to be atomic about.
+
+The cost is that the number **falls when a plan is deleted**, because that plan's edits leave
+the sum. This is accepted and must be stated in the metric's help text. It is the honest
+number: it is the edits that still exist.
+
+The 24-hour figure uses a gauge-appropriate expression rather than `increase()`, which is only
+valid on counters:
+
+```promql
+clamp_min(sf_room_revisions - (sf_room_revisions offset 24h), 0)
+```
+
+`clamp_min` because a deletion can make the difference negative, and "minus four edits
+yesterday" is not a thing. A large deletion will show as a flat zero for a day; that is a
+known and acceptable distortion, not a bug to chase.
+
+Any window works by changing the offset. No timezone handling and no midnight reset job,
+which was the original reason for preferring this over Albion Roads' `daily_*` gauges.
+
+## Activity (#4, #6, #7): two fields on the user, not a new collection
+
+The first draft proposed an hourly rollup collection. Codex was right that hourly buckets
+cannot answer a **rolling** one-hour window, only a calendar one, and requirement 7 asks for a
+rolling one.
+
+Two fields on `User` instead, written in **one** update operation:
+
+```js
+users.updateOne({ _id: userId }, {
+  $max: { lastActiveAt: at },   // never moves backwards
+  $inc: { editCount: 1 },
+})
+```
+
+`lastActiveAt` answers every window **exactly and with no boundary error**, because it stores
+a timestamp rather than a bucket:
+
+```
+sf_active_accounts{window="24h"}  =  countDocuments({ lastActiveAt: { $gt: now - 24h } })
+```
+
+**`$max`, not `$set`.** `RoomOpService` queues one apply per *room*
+(`enqueue(op.roomId, ...)`), so a single user editing two rooms at once has no global
+ordering, and a post-commit write for the earlier op can reach Mongo after the later one.
+`$set` would move the timestamp backwards. `$max` cannot, which also makes the write safe to
+repeat and removes any need for a marker or reconciliation.
+
+`editCount` is an `$inc`. Mongo's `$inc` is itself atomic, so concurrent increments do not
+overwrite each other; the approximation comes from the post-commit attempt being allowed to
+fail. **It is an approximate ranking, not an audit count**, and its help text says so. Nothing
+else may be derived from it and it must never be presented as a total. When an exact figure is
+wanted, `sum(Room.revision)` is exact for surviving plans.
+
+The update goes after the room write commits, in **its own** `try/catch`, beside but not
+inside the one guarding `activity.record`. Two independent attempts, so a failure of either
+cannot skip the other, and neither can revoke an accepted edit.
+
+**What "active" means, precisely:** an account that made an accepted room op in the window.
+Signing in, creating a plan, renaming one and joining one are **not** ops and do not count.
+The first draft called `window="1h"` "active sessions", which was wrong. There is no session
+concept here; `sf_ws_connections` is the live-socket view and is a different question.
+
+**Backfill.** Seed `lastActiveAt` from the newest `room_activity` row per actor
+**`where kind === 'op'`**. The filter is essential and revision 2 omitted it: the collection
+also holds `created`, `joined`, `renamed` and `deleted`, so without it a user who merely
+joined a plan would be counted as having edited one, contradicting the definition above.
+
+It runs **at boot**, and needs no marker or lock because it writes with the same `$max`. Running
+it twice, or concurrently on two boots, cannot lower a value or double anything. That is the
+whole reason `$max` is worth having beyond the ordering fix.
+
+It is a partial bootstrap, not a reconstruction: `room_activity` is trimmed to 200 rows per
+room (the trim keeps the newest, so the most recent op per actor usually survives) and is
+deleted outright with hard-deleted rooms. `editCount` is **not** backfilled and starts at
+zero. Both facts go in the metric help text, so an early low number is not read as a fall.
+
+## Identified metrics (#3, #4, #5) and what the cap really bounds
+
+These carry usernames and room ids. That is deliberate: the operator looking at data the
+service already stores, in a different viewer, on an endpoint that is not publicly routable.
+
+Top 20 by the measured value, computed in Mongo so the cap governs what is exported.
+
+**The cap does not bound Prometheus cardinality, and the first draft was wrong to claim it
+did.** It bounds what is exported *per scrape*. Prometheus keeps every series it has ever
+seen for the full 90-day retention, so the real bound is:
+
+> one series per user or room that has **ever** entered the top 20, for 90 days after it
+> last did
+
+At this service's size that is tens of series and a non-issue. It is written down because the
+first draft's privacy claim, that "only the handful worth acting on ever leaves the database",
+was false. Over 90 days it is everyone who ever ranks.
+
+**Ties must break deterministically** (by `userId` or `roomId` after the measured value), or
+equal-valued entries swap in and out between scrapes and mint series for no reason.
+
+**Resolving owners:** `Room.createdBy` is a **user id**, not a username. One
+`find({ _id: { $in: [...] } })` over the at most 20 ids resolves them. A user id that no longer
+resolves is labelled `(deleted)` rather than dropped or allowed to fail the scrape, so a
+deleted account cannot silently remove a large plan from the panel.
+
+`docs/telemetry.md` describes what browsers **send**; usernames are not in the heartbeat and
+will not be. It stays accurate as written and is not edited. Its "no usernames" line is about
+the heartbeat and must not be removed.
+
+## Keeping `/metrics` off the public internet
+
+The first draft proposed an app-level private-address guard. Codex's objection stands and is
+the most serious operational point in the review: the container sees the *tunnel* as its peer,
+not the caller. If the tunnel's address is itself private, the guard passes public traffic
+while appearing to block it. **A guard that fails open is worse than no guard**, because it
+invites trust.
+
+**The bearer token is the control.** Everything else is defence in depth, and the plan should
+stop pretending otherwise. Revision 2 claimed moving the control to the tunnel made the
+endpoint "not publicly routable"; the second review correctly pointed out that
+`docker-compose-server.yml` publishes `3001:3001` and the preview file `3002:3002`, on all
+host interfaces, so a tunnel path exclusion does not close the host port.
+
+What is actually true, and what `docs/deployment.md` should say:
+
+- The API box holds a **private address behind NAT with no port forward**, so the published
+  ports are reachable from the LAN and not from the internet. That is a property of the
+  network, not of anything in this repository, and it is not enforced by any code here.
+- The **tunnel** is the only public route in, so excluding `/metrics` there removes the public
+  path. Worth doing, still not a boundary on its own.
+- The **token** is what holds if either of the above changes.
+
+No app-level address guard is being built. The second review is right that with Docker
+publishing the port and a tunnel in front, `remoteAddress` identifies the immediate peer
+rather than the caller, and a guard that cannot tell them apart may fail open while looking
+like protection. A measurement task remains, but nothing depends on its outcome.
+
+## Cost and caching
+
+Correcting the first draft: the current group is **four `countDocuments` plus one
+aggregation**, not five counts. `sumRoomFactories()` is already a `$group` over all live
+rooms.
+
+Two groups with separate TTLs:
+
+| Group | Contents | TTL |
+| --- | --- | --- |
+| cheap | room counts, user count, membership count, `sum(Room.revision)` | 15s |
+| expensive | top-20 room factories, top-20 user edits, top-20 user factories, the five `sf_active_accounts` windows | 120s |
+
+**In-flight coalescing is required, not optional.** The current `databaseCounts()` has no
+lock, so two scrapes arriving on expiry both run the query. Hold the in-flight promise and let
+the second caller await the first.
+
+A stale group keeps its previous values and does not fail the scrape, matching the existing
+`sf_metrics_database_up` behaviour. At a 30s scrape the expensive group is refreshed every
+fourth scrape and repeats in between; that is intended, and the dashboard must not present
+those values as sub-minute fresh.
+
+`sf_active_accounts` needs an index on `{ lastActiveAt: -1 }`. The first draft's
+`room_activity {at: -1}` index is **dropped**: with the rollup gone it had no consumer, except
+the one-off backfill, which does not justify a permanent index.
+
+## Testing
+
+Mirroring `backend/test/metrics.spec.ts`, which already seeds rooms and asserts gauge values.
+
+- Each new gauge against seeded data, including the empty case
+- `sf_room_revisions` falls when a room is deleted, which is the documented behaviour
+- The top-N cap holds beyond twenty entries, and ties break deterministically across two scrapes
+- An entry leaving the top twenty stops being exported
+- A room whose `createdBy` no longer resolves is labelled `(deleted)`
+- `actor: 'anon'` never becomes a username label and never counts as an active account
+- Each `sf_active_accounts` window counts only users inside it, tested on the boundary
+- The backfill is idempotent and does not lower an existing `lastActiveAt`
+- An op still succeeds when the metrics write throws
+- Two concurrent scrapes on an expired cache issue one query, not two
+
+## Risks
+
+- **`editCount` is approximate by construction.** Accepted, and stated in its help text. If an
+  exact edit total is ever needed, `sum(Room.revision)` is the exact figure for surviving plans.
+- **`sf_room_revisions` falls on deletion.** Accepted; the 24h expression clamps at zero.
+- **30-day windows are thin at first.** The backfill helps `lastActiveAt`; `editCount` genuinely
+  starts at zero and needs weeks before rankings mean anything.
+- **The tunnel exclusion is a manual infrastructure step**, so it is not enforced by anything in
+  the repo. It goes at the top of the PR, and the bearer token is what holds if it is forgotten.
+- **Two writes are added to the op path.** They sit inside the existing best-effort catch, so the
+  failure mode is a lost metric rather than a lost edit, which is the same trade the activity
+  log already makes.
+
+## Review responses
+
+**Round one** (revision 1 → 2):
+
+| Finding | Response |
+| --- | --- |
+| 1. No transaction path exists | Persisted counter removed entirely; `sum(Room.revision)` needs no atomicity |
+| 2. Seed races live edits | No seed exists any more |
+| 3. Hourly buckets cannot do a rolling hour | Rollup replaced by a `lastActiveAt` timestamp, exact for any window |
+| 4. No migration story | Backfill from `room_activity`, gaps stated in the help text |
+| 5. Top-20 does not bound cardinality | Conceded; the real 90-day bound written down, false privacy claim removed |
+| 6. `createdBy` is an id; "sessions" is wrong | Resolution and `(deleted)` fallback specified; "active" defined as an accepted op |
+| 7. Guard may fail open | App-level guard dropped |
+| 8. Cache underspecified | Two named groups with TTLs, coalescing required, "five counts" error corrected |
+| 9. `{at:-1}` index orphaned | Dropped |
+| 10. Post-commit write is the likely failure | No exactness claimed of `editCount` |
+
+**Round two** (revision 2 → 3):
+
+| Finding | Response |
+| --- | --- |
+| 1. Backfill did not filter to `kind: 'op'` | **Fixed.** Filter added; it contradicted the plan's own definition of active |
+| 2. `$set` can move `lastActiveAt` backwards | **Fixed.** `$max`, which also makes the backfill inherently safe to repeat |
+| 3. Dashboard generator is not in the repo | **Fixed.** Generator and both dashboard JSON files are now committed |
+| 4. Post-commit sequencing; should be one update | **Fixed.** One `updateOne` in its own `try/catch`, separate from `activity.record` |
+| 5. No reset rule for departed top-N entries | **Fixed.** Reset on successful refresh, leave untouched on a failed one |
+| 6. Tunnel exclusion is not a complete boundary | **Conceded.** The token is named as the control; the port exposure is documented plainly |
+| 7. Backfill has no executable lifecycle | **Fixed.** Runs at boot; `$max` means it needs no marker or lock |
+| 8. `$inc` rationale was wrong | **Fixed.** `$inc` is atomic; the approximation is the best-effort attempt failing |
+
+## Out of scope
+
+Alerting rules, `collectDefaultMetrics`, and any change to the browser heartbeat or its
+15-minute window.

--- a/backend/README.md
+++ b/backend/README.md
@@ -68,7 +68,7 @@ Every route except `GET /health` and `GET /share/:id` requires an `X-App-Version
 | `GET /share/:id` | Reads a snapshot link and bumps its view counter |
 | `POST /save`, `GET /load` | **410 Gone.** Replaced by synced tabs |
 | `GET /health` | The one to monitor. Pings Mongo and returns **503** if it doesn't answer inside 3s. Rate limited to 10 requests a minute, in its own bucket |
-| `GET /metrics` | Prometheus scrape target. Needs `Authorization: Bearer $METRICS_TOKEN`; **404 when `METRICS_TOKEN` is unset**, so a box that never got the variable exposes nothing. 30 a minute, own bucket |
+| `GET /metrics` | Prometheus scrape target. Needs `Authorization: Bearer $METRICS_TOKEN`; **404 when `METRICS_TOKEN` is unset**, so a box that never got the variable exposes nothing. 30 a minute, own bucket. Carries usernames and plan ids in the top-20 gauges, so the token is what keeps it private |
 | `POST /telemetry` | The anonymous client heartbeat, unauthenticated by design. 60 a minute per address in its own bucket, plus a 30s floor per instance. See [docs/telemetry.md](../docs/telemetry.md) for exactly what it collects |
 
 `GET /hello` is gone — it duplicated `/health` and nothing should have been monitoring it.

--- a/backend/src/auth/user.schema.ts
+++ b/backend/src/auth/user.schema.ts
@@ -20,7 +20,32 @@ export class User {
   /** Set once, by the legacy blob import. Its presence is what makes the import idempotent. */
   @Prop({ type: String, default: null })
   legacyImportRoomId!: string | null
+
+  /**
+   * When this account last had an edit accepted. Written with `$max`, never `$set`: ops are
+   * queued per room, not per account, so one person editing two rooms has no global ordering
+   * and a plain set would let an older timestamp overwrite a newer one.
+   *
+   * Null means "never seen editing", which after the boot backfill also covers anyone whose
+   * only activity predates what `room_activity` still holds.
+   */
+  @Prop({ type: Date, default: null })
+  lastActiveAt!: Date | null
+
+  /**
+   * Accepted edits by this account, for ranking who is busiest and nothing else.
+   *
+   * **Approximate on purpose.** The increment happens after the edit commits and is allowed
+   * to fail, because no metric may cost somebody their edit. `$inc` itself is atomic, so
+   * nothing is lost to concurrency; what is lost is the occasional write that never ran.
+   * When an exact number is wanted, sum `Room.revision` instead.
+   */
+  @Prop({ type: Number, default: 0 })
+  editCount!: number
 }
 
 export type UserDocument = HydratedDocument<User>
 export const UserSchema = SchemaFactory.createForClass(User)
+
+// Every sf_active_accounts window is a range scan on this.
+UserSchema.index({ lastActiveAt: -1 })

--- a/backend/src/metrics/cached-query.spec.ts
+++ b/backend/src/metrics/cached-query.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { CachedQuery } from './cached-query'
+
+/** A load that only settles when the test says so, for exercising the in-flight window. */
+const deferred = <T> () => {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+describe('CachedQuery', () => {
+  it('loads on the first call and reports it as a refresh', async () => {
+    const load = vi.fn().mockResolvedValue(1)
+    const cache = new CachedQuery(1000, load)
+
+    expect(await cache.get(0)).toEqual({ value: 1, refreshed: true, failed: false })
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  it('serves the cached value inside the TTL without reporting a refresh', async () => {
+    const load = vi.fn().mockResolvedValue(1)
+    const cache = new CachedQuery(1000, load)
+
+    await cache.get(0)
+    expect(await cache.get(999)).toEqual({ value: 1, refreshed: false, failed: false })
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  it('reloads once the TTL has passed', async () => {
+    const load = vi.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(2)
+    const cache = new CachedQuery(1000, load)
+
+    await cache.get(0)
+    expect(await cache.get(1000)).toEqual({ value: 2, refreshed: true, failed: false })
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  // The whole reason this class exists. Two scrapes arriving after expiry must not both run
+  // an aggregation, least of all when the database is already the thing struggling.
+  it('coalesces concurrent callers into one load', async () => {
+    const gate = deferred<number>()
+    const load = vi.fn().mockReturnValue(gate.promise)
+    const cache = new CachedQuery(1000, load)
+
+    const first = cache.get(0)
+    const second = cache.get(0)
+    gate.resolve(7)
+
+    expect(await first).toEqual({ value: 7, refreshed: true, failed: false })
+    expect(await second).toEqual({ value: 7, refreshed: true, failed: false })
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts a fresh load once the shared one has settled', async () => {
+    const load = vi.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(2)
+    const cache = new CachedQuery(1000, load)
+
+    await Promise.all([cache.get(0), cache.get(0)])
+    await cache.get(5000)
+
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the last good value when a load fails, and says it failed', async () => {
+    const load = vi.fn().mockResolvedValueOnce(1).mockRejectedValueOnce(new Error('mongo is down'))
+    const cache = new CachedQuery(1000, load)
+
+    await cache.get(0)
+    const outcome = await cache.get(2000)
+
+    expect(outcome).toEqual({ value: 1, refreshed: false, failed: true })
+  })
+
+  it('reports null rather than a wrong number when the very first load fails', async () => {
+    const load = vi.fn().mockRejectedValue(new Error('mongo is down'))
+    const cache = new CachedQuery(1000, load)
+
+    expect(await cache.get(0)).toEqual({ value: null, refreshed: false, failed: true })
+  })
+
+  it('recovers on the next call after a failure', async () => {
+    const load = vi.fn()
+      .mockRejectedValueOnce(new Error('mongo is down'))
+      .mockResolvedValueOnce(3)
+    const cache = new CachedQuery(1000, load)
+
+    await cache.get(0)
+    expect(await cache.get(1)).toEqual({ value: 3, refreshed: true, failed: false })
+  })
+
+  // A failed load must not be cached, or one blip would blank the panel for the whole TTL.
+  it('retries immediately after a failure rather than caching it', async () => {
+    const load = vi.fn()
+      .mockRejectedValueOnce(new Error('blip'))
+      .mockResolvedValueOnce(9)
+    const cache = new CachedQuery(60_000, load)
+
+    await cache.get(0)
+    await cache.get(1)
+
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+})

--- a/backend/src/metrics/cached-query.ts
+++ b/backend/src/metrics/cached-query.ts
@@ -1,0 +1,59 @@
+export interface CacheOutcome<T> {
+  /** The freshest answer available, or null when nothing has ever loaded successfully. */
+  value: T | null
+  /** True only when this call performed a successful load. */
+  refreshed: boolean
+  /** True when a load was attempted and threw. The previous value, if any, still stands. */
+  failed: boolean
+}
+
+/**
+ * One cached answer, with the two properties a scrape endpoint needs and the naive version
+ * lacks.
+ *
+ * **Coalescing.** Two scrapes arriving after the TTL expires must not both run the query. The
+ * second awaits the first's in-flight promise instead. Without this, a slow aggregation and a
+ * short interval let load pile up exactly when the database is already struggling.
+ *
+ * **Last good answer.** A failed load keeps the previous value rather than clearing it, so an
+ * outage shows as a flat line plus `sf_metrics_database_up 0` rather than a cliff to zero. It
+ * is the caller's job to report the failure; this only remembers.
+ *
+ * `refreshed` exists so a caller can tell a real reload from a cache hit, which matters for
+ * gauges carrying dynamic labels: those must be reset and repopulated on a reload, and left
+ * completely alone otherwise.
+ */
+export class CachedQuery<T> {
+  private value: T | null = null
+  private loadedAtMs = 0
+  private inFlight: Promise<CacheOutcome<T>> | null = null
+
+  constructor (
+    private readonly ttlMs: number,
+    private readonly load: () => Promise<T>,
+  ) {}
+
+  async get (nowMs: number): Promise<CacheOutcome<T>> {
+    if (this.value !== null && nowMs - this.loadedAtMs < this.ttlMs) {
+      return { value: this.value, refreshed: false, failed: false }
+    }
+
+    this.inFlight ??= this.run(nowMs)
+    return this.inFlight
+  }
+
+  private async run (nowMs: number): Promise<CacheOutcome<T>> {
+    try {
+      const loaded = await this.load()
+      this.value = loaded
+      this.loadedAtMs = nowMs
+      return { value: loaded, refreshed: true, failed: false }
+    } catch {
+      return { value: this.value, refreshed: false, failed: true }
+    } finally {
+      // Cleared after the await settles, so every caller that joined this attempt gets its
+      // result and only a later call starts a new one.
+      this.inFlight = null
+    }
+  }
+}

--- a/backend/src/metrics/metrics.constants.ts
+++ b/backend/src/metrics/metrics.constants.ts
@@ -7,11 +7,40 @@
 export const METRICS_TOKEN_VAR = 'METRICS_TOKEN'
 
 /**
- * How long a scrape's database counts are reused. Prometheus scrapes every 15-60s, more
- * than one scraper is normal, and these five numbers move slowly; without this each
- * scrape is five queries for an answer that has not changed.
+ * How long the cheap counts are reused. Four `countDocuments` and one `$group`, all fast.
+ * At a 30s scrape this saves nothing on its own; it exists so that two scrapers, or a
+ * scrape overlapping a manual check, do not both run the same queries.
  */
-export const METRICS_CACHE_MS = 10_000
+export const METRICS_CACHE_MS = 15_000
+
+/**
+ * How long the expensive statistics are reused: the three top-20 aggregations and the five
+ * active-account windows. At a 30s scrape these refresh roughly every fourth scrape and
+ * repeat in between, which is why the dashboard must not present them as sub-minute fresh.
+ */
+export const METRICS_SLOW_CACHE_MS = 120_000
+
+/**
+ * How many rows each identified metric exports per scrape.
+ *
+ * This bounds what leaves the database at any moment. It does **not** bound Prometheus
+ * cardinality over time: every username or room id that ever enters the top 20 keeps a
+ * series for the retention period after it drops out. At this service's size that is tens
+ * of series, but it is not the same claim.
+ */
+export const METRICS_TOP_N = 20
+
+/** The label used when a room's `createdBy` no longer resolves to an account. */
+export const DELETED_OWNER = '(deleted)'
+
+/** The windows `sf_active_accounts` reports, as label value to milliseconds. */
+export const ACTIVE_ACCOUNT_WINDOWS: ReadonlyArray<readonly [string, number]> = [
+  ['1h', 60 * 60 * 1000],
+  ['24h', 24 * 60 * 60 * 1000],
+  ['7d', 7 * 24 * 60 * 60 * 1000],
+  ['14d', 14 * 24 * 60 * 60 * 1000],
+  ['30d', 30 * 24 * 60 * 60 * 1000],
+] as const
 
 /**
  * The most *named* versions `sf_clients_by_version` will ever mint, busiest kept and the

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common'
+import { Module, OnModuleInit } from '@nestjs/common'
 
 import { AuthModule } from '../auth/auth.module'
 import { MetricsController } from './metrics.controller'
@@ -8,6 +8,7 @@ import { RealtimeModule } from '../realtime/realtime.module'
 import { RoomsModule } from '../rooms/rooms.module'
 import { TelemetryController } from './telemetry.controller'
 import { TelemetryService } from './telemetry.service'
+import { UserActivityService } from '../rooms/user-activity.service'
 
 /**
  * Observability, reading everything and owning nothing. `/telemetry` lives here rather
@@ -22,4 +23,18 @@ import { TelemetryService } from './telemetry.service'
   controllers: [MetricsController, TelemetryController],
   providers: [MetricsService, TelemetryService, MetricsTokenGuard],
 })
-export class MetricsModule {}
+export class MetricsModule implements OnModuleInit {
+  constructor (private readonly userActivity: UserActivityService) {}
+
+  /**
+   * Seeds `lastActiveAt` from what the activity log still holds, so the account windows are
+   * not blank for a month after release. Needs no marker: the backfill writes with `$max`,
+   * so running it on every boot cannot lower a value or double anything.
+   *
+   * Not awaited. Boot must not block on it, and a failure is logged rather than thrown —
+   * `/health` answering is worth more than a seeded gauge.
+   */
+  onModuleInit (): void {
+    void this.userActivity.backfillSafely()
+  }
+}

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -1,31 +1,43 @@
 import { Gauge, Registry } from 'prom-client'
-import { Inject, Injectable } from '@nestjs/common'
+import { Inject, Injectable, Logger } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
+import { Types } from 'mongoose'
 import type { Model } from 'mongoose'
 
+import {
+  ACTIVE_ACCOUNT_WINDOWS,
+  DELETED_OWNER,
+  METRICS_CACHE_MS,
+  METRICS_SLOW_CACHE_MS,
+  METRICS_TOP_N,
+} from './metrics.constants'
 import { CLOCK, Clock } from '../rooms/clock'
+import { CachedQuery } from './cached-query'
 import { ConnectionRegistry } from '../realtime/connection-registry'
-import { METRICS_CACHE_MS } from './metrics.constants'
 import { Room } from '../rooms/schemas/room.schema'
 import { RoomMembership } from '../rooms/schemas/room-membership.schema'
 import { TelemetryService } from './telemetry.service'
 import { User } from '../auth/user.schema'
 
-/** The five numbers that cost a database round trip, and are therefore cached together. */
-interface DatabaseCounts {
+/** The fast numbers: four counts and one aggregation over the rooms collection. */
+interface CheapCounts {
   sharedRooms: number
   privateRooms: number
   roomFactories: number
+  roomRevisions: number
   roomMembers: number
   users: number
 }
 
-const ZERO_COUNTS: DatabaseCounts = {
-  sharedRooms: 0,
-  privateRooms: 0,
-  roomFactories: 0,
-  roomMembers: 0,
-  users: 0,
+interface OwnedTotal { name: string, value: number }
+interface RoomTotal { roomId: string, owner: string, factories: number }
+
+/** The slow numbers: five window counts and three top-N aggregations. */
+interface SlowStats {
+  activeAccounts: Array<readonly [string, number]>
+  topRooms: RoomTotal[]
+  topEditors: OwnedTotal[]
+  topOwners: OwnedTotal[]
 }
 
 /**
@@ -35,16 +47,18 @@ const ZERO_COUNTS: DatabaseCounts = {
  * Two Nest apps in one process — which is every backend spec file — would otherwise fight
  * over the same metric names, and one app's numbers would show up in the other's scrape.
  *
- * Gauges throughout. Every one of these is a level that can go down as well as up (rooms
- * are deleted, clients go away), which is what separates a gauge from a counter; nothing
- * here is a monotonic event tally.
+ * Gauges throughout, including the edit total. `sf_room_revisions` is a sum over live rooms,
+ * so it falls when a plan is deleted and is therefore not a counter, whatever its shape
+ * suggests. That is the honest number: it is the edits that still exist.
  */
 @Injectable()
 export class MetricsService {
+  private readonly logger = new Logger(MetricsService.name)
   private readonly registry = new Registry()
 
   private readonly roomsTotal: Gauge<'shared'>
   private readonly roomFactoriesTotal: Gauge<string>
+  private readonly roomRevisions: Gauge<string>
   private readonly roomMembersTotal: Gauge<string>
   private readonly usersTotal: Gauge<string>
   private readonly wsConnections: Gauge<string>
@@ -55,9 +69,13 @@ export class MetricsService {
   private readonly clientFactoriesTotal: Gauge<string>
   private readonly clientsByVersion: Gauge<'version'>
 
-  private cached: DatabaseCounts = ZERO_COUNTS
-  private cachedAtMs = 0
-  private everRead = false
+  private readonly activeAccounts: Gauge<'window'>
+  private readonly roomFactories: Gauge<'room_id' | 'owner'>
+  private readonly userEdits: Gauge<'username'>
+  private readonly userFactories: Gauge<'username'>
+
+  private readonly cheap: CachedQuery<CheapCounts>
+  private readonly slow: CachedQuery<SlowStats>
 
   constructor (
     @InjectModel(Room.name) private readonly rooms: Model<Room>,
@@ -80,9 +98,14 @@ export class MetricsService {
       help: 'Factories summed across every live synced tab.',
       registers,
     })
+    this.roomRevisions = new Gauge({
+      name: 'sf_room_revisions',
+      help: 'Accepted edits summed across live synced tabs. Falls when a tab is deleted, because those edits no longer exist, so it is a gauge and not a counter.',
+      registers,
+    })
     this.roomMembersTotal = new Gauge({
       name: 'sf_room_members_total',
-      help: 'Membership rows across all synced tabs, owners included. The sweeper deletes a room\'s rows with it.',
+      help: 'Person-to-tab access grants, owners included. One per tab plus one per extra collaborator.',
       registers,
     })
     this.usersTotal = new Gauge({
@@ -97,7 +120,7 @@ export class MetricsService {
     })
     this.databaseUp = new Gauge({
       name: 'sf_metrics_database_up',
-      help: '1 when the last scrape read the database. At 0 the sf_rooms/members/users gauges are stale, not zero.',
+      help: '1 when the last scrape read the database. At 0 the database-backed gauges are stale, not zero.',
       registers,
     })
 
@@ -124,6 +147,34 @@ export class MetricsService {
       labelNames: ['version'],
       registers,
     })
+
+    this.activeAccounts = new Gauge({
+      name: 'sf_active_accounts',
+      help: 'Accounts whose last accepted edit falls inside the window. Signing in, creating a tab and joining one are not edits and do not count.',
+      labelNames: ['window'],
+      registers,
+    })
+    this.roomFactories = new Gauge({
+      name: 'sf_room_factories',
+      help: `The ${METRICS_TOP_N} largest synced tabs by factory count.`,
+      labelNames: ['room_id', 'owner'],
+      registers,
+    })
+    this.userEdits = new Gauge({
+      name: 'sf_user_edits',
+      help: `The ${METRICS_TOP_N} busiest accounts by accepted edits. Approximate: the count is written after the edit commits and is allowed to fail. Starts from zero at release rather than being backfilled.`,
+      labelNames: ['username'],
+      registers,
+    })
+    this.userFactories = new Gauge({
+      name: 'sf_user_factories',
+      help: `The ${METRICS_TOP_N} accounts owning the most factories, summed over the synced tabs they created.`,
+      labelNames: ['username'],
+      registers,
+    })
+
+    this.cheap = new CachedQuery(METRICS_CACHE_MS, () => this.loadCheap())
+    this.slow = new CachedQuery(METRICS_SLOW_CACHE_MS, () => this.loadSlow())
   }
 
   get contentType (): string {
@@ -140,14 +191,28 @@ export class MetricsService {
     this.wsConnections.set(this.connections.size())
     this.setClientGauges()
 
-    const counts = await this.databaseCounts()
-    if (!counts) return
+    const nowMs = this.clock.now().getTime()
+    const [cheap, slow] = await Promise.all([this.cheap.get(nowMs), this.slow.get(nowMs)])
 
-    this.roomsTotal.set({ shared: 'true' }, counts.sharedRooms)
-    this.roomsTotal.set({ shared: 'false' }, counts.privateRooms)
-    this.roomFactoriesTotal.set(counts.roomFactories)
-    this.roomMembersTotal.set(counts.roomMembers)
-    this.usersTotal.set(counts.users)
+    // Either group failing means the database was unreadable this scrape. A 500 would cost
+    // Prometheus every series here, the in-memory ones included, so the outage is reported
+    // as a signal and the last good values stand.
+    this.databaseUp.set(cheap.failed || slow.failed ? 0 : 1)
+
+    if (cheap.value) {
+      this.roomsTotal.set({ shared: 'true' }, cheap.value.sharedRooms)
+      this.roomsTotal.set({ shared: 'false' }, cheap.value.privateRooms)
+      this.roomFactoriesTotal.set(cheap.value.roomFactories)
+      this.roomRevisions.set(cheap.value.roomRevisions)
+      this.roomMembersTotal.set(cheap.value.roomMembers)
+      this.usersTotal.set(cheap.value.users)
+    }
+
+    // Only on a real reload. prom-client remembers every label set it has been given, so a
+    // room or account that has dropped out of the top N would keep reporting its last value
+    // forever unless the gauge is cleared first. Equally, a failed reload must leave the
+    // previous set intact rather than blanking the panel.
+    if (slow.refreshed && slow.value) this.setSlowGauges(slow.value)
   }
 
   private setClientGauges (): void {
@@ -159,56 +224,137 @@ export class MetricsService {
     this.clientTabs.set({ kind: 'cloud' }, census.cloudTabs)
     this.clientFactoriesTotal.set(census.factories)
 
-    // Reset first: a version nobody runs any more would otherwise keep reporting its last
-    // count for the life of the process, because prom-client remembers every label set it
-    // has been given.
     this.clientsByVersion.reset()
     for (const [version, clients] of census.byVersion) {
       this.clientsByVersion.set({ version }, clients)
     }
   }
 
-  /**
-   * Cached, and on a database failure the previous answer stands rather than the scrape
-   * failing. A 500 here would cost Prometheus every metric on the endpoint, including the
-   * client ones that were still perfectly readable — so the outage is reported as
-   * `sf_metrics_database_up 0` instead, which is a signal rather than a gap. Returns null
-   * when there is nothing new to write.
-   */
-  private async databaseCounts (): Promise<DatabaseCounts | null> {
-    const nowMs = this.clock.now().getTime()
-    if (this.everRead && nowMs - this.cachedAtMs < METRICS_CACHE_MS) return null
+  private setSlowGauges (stats: SlowStats): void {
+    for (const [window, accounts] of stats.activeAccounts) {
+      this.activeAccounts.set({ window }, accounts)
+    }
 
-    try {
-      const [sharedRooms, privateRooms, roomFactories, roomMembers, users] = await Promise.all([
-        this.rooms.countDocuments({ deletedAt: null, shared: true }),
-        // `$ne: true` rather than `false`, so a document predating the field still counts
-        // once rather than not at all.
-        this.rooms.countDocuments({ deletedAt: null, shared: { $ne: true } }),
-        this.sumRoomFactories(),
-        this.memberships.countDocuments(),
-        this.users.countDocuments(),
-      ])
+    this.roomFactories.reset()
+    for (const room of stats.topRooms) {
+      this.roomFactories.set({ room_id: room.roomId, owner: room.owner }, room.factories)
+    }
 
-      this.cached = { sharedRooms, privateRooms, roomFactories, roomMembers, users }
-      this.cachedAtMs = nowMs
-      this.everRead = true
-      this.databaseUp.set(1)
-      return this.cached
-    } catch (error) {
-      console.error(`Metrics database read failed: ${error instanceof Error ? error.message : String(error)}`)
-      this.databaseUp.set(0)
-      // Nothing on the first failure: reporting zero rooms would read as an empty
-      // database rather than an unreachable one.
-      return this.everRead ? this.cached : null
+    this.userEdits.reset()
+    for (const editor of stats.topEditors) {
+      this.userEdits.set({ username: editor.name }, editor.value)
+    }
+
+    this.userFactories.reset()
+    for (const owner of stats.topOwners) {
+      this.userFactories.set({ username: owner.name }, owner.value)
     }
   }
 
-  private async sumRoomFactories (): Promise<number> {
-    const [row] = await this.rooms.aggregate<{ total: number }>([
-      { $match: { deletedAt: null } },
-      { $group: { _id: null, total: { $sum: { $size: { $ifNull: ['$factories', []] } } } } },
+  private async loadCheap (): Promise<CheapCounts> {
+    const [sharedRooms, privateRooms, totals, roomMembers, users] = await Promise.all([
+      this.rooms.countDocuments({ deletedAt: null, shared: true }),
+      // `$ne: true` rather than `false`, so a document predating the field still counts
+      // once rather than not at all.
+      this.rooms.countDocuments({ deletedAt: null, shared: { $ne: true } }),
+      this.sumRoomTotals(),
+      this.memberships.countDocuments(),
+      this.users.countDocuments(),
     ])
-    return row?.total ?? 0
+
+    return { sharedRooms, privateRooms, ...totals, roomMembers, users }
+  }
+
+  private async loadSlow (): Promise<SlowStats> {
+    const now = this.clock.now()
+    const [activeAccounts, topRooms, topEditors, topOwners] = await Promise.all([
+      this.countActiveAccounts(now),
+      this.findLargestRooms(),
+      this.findBusiestEditors(),
+      this.findLargestOwners(),
+    ])
+
+    return { activeAccounts, topRooms, topEditors, topOwners }
+  }
+
+  /** Factories and accepted edits in one pass, since both are sums over the same documents. */
+  private async sumRoomTotals (): Promise<{ roomFactories: number, roomRevisions: number }> {
+    const [row] = await this.rooms.aggregate<{ factories: number, revisions: number }>([
+      { $match: { deletedAt: null } },
+      {
+        $group: {
+          _id: null,
+          factories: { $sum: { $size: { $ifNull: ['$factories', []] } } },
+          revisions: { $sum: { $ifNull: ['$revision', 0] } },
+        },
+      },
+    ])
+    return { roomFactories: row?.factories ?? 0, roomRevisions: row?.revisions ?? 0 }
+  }
+
+  private async countActiveAccounts (now: Date): Promise<Array<readonly [string, number]>> {
+    return Promise.all(ACTIVE_ACCOUNT_WINDOWS.map(async ([label, ms]) => {
+      const since = new Date(now.getTime() - ms)
+      const active = await this.users.countDocuments({ lastActiveAt: { $gt: since } })
+      return [label, active] as const
+    }))
+  }
+
+  /** Sorted by size then by id, so equal-sized rooms do not swap places between scrapes. */
+  private async findLargestRooms (): Promise<RoomTotal[]> {
+    const rows = await this.rooms.aggregate<{ roomId: string, createdBy: string, factories: number }>([
+      { $match: { deletedAt: null } },
+      {
+        $project: {
+          roomId: 1,
+          createdBy: 1,
+          factories: { $size: { $ifNull: ['$factories', []] } },
+        },
+      },
+      { $sort: { factories: -1, roomId: 1 } },
+      { $limit: METRICS_TOP_N },
+    ])
+
+    const owners = await this.resolveUsernames(rows.map(row => row.createdBy))
+    return rows.map(row => ({
+      roomId: row.roomId,
+      owner: owners.get(row.createdBy) ?? DELETED_OWNER,
+      factories: row.factories,
+    }))
+  }
+
+  private async findBusiestEditors (): Promise<OwnedTotal[]> {
+    const rows = await this.users
+      .find({ editCount: { $gt: 0 } }, { username: 1, editCount: 1 })
+      .sort({ editCount: -1, _id: 1 })
+      .limit(METRICS_TOP_N)
+      .lean()
+
+    return rows.map(row => ({ name: row.username, value: row.editCount }))
+  }
+
+  private async findLargestOwners (): Promise<OwnedTotal[]> {
+    const rows = await this.rooms.aggregate<{ _id: string, factories: number }>([
+      { $match: { deletedAt: null } },
+      { $group: { _id: '$createdBy', factories: { $sum: { $size: { $ifNull: ['$factories', []] } } } } },
+      { $sort: { factories: -1, _id: 1 } },
+      { $limit: METRICS_TOP_N },
+    ])
+
+    const owners = await this.resolveUsernames(rows.map(row => row._id))
+    return rows.map(row => ({ name: owners.get(row._id) ?? DELETED_OWNER, value: row.factories }))
+  }
+
+  /**
+   * `Room.createdBy` holds a user id, not a username, so the top-N rows have to be joined
+   * back to accounts. Ids that are not valid ObjectIds are skipped rather than passed to
+   * Mongo, which would throw a cast error and fail the whole scrape over one bad row.
+   */
+  private async resolveUsernames (ids: string[]): Promise<Map<string, string>> {
+    const valid = [...new Set(ids)].filter(id => Types.ObjectId.isValid(id))
+    if (valid.length === 0) return new Map()
+
+    const accounts = await this.users.find({ _id: { $in: valid } }, { username: 1 }).lean()
+    return new Map(accounts.map(account => [String(account._id), account.username]))
   }
 }

--- a/backend/src/realtime/room-op.service.ts
+++ b/backend/src/realtime/room-op.service.ts
@@ -8,6 +8,7 @@ import { APPLIED_OPS_RING, Room } from '../rooms/schemas/room.schema'
 import { CLOCK, Clock } from '../rooms/clock'
 import { RoomAccess, RoomAccessRole } from './room-access.service'
 import { RoomActivityService } from '../rooms/room-activity.service'
+import { UserActivityService } from '../rooms/user-activity.service'
 import { mergeFactories } from './room-snapshot'
 
 export type OpOutcome =
@@ -36,6 +37,7 @@ export class RoomOpService {
   constructor (
     @InjectModel(Room.name) private readonly rooms: Model<Room>,
     private readonly activity: RoomActivityService,
+    private readonly userActivity: UserActivityService,
     @Inject(CLOCK) private readonly clock: Clock,
   ) {}
 
@@ -103,10 +105,17 @@ export class RoomOpService {
 
     // Past this line the content is committed, so nothing may deny the sender its
     // ack or the peers their broadcast: a wedged client is worse than a lost row.
+    // Two separate attempts on purpose — one failing must not skip the other.
     try {
       await this.activity.record(op.roomId, actor, 'op')
     } catch (cause) {
       this.logger.error(`Failed to record op activity for room ${op.roomId}`, cause)
+    }
+
+    try {
+      await this.userActivity.recordEdit(actor, this.clock.now())
+    } catch (cause) {
+      this.logger.error(`Failed to stamp editor activity for ${op.roomId}`, cause)
     }
 
     return { status: 'applied', revision: updated.revision }

--- a/backend/src/rooms/rooms.module.ts
+++ b/backend/src/rooms/rooms.module.ts
@@ -14,6 +14,7 @@ import { RoomMembership, RoomMembershipSchema } from './schemas/room-membership.
 import { RoomSweeperService } from './room-sweeper.service'
 import { RoomsController } from './rooms.controller'
 import { RoomsService } from './rooms.service'
+import { UserActivityService } from './user-activity.service'
 
 @Module({
   imports: [
@@ -32,10 +33,20 @@ import { RoomsService } from './rooms.service'
     RoomEventsService,
     RoomSweeperService,
     LegacyImportService,
+    UserActivityService,
     EnsureStepRunner,
     { provide: CLOCK, useValue: systemClock },
   ],
-  // Exported for the WS gateway, which reads rooms and listens for fan-out.
-  exports: [RoomsService, RoomActivityService, RoomEventsService, MongooseModule, CLOCK],
+  // Exported for the WS gateway, which reads rooms and listens for fan-out, and for the
+  // metrics module. UserActivityService lives here rather than in metrics/ so that
+  // RealtimeModule can reach it without the two modules importing each other.
+  exports: [
+    RoomsService,
+    RoomActivityService,
+    RoomEventsService,
+    UserActivityService,
+    MongooseModule,
+    CLOCK,
+  ],
 })
 export class RoomsModule {}

--- a/backend/src/rooms/user-activity.service.ts
+++ b/backend/src/rooms/user-activity.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
+import type { Model } from 'mongoose'
+
+import { RoomActivity } from './schemas/room-activity.schema'
+import { User } from '../auth/user.schema'
+
+/** `room_activity` records this for a write with no account behind it. */
+export const ANONYMOUS_ACTOR = 'anon'
+
+/**
+ * Stamps an account as having edited, so the metrics module can answer "how many accounts were
+ * active in the last hour / day / week" from a timestamp rather than a bucket.
+ *
+ * Deliberately tiny, and deliberately not a general activity log — `room_activity` already is
+ * one, but the sweeper trims it to 200 rows per room, so it cannot answer anything older than
+ * the busiest plans' recent history.
+ *
+ * Lives under `rooms/` rather than `metrics/` only to keep the module graph acyclic:
+ * MetricsModule already imports RealtimeModule for the socket count, so RealtimeModule
+ * cannot import MetricsModule back. Both import RoomsModule.
+ */
+@Injectable()
+export class UserActivityService {
+  private readonly logger = new Logger(UserActivityService.name)
+
+  constructor (
+    @InjectModel(User.name) private readonly users: Model<User>,
+    @InjectModel(RoomActivity.name) private readonly activity: Model<RoomActivity>,
+  ) {}
+
+  /**
+   * One update, two fields. `$max` on the date because ops are queued per room and not per
+   * account: the same person editing two rooms at once has no global ordering, so a `$set`
+   * would let the earlier op's write land last and move the timestamp backwards.
+   *
+   * Anonymous visitors have no account to stamp.
+   */
+  async recordEdit (userId: string, at: Date): Promise<void> {
+    if (userId === ANONYMOUS_ACTOR) return
+
+    await this.users.updateOne(
+      { _id: userId },
+      { $max: { lastActiveAt: at }, $inc: { editCount: 1 } },
+    )
+  }
+
+  /**
+   * Seeds `lastActiveAt` from whatever `room_activity` still holds, so the windows are not
+   * blank for a month after release.
+   *
+   * **Only `kind: 'op'` counts.** The collection also holds `created`, `joined`, `renamed` and
+   * `deleted`, and treating those as edits would contradict what the metric claims to measure:
+   * somebody who joined a shared plan and never touched it is not an active editor.
+   *
+   * Needs no marker and no lock: it writes with the same `$max`, so running it twice, or on two
+   * boots at once, cannot lower a value or double anything. A partial bootstrap rather than a
+   * reconstruction — the activity log is trimmed per room and dropped with deleted rooms.
+   */
+  async backfillLastActive (): Promise<number> {
+    const newest = await this.activity.aggregate<{ _id: string, at: Date }>([
+      { $match: { kind: 'op', actor: { $ne: ANONYMOUS_ACTOR } } },
+      { $group: { _id: '$actor', at: { $max: '$at' } } },
+    ])
+
+    if (newest.length === 0) return 0
+
+    const writes = newest.map(({ _id, at }) => ({
+      updateOne: { filter: { _id }, update: { $max: { lastActiveAt: at } } },
+    }))
+
+    // Unordered: one unmatched id (an account deleted since) must not stop the rest.
+    const result = await this.users.bulkWrite(writes, { ordered: false })
+    return result.modifiedCount ?? 0
+  }
+
+  /** Logged rather than thrown: a blank window is worth less than a failed boot. */
+  async backfillSafely (): Promise<void> {
+    try {
+      const stamped = await this.backfillLastActive()
+      if (stamped > 0) this.logger.log(`Backfilled lastActiveAt for ${stamped} account(s)`)
+    } catch (cause) {
+      this.logger.error('Failed to backfill lastActiveAt', cause)
+    }
+  }
+}

--- a/backend/test/metrics-usage.spec.ts
+++ b/backend/test/metrics-usage.spec.ts
@@ -1,0 +1,440 @@
+import { randomUUID } from 'node:crypto'
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { getModelToken } from '@nestjs/mongoose'
+import type { Model } from 'mongoose'
+
+import {
+  ACTIVE_ACCOUNT_WINDOWS,
+  DELETED_OWNER,
+  METRICS_SLOW_CACHE_MS,
+  METRICS_TOP_N,
+} from '../src/metrics/metrics.constants'
+import { ANONYMOUS_ACTOR, UserActivityService } from '../src/rooms/user-activity.service'
+import { Room } from '../src/rooms/schemas/room.schema'
+import { RoomActivity } from '../src/rooms/schemas/room-activity.schema'
+import { RoomOpService } from '../src/realtime/room-op.service'
+import { TestContext, awaitConnection, createTestApp, destroyTestApp } from './utils/test-app'
+import { User } from '../src/auth/user.schema'
+import { FakeClock, resetRooms } from './utils/rooms'
+import { clearMetricsToken, labelValues, sample, scrapeMetrics, useMetricsToken } from './utils/metrics'
+
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
+
+describe('the database-backed usage metrics', () => {
+  let context: TestContext
+  const clock = new FakeClock()
+
+  const rooms = () => context.app.get<Model<Room>>(getModelToken(Room.name))
+  const users = () => context.app.get<Model<User>>(getModelToken(User.name))
+
+  const seedUser = async (username: string, extra: Partial<User> = {}) =>
+    users().create({ username, password: 'hashed', ...extra })
+
+  const seedRoom = async (factories: number, overrides: Partial<Room> = {}) =>
+    rooms().create({
+      roomId: randomUUID(),
+      name: 'Iron Line',
+      createdBy: 'someone',
+      factories: Array.from({ length: factories }, (_unused, index) => ({ id: index })),
+      ...overrides,
+    })
+
+  /** Past both cache windows every time, so each case reads what it just seeded. */
+  const scrape = async (): Promise<string> => {
+    clock.advance(METRICS_SLOW_CACHE_MS + 1)
+    const response = await scrapeMetrics(context.app)
+    expect(response.status).toBe(200)
+    return response.text
+  }
+
+  beforeAll(async () => {
+    context = await createTestApp({ clock, unthrottled: true })
+    await awaitConnection(context.app)
+    useMetricsToken()
+  })
+
+  afterAll(async () => {
+    await destroyTestApp(context)
+    clearMetricsToken()
+  })
+
+  // Forward only: winding the clock back would put a previous case's cache stamp in the future.
+  beforeEach(async () => {
+    await resetRooms(context.app)
+  })
+
+  describe('sf_room_revisions', () => {
+    it('sums accepted edits across live rooms', async () => {
+      await seedRoom(2, { revision: 30 })
+      await seedRoom(1, { revision: 12 })
+
+      expect(sample(await scrape(), 'sf_room_revisions')).toBe(42)
+    })
+
+    it('treats a room with no revision field as zero rather than skipping it', async () => {
+      await seedRoom(1, { revision: 5 })
+      await rooms().collection.insertOne({ roomId: randomUUID(), name: 'Old', createdBy: 'x', factories: [], deletedAt: null })
+
+      expect(sample(await scrape(), 'sf_room_revisions')).toBe(5)
+    })
+
+    // Documented behaviour, not a defect: those edits no longer exist. It is why this is a
+    // gauge, and why the dashboard clamps the 24h difference at zero.
+    it('falls when a room is deleted, which is why it is not a counter', async () => {
+      const doomed = await seedRoom(1, { revision: 40 })
+      await seedRoom(1, { revision: 4 })
+      expect(sample(await scrape(), 'sf_room_revisions')).toBe(44)
+
+      await rooms().deleteOne({ roomId: doomed.roomId })
+
+      expect(sample(await scrape(), 'sf_room_revisions')).toBe(4)
+    })
+
+    it('reports zero rather than nothing on an empty database', async () => {
+      expect(sample(await scrape(), 'sf_room_revisions')).toBe(0)
+    })
+  })
+
+  describe('sf_active_accounts', () => {
+    it('counts an account in every window wider than its last edit', async () => {
+      const now = clock.now().getTime()
+      await seedUser('recent', { lastActiveAt: new Date(now - 30 * 60 * 1000) })
+      await seedUser('yesterday', { lastActiveAt: new Date(now - 20 * HOUR) })
+      await seedUser('lastweek', { lastActiveAt: new Date(now - 6 * DAY) })
+      await seedUser('ancient', { lastActiveAt: new Date(now - 200 * DAY) })
+      await seedUser('never')
+
+      const body = await scrape()
+
+      // The clock advanced inside scrape(), so each boundary has moved a little; the
+      // orderings below hold regardless.
+      expect(sample(body, 'sf_active_accounts', 'window="1h"')).toBe(1)
+      expect(sample(body, 'sf_active_accounts', 'window="24h"')).toBe(2)
+      expect(sample(body, 'sf_active_accounts', 'window="7d"')).toBe(3)
+      expect(sample(body, 'sf_active_accounts', 'window="30d"')).toBe(3)
+    })
+
+    it('exports every configured window, even at zero', async () => {
+      const body = await scrape()
+
+      for (const [label] of ACTIVE_ACCOUNT_WINDOWS) {
+        expect(sample(body, 'sf_active_accounts', `window="${label}"`)).toBe(0)
+      }
+    })
+
+    it('never counts an account that has only ever signed in', async () => {
+      await seedUser('lurker')
+
+      expect(sample(await scrape(), 'sf_active_accounts', 'window="30d"')).toBe(0)
+    })
+  })
+
+  describe('sf_room_factories, the largest plans', () => {
+    it('names the biggest rooms and resolves the owner to a username', async () => {
+      const owner = await seedUser('mael')
+      const big = await seedRoom(40, { createdBy: String(owner._id) })
+      await seedRoom(3, { createdBy: String(owner._id) })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_room_factories', `room_id="${big.roomId}",owner="mael"`)).toBe(40)
+    })
+
+    it('labels an owner who no longer exists rather than dropping the room', async () => {
+      const room = await seedRoom(9, { createdBy: '507f1f77bcf86cd799439011' })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_room_factories', `room_id="${room.roomId}",owner="${DELETED_OWNER}"`)).toBe(9)
+    })
+
+    // A cast error on one bad row must not take the whole scrape down.
+    it('survives a createdBy that is not an object id at all', async () => {
+      const room = await seedRoom(4, { createdBy: 'not-an-object-id' })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_room_factories', `room_id="${room.roomId}",owner="${DELETED_OWNER}"`)).toBe(4)
+    })
+
+    it(`exports at most ${METRICS_TOP_N} rooms however many exist`, async () => {
+      for (let index = 0; index < METRICS_TOP_N + 8; index++) await seedRoom(index + 1)
+
+      const labels = labelValues(await scrape(), 'sf_room_factories', 'room_id')
+
+      expect(labels.length).toBe(METRICS_TOP_N)
+    })
+
+    it('drops a room that has fallen out of the top N', async () => {
+      const small = await seedRoom(1)
+      expect(sample(await scrape(), 'sf_room_factories', `room_id="${small.roomId}",owner="${DELETED_OWNER}"`)).toBe(1)
+
+      for (let index = 0; index < METRICS_TOP_N; index++) await seedRoom(50 + index)
+
+      const body = await scrape()
+      expect(sample(body, 'sf_room_factories', `room_id="${small.roomId}",owner="${DELETED_OWNER}"`)).toBeUndefined()
+    })
+
+    it('breaks ties on room id, so equal rooms keep their order between scrapes', async () => {
+      for (let index = 0; index < METRICS_TOP_N + 5; index++) await seedRoom(7)
+
+      const first = labelValues(await scrape(), 'sf_room_factories', 'room_id')
+      const second = labelValues(await scrape(), 'sf_room_factories', 'room_id')
+
+      expect(first).toEqual(second)
+    })
+  })
+
+  describe('sf_user_edits and sf_user_factories', () => {
+    it('ranks the busiest editors', async () => {
+      await seedUser('busy', { editCount: 120 })
+      await seedUser('quiet', { editCount: 3 })
+      await seedUser('idle')
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_user_edits', 'username="busy"')).toBe(120)
+      expect(sample(body, 'sf_user_edits', 'username="quiet"')).toBe(3)
+      // Never edited, so absent rather than a zero series taking up space.
+      expect(sample(body, 'sf_user_edits', 'username="idle"')).toBeUndefined()
+    })
+
+    it('sums factories across the rooms an account owns', async () => {
+      const owner = await seedUser('builder')
+      await seedRoom(10, { createdBy: String(owner._id) })
+      await seedRoom(15, { createdBy: String(owner._id) })
+
+      expect(sample(await scrape(), 'sf_user_factories', 'username="builder"')).toBe(25)
+    })
+
+    it(`caps both at ${METRICS_TOP_N}`, async () => {
+      for (let index = 0; index < METRICS_TOP_N + 6; index++) {
+        const owner = await seedUser(`user-${index}`, { editCount: index + 1 })
+        await seedRoom(index + 1, { createdBy: String(owner._id) })
+      }
+
+      const body = await scrape()
+
+      expect(labelValues(body, 'sf_user_edits', 'username').length).toBe(METRICS_TOP_N)
+      expect(labelValues(body, 'sf_user_factories', 'username').length).toBe(METRICS_TOP_N)
+    })
+
+    it('stops exporting an editor who has fallen out of the top N', async () => {
+      await seedUser('early', { editCount: 1 })
+      expect(sample(await scrape(), 'sf_user_edits', 'username="early"')).toBe(1)
+
+      for (let index = 0; index < METRICS_TOP_N; index++) {
+        await seedUser(`louder-${index}`, { editCount: 100 + index })
+      }
+
+      expect(sample(await scrape(), 'sf_user_edits', 'username="early"')).toBeUndefined()
+    })
+  })
+})
+
+describe('UserActivityService', () => {
+  let context: TestContext
+  const clock = new FakeClock()
+
+  const users = () => context.app.get<Model<User>>(getModelToken(User.name))
+  const activity = () => context.app.get<Model<RoomActivity>>(getModelToken(RoomActivity.name))
+  const service = () => context.app.get(UserActivityService)
+
+  const seedUser = async (username: string, extra: Partial<User> = {}) =>
+    users().create({ username, password: 'hashed', ...extra })
+
+  const reload = async (id: unknown) => users().findById(id).lean()
+
+  beforeAll(async () => {
+    context = await createTestApp({ clock, unthrottled: true })
+    await awaitConnection(context.app)
+  })
+
+  afterAll(async () => {
+    await destroyTestApp(context)
+  })
+
+  beforeEach(async () => {
+    await resetRooms(context.app)
+  })
+
+  describe('recordEdit', () => {
+    it('stamps the timestamp and counts the edit', async () => {
+      const user = await seedUser('editor')
+      const at = new Date('2026-09-02T10:00:00Z')
+
+      await service().recordEdit(String(user._id), at)
+
+      const stored = await reload(user._id)
+      expect(stored?.lastActiveAt?.toISOString()).toBe(at.toISOString())
+      expect(stored?.editCount).toBe(1)
+    })
+
+    /**
+     * The reason the field uses `$max`. Ops queue per room, not per account, so one person
+     * editing two rooms has no global ordering and the earlier op's write can land last.
+     */
+    it('never moves lastActiveAt backwards', async () => {
+      const user = await seedUser('editor')
+      const later = new Date('2026-09-02T12:00:00Z')
+      const earlier = new Date('2026-09-02T09:00:00Z')
+
+      await service().recordEdit(String(user._id), later)
+      await service().recordEdit(String(user._id), earlier)
+
+      const stored = await reload(user._id)
+      expect(stored?.lastActiveAt?.toISOString()).toBe(later.toISOString())
+      // The out-of-order write still counts as an edit; only the date is clamped.
+      expect(stored?.editCount).toBe(2)
+    })
+
+    it('ignores anonymous visitors, who have no account to stamp', async () => {
+      await expect(service().recordEdit(ANONYMOUS_ACTOR, new Date())).resolves.toBeUndefined()
+    })
+
+    it('does not create an account for an id that no longer exists', async () => {
+      await service().recordEdit('507f1f77bcf86cd799439011', new Date())
+
+      expect(await users().countDocuments()).toBe(0)
+    })
+  })
+
+  describe('backfillLastActive', () => {
+    const op = async (actor: string, at: Date) =>
+      activity().create({ roomId: randomUUID(), actor, kind: 'op', at })
+
+    it('seeds from the newest op per account', async () => {
+      const user = await seedUser('returning')
+      const newest = new Date('2026-08-30T10:00:00Z')
+      await op(String(user._id), new Date('2026-08-01T10:00:00Z'))
+      await op(String(user._id), newest)
+
+      await service().backfillLastActive()
+
+      expect((await reload(user._id))?.lastActiveAt?.toISOString()).toBe(newest.toISOString())
+    })
+
+    /**
+     * The bug the second review caught. `room_activity` also holds `created`, `joined`,
+     * `renamed` and `deleted`; counting those as edits would contradict what the metric says
+     * it measures.
+     */
+    it('ignores activity that is not an accepted edit', async () => {
+      const user = await seedUser('joiner')
+      await activity().create({ roomId: randomUUID(), actor: String(user._id), kind: 'joined', at: new Date() })
+      await activity().create({ roomId: randomUUID(), actor: String(user._id), kind: 'created', at: new Date() })
+      await activity().create({ roomId: randomUUID(), actor: String(user._id), kind: 'renamed', at: new Date() })
+
+      await service().backfillLastActive()
+
+      expect((await reload(user._id))?.lastActiveAt).toBeNull()
+    })
+
+    it('skips anonymous actors', async () => {
+      await op(ANONYMOUS_ACTOR, new Date())
+
+      await expect(service().backfillLastActive()).resolves.toBe(0)
+    })
+
+    // No marker and no lock, because `$max` makes a repeat run a no-op.
+    it('is safe to run twice', async () => {
+      const user = await seedUser('returning')
+      const at = new Date('2026-08-30T10:00:00Z')
+      await op(String(user._id), at)
+
+      await service().backfillLastActive()
+      await service().backfillLastActive()
+
+      expect((await reload(user._id))?.lastActiveAt?.toISOString()).toBe(at.toISOString())
+      expect((await reload(user._id))?.editCount).toBe(0)
+    })
+
+    it('never lowers a timestamp a live edit has already set', async () => {
+      const user = await seedUser('active')
+      const live = new Date('2026-09-02T12:00:00Z')
+      await service().recordEdit(String(user._id), live)
+      await op(String(user._id), new Date('2026-08-01T10:00:00Z'))
+
+      await service().backfillLastActive()
+
+      expect((await reload(user._id))?.lastActiveAt?.toISOString()).toBe(live.toISOString())
+    })
+
+    it('does not backfill the edit count, which starts from release', async () => {
+      const user = await seedUser('returning')
+      await op(String(user._id), new Date())
+      await op(String(user._id), new Date())
+
+      await service().backfillLastActive()
+
+      expect((await reload(user._id))?.editCount).toBe(0)
+    })
+
+    it('swallows a failure rather than stopping boot', async () => {
+      await expect(service().backfillSafely()).resolves.toBeUndefined()
+    })
+  })
+})
+
+/**
+ * The invariant the whole design bends around: an edit is committed before any metric is
+ * written, and no metric failure may take it back. `RoomOpService` keeps the two post-commit
+ * writes in separate `try/catch` blocks so neither can skip the other either.
+ */
+describe('an accepted edit survives the metrics write failing', () => {
+  let context: TestContext
+  const clock = new FakeClock()
+  const failures: string[] = []
+
+  const rooms = () => context.app.get<Model<Room>>(getModelToken(Room.name))
+
+  beforeAll(async () => {
+    context = await createTestApp({
+      clock,
+      unthrottled: true,
+      userActivity: {
+        recordEdit: async (userId: string) => {
+          failures.push(userId)
+          throw new Error('injected editor-stamp failure')
+        },
+      },
+    })
+    await awaitConnection(context.app)
+  })
+
+  afterAll(async () => {
+    await destroyTestApp(context)
+  })
+
+  it('still applies the op, and still bumps the room revision', async () => {
+    const actor = '507f1f77bcf86cd799439011'
+    const room = await rooms().create({
+      roomId: randomUUID(),
+      name: 'Iron Line',
+      createdBy: actor,
+      factories: [],
+      revision: 0,
+    })
+
+    const ops = context.app.get(RoomOpService)
+    const outcome = await ops.apply(
+      {
+        type: 'op',
+        roomId: room.roomId,
+        opId: randomUUID(),
+        baseRevision: 0,
+        diff: { powerTarget: 42 },
+      } as never,
+      actor,
+      async () => ({ status: 'granted', role: 'owner', room: room.toObject() }) as never,
+    )
+
+    expect(outcome).toEqual({ status: 'applied', revision: 1 })
+    expect(failures).toContain(actor)
+
+    const stored = await rooms().findOne({ roomId: room.roomId }).lean()
+    expect(stored?.revision).toBe(1)
+  })
+})

--- a/backend/test/utils/test-app.ts
+++ b/backend/test/utils/test-app.ts
@@ -11,6 +11,7 @@ import type { Connection } from 'mongoose'
 import { CLOCK, Clock } from '../../src/rooms/clock'
 import { EnsureStepRunner } from '../../src/rooms/ensure-step.runner'
 import { RoomActivityService } from '../../src/rooms/room-activity.service'
+import { UserActivityService } from '../../src/rooms/user-activity.service'
 import { configureApp } from '../../src/bootstrap'
 import { AppModule } from '../../src/app.module'
 
@@ -28,6 +29,8 @@ export interface TestAppOptions {
   stepRunner?: EnsureStepRunner
   /** Replaces the activity log, so a post-commit write can be made to fail. */
   activity?: Pick<RoomActivityService, 'record' | 'recordOnce'>
+  /** Replaces the editor stamp, the other post-commit write, for the same reason. */
+  userActivity?: Pick<UserActivityService, 'recordEdit'>
   clock?: Clock
   /**
    * Suites that make hundreds of calls from one address would otherwise trip the
@@ -50,6 +53,11 @@ export const createTestApp = async (options: TestAppOptions = {}): Promise<TestC
   const builder = Test.createTestingModule({ imports: [AppModule] })
   if (options.stepRunner) builder.overrideProvider(EnsureStepRunner).useValue(options.stepRunner)
   if (options.activity) builder.overrideProvider(RoomActivityService).useValue(options.activity)
+  if (options.userActivity) {
+    builder.overrideProvider(UserActivityService)
+      // The boot backfill is a no-op here: these suites assert the seam, not the seeding.
+      .useValue({ ...options.userActivity, backfillSafely: async () => undefined })
+  }
   if (options.clock) builder.overrideProvider(CLOCK).useValue(options.clock)
   if (options.unthrottled) builder.overrideProvider(ThrottlerStorage).useValue(NEVER_THROTTLED)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -433,6 +433,24 @@ On the box (`ssh sf`), one-off, and not done by any deploy:
   (`openssl rand -hex 32`), put it in the env file, and give the same value to the
   Prometheus scrape job as a bearer token. Nothing else reads it, so rotating it means
   editing those two places and restarting the container.
+
+  **The token is the access control, and it is worth being honest about why.**
+  `/metrics` carries usernames and plan ids in its top-20 gauges, so it is not a
+  page to leave open. Two things people assume protect it and do not:
+
+  - The compose files publish `3001:3001` (and `3002:3002` for preview) on **all**
+    host interfaces. Excluding `/metrics` at the tunnel removes the public route but
+    does not close the host port. Anything that can reach the box on the LAN can
+    reach `/metrics`, and only the token stops it.
+  - An application-level "private addresses only" check was considered and rejected.
+    Behind Docker port publishing with a tunnel in front, the container sees the
+    tunnel as its peer rather than the caller, so such a guard can pass public
+    traffic while looking like it blocks it. A guard that fails open is worse than
+    none, because it invites trust.
+
+  What actually keeps it private today is that the box holds a private address behind
+  NAT with no port forward, plus the token. The first of those is a property of the
+  network and is not enforced by anything in this repository.
 - The tunnel in front of the API must forward WebSocket upgrades to `/ws` on the
   same origin as the REST routes. Nothing in the repo can prove this; check it
   from the production origin after the first v7 deploy.

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -1,0 +1,91 @@
+# Grafana dashboards
+
+The two dashboards that read `GET /metrics`, and the script that generates them.
+
+| File | What it is |
+| --- | --- |
+| `generate.py` | The source of truth. Everything else here is output. |
+| `satisfactory-factories.json` | Production, every query pinned to `job="satisfactory-factories"` |
+| `satisfactory-factories-preview.json` | Preview, pinned to `job="satisfactory-factories-preview"` |
+
+## Why a generator rather than hand-edited JSON
+
+The dashboards are 41 panels each and identical apart from one label matcher. Keeping two
+hand-written copies in step would not survive contact with a single edit.
+
+More importantly, **production and preview export the same metric names**. An unfiltered query
+silently adds the two environments together and nobody notices, because the answer looks
+plausible. Every query the generator emits is pinned to one job, which is the only reliable way
+to keep that from happening.
+
+## Regenerating
+
+```sh
+cd docs/grafana
+python3 generate.py satisfactory-factories "" satisfactory-factories-metrics > satisfactory-factories.json
+python3 generate.py satisfactory-factories-preview " (Preview)" satisfactory-factories-metrics-preview > satisfactory-factories-preview.json
+```
+
+The three arguments are the Prometheus job name, a suffix for the dashboard title, and the
+Grafana resource name. Nothing else differs between the two.
+
+## Applying
+
+Import through the Grafana UI, or POST to the schema-v2 API:
+
+```sh
+curl -X POST \
+  -H "Authorization: Bearer $GRAFANA_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data-binary @satisfactory-factories.json \
+  "$GRAFANA_URL/apis/dashboard.grafana.app/v2/namespaces/default/dashboards"
+```
+
+Updating an existing one is a `PUT` to `.../dashboards/<metadata.name>`, and the body must
+carry the current `metadata.resourceVersion` or the API rejects it as a conflict. The service
+account needs Admin: an Editor can create a dashboard at the top level and then gets 403
+reading it back.
+
+These are **not** provisioned from disk, deliberately. A provisioned dashboard is read-only in
+the UI, and the whole point of publishing the JSON is that panels can still be tweaked by hand.
+If you do tweak one, export it and fold the change back into `generate.py`, or the next
+regeneration will quietly undo it.
+
+## Reading the dashboards
+
+Row titles say where the numbers come from, because the two sources behave completely
+differently and nothing on a panel reveals which it is:
+
+- **"from browsers"** is the anonymous heartbeat. It expires 15 minutes after a tab closes, so
+  these panels read zero overnight and after a restart. That is correct, not a fault. Local
+  plans and signed-out visitors appear nowhere else.
+- **"from the database"** is permanent. It survives restarts and answers questions about the
+  service rather than about this minute.
+
+Two panels are worth knowing the shape of:
+
+- **Edits** come from `sf_room_revisions`, a sum of `Room.revision` over live plans. It is a
+  gauge, so it *falls* when a plan is deleted. The 24-hour panel is therefore an offset
+  difference clamped at zero, not `increase()`, which is only valid on counters.
+- **Busiest Accounts** is approximate. The count is written after an edit commits and is
+  allowed to fail, because no metric may cost somebody their edit. Use it for ranking and
+  nothing else; `sf_room_revisions` is the exact figure.
+
+## Checking a change before applying it
+
+Every expression can be validated against Prometheus without touching Grafana:
+
+```sh
+python3 -c "
+import json,sys
+d=json.load(open('satisfactory-factories-preview.json'))
+for e in d['spec']['elements'].values():
+    for q in e['spec']['data']['spec']['queries']:
+        print(q['spec']['query']['spec']['expr'])
+" | while read -r q; do
+  curl -sG --data-urlencode "query=$q" "$PROM_URL/api/v1/query" -o /dev/null -w "%{http_code} $q\n"
+done
+```
+
+Anything that is not `200` is a syntax error that would have shown up as a silently empty
+panel.

--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""Generates the Satisfactory Factories Grafana dashboard (schema v2, Grafana 13.0.2).
+
+Written as a generator rather than hand-authored JSON so the panel shapes stay
+consistent and the preview variant is the same file with one argument changed.
+"""
+import json
+import sys
+
+JOB = sys.argv[1] if len(sys.argv) > 1 else "satisfactory-factories"
+TITLE_SUFFIX = sys.argv[2] if len(sys.argv) > 2 else ""
+NAME = sys.argv[3] if len(sys.argv) > 3 else "satisfactory-factories-metrics"
+
+DS = {"name": "prometheus"}
+VERSION = "13.0.2"
+
+# Every query is pinned to one job. Production and preview export identical metric
+# names, so an unfiltered query silently adds the two environments together.
+J = '{job="%s"}' % JOB
+
+
+def sel(extra=""):
+    """A selector on this job, optionally with more label matchers."""
+    inner = 'job="%s"' % JOB
+    if extra:
+        inner += "," + extra
+    return "{" + inner + "}"
+
+
+def query(expr, legend, ref="A", instant=False):
+    spec = {"editorMode": "code", "expr": expr, "legendFormat": legend}
+    if instant:
+        spec.update({"instant": True, "range": False})
+    else:
+        spec["range"] = True
+    return {
+        "kind": "PanelQuery",
+        "spec": {
+            "query": {
+                "kind": "DataQuery",
+                "group": "prometheus",
+                "version": "v0",
+                "datasource": DS,
+                "spec": spec,
+            },
+            "refId": ref,
+            "hidden": False,
+        },
+    }
+
+
+def panel(pid, title, description, queries, viz):
+    return {
+        "kind": "Panel",
+        "spec": {
+            "id": pid,
+            "title": title,
+            "description": description,
+            "links": [],
+            "data": {
+                "kind": "QueryGroup",
+                "spec": {"queries": queries, "transformations": [], "queryOptions": {}},
+            },
+            "vizConfig": viz,
+        },
+    }
+
+
+def stat(steps, unit="short", graph="none", color_mode="background",
+         text_mode="auto", decimals=None, fixed=None, minmax=None):
+    defaults = {
+        "unit": unit,
+        "thresholds": {"mode": "absolute", "steps": steps},
+        "color": {"mode": "fixed", "fixedColor": fixed} if fixed else {"mode": "thresholds"},
+    }
+    if decimals is not None:
+        defaults["decimals"] = decimals
+    if minmax:
+        defaults["min"], defaults["max"] = minmax
+    return {
+        "kind": "VizConfig",
+        "group": "stat",
+        "version": VERSION,
+        "spec": {
+            "options": {
+                "colorMode": color_mode,
+                "graphMode": graph,
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+                "showPercentChange": False,
+                "textMode": text_mode,
+                "wideLayout": True,
+            },
+            "fieldConfig": {"defaults": defaults, "overrides": []},
+        },
+    }
+
+
+def timeseries(unit="short", fill=15, stack="none", steps=None, decimals=None,
+               fixed=None, minmax=None, tooltip="multi", points="auto", width=2):
+    defaults = {
+        "unit": unit,
+        "thresholds": {"mode": "absolute", "steps": steps or [{"value": 0, "color": "green"}]},
+        "color": {"mode": "fixed", "fixedColor": fixed} if fixed else {"mode": "palette-classic"},
+        "custom": {
+            "axisBorderShow": False,
+            "axisCenteredZero": False,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": fill,
+            "gradientMode": "opacity",
+            "hideFrom": {"legend": False, "tooltip": False, "viz": False},
+            "insertNulls": False,
+            "lineInterpolation": "linear",
+            "lineWidth": width,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": points,
+            "showValues": False,
+            "spanNulls": False,
+            "stacking": {"group": "A", "mode": stack},
+            "thresholdsStyle": {"mode": "off"},
+        },
+    }
+    if decimals is not None:
+        defaults["decimals"] = decimals
+    if minmax:
+        defaults["min"], defaults["max"] = minmax
+    return {
+        "kind": "VizConfig",
+        "group": "timeseries",
+        "version": VERSION,
+        "spec": {
+            "options": {
+                "annotations": {"clustering": -1, "multiLane": False},
+                "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": True},
+                "tooltip": {"hideZeros": False, "mode": tooltip, "sort": "none"},
+            },
+            "fieldConfig": {"defaults": defaults, "overrides": []},
+        },
+    }
+
+
+def bargauge(display_name=None, unit="short"):
+    defaults = {
+        "unit": unit,
+        "thresholds": {"mode": "absolute", "steps": [{"value": 0, "color": "green"}]},
+        "color": {"mode": "palette-classic"},
+    }
+    if display_name:
+        defaults["displayName"] = display_name
+    return {
+        "kind": "VizConfig",
+        "group": "bargauge",
+        "version": VERSION,
+        "spec": {
+            "options": {
+                "displayMode": "gradient",
+                "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": False},
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+                "showUnfilled": True,
+                "sizing": "auto",
+                "valueMode": "color",
+            },
+            "fieldConfig": {"defaults": defaults, "overrides": []},
+        },
+    }
+
+
+GREEN = [{"value": 0, "color": "green"}]
+BLUE = [{"value": 0, "color": "blue"}]
+GREY = [{"value": 0, "color": "#6a6a6a"}]
+
+elements = {}
+
+
+def add(pid, *args, **kwargs):
+    elements["panel-%d" % pid] = panel(pid, *args, **kwargs)
+
+
+# ---------------------------------------------------------------- live right now
+add(1, "Active Browsers",
+    "Browsers that sent a heartbeat in the last 15 minutes. Counts local-only and signed-out users, who are invisible to the server otherwise.",
+    [query("sum(sf_active_clients%s)" % J, "Active")],
+    stat([{"value": 0, "color": "red"}, {"value": 1, "color": "green"}], graph="area"))
+
+add(2, "Signed In vs Signed Out",
+    "Whether somebody is signed in. Never who.",
+    [query('sum(sf_active_clients%s)' % sel('signed_in="true"'), "Signed in", "A"),
+     query('sum(sf_active_clients%s)' % sel('signed_in="false"'), "Signed out", "B")],
+    stat(GREEN, color_mode="value", text_mode="value_and_name"))
+
+add(3, "Live Sockets",
+    "Open realtime connections. One socket carries every synced tab in a browser, so this is below the active-browser count by design.",
+    [query("sum(sf_ws_connections%s)" % J, "Sockets")],
+    stat([{"value": 0, "color": "blue"}], graph="area"))
+
+add(4, "Signed-in Share",
+    "What fraction of active browsers have an account signed in.",
+    [query("sum(sf_active_clients%s) / sum(sf_active_clients%s)" % (sel('signed_in="true"'), J), "Signed in")],
+    stat([{"value": 0, "color": "red"}, {"value": 0.2, "color": "#EAB839"}, {"value": 0.4, "color": "green"}],
+         unit="percentunit", minmax=(0, 1)))
+
+add(5, "Database Readable",
+    "1 when the last scrape read Mongo. At 0 the room and account gauges are frozen at their last values, not actually zero. This is the one to alert on.",
+    [query("min(sf_metrics_database_up%s)" % J, "Database")],
+    stat([{"value": 0, "color": "red"}, {"value": 1, "color": "green"}]))
+
+# ------------------------------------------------------------ clients over time
+add(10, "Active Browsers Over Time",
+    "Stacked, so the total height is every active browser.",
+    [query("sum by (signed_in) (sf_active_clients%s)" % J, "{{signed_in}}")],
+    timeseries(fill=25, stack="normal"))
+
+add(11, "Live Sockets Over Time",
+    "Realtime connections held open.",
+    [query("sum(sf_ws_connections%s)" % J, "Sockets"),
+     query("max(max_over_time(sf_ws_connections%s[24h]))" % J, "24h peak", "B")],
+    timeseries(fill=15, fixed=None))
+
+add(12, "Records",
+    "Now, and the 24 hour average and peak. Built from subqueries over the scrape series.",
+    [query("sum(sf_active_clients%s)" % J, "Browsers now", "A"),
+     query("avg_over_time(sum(sf_active_clients%s)[24h:5m])" % J, "24h avg browsers", "B"),
+     query("max_over_time(sum(sf_active_clients%s)[24h:5m])" % J, "24h peak browsers", "C"),
+     query("max(max_over_time(sf_ws_connections%s[24h]))" % J, "24h peak sockets", "D")],
+    stat(BLUE, color_mode="value", text_mode="value_and_name", decimals=1))
+
+# ----------------------------------------------------------- plans in browsers
+add(20, "Plans Open in Browsers",
+    "Planner tabs, not browser tabs. Local plans never reach the server, so this is the only place they are counted.",
+    [query('sum(sf_client_tabs%s)' % sel('kind="local"'), "Local", "A"),
+     query('sum(sf_client_tabs%s)' % sel('kind="cloud"'), "Cloud", "B")],
+    stat(GREEN, color_mode="value", text_mode="value_and_name"))
+
+add(21, "Cloud Share of Plans",
+    "What fraction of open plans are synced rather than local only. The headline adoption number for syncing.",
+    [query("sum(sf_client_tabs%s) / sum(sf_client_tabs%s)" % (sel('kind="cloud"'), J), "Synced")],
+    stat([{"value": 0, "color": "red"}, {"value": 0.25, "color": "#EAB839"}, {"value": 0.5, "color": "green"}],
+         unit="percentunit", minmax=(0, 1)))
+
+add(22, "Factories in Browsers",
+    "Factories summed across active browsers, local plans included.",
+    [query("sum(sf_client_factories_total%s)" % J, "Factories")],
+    stat(BLUE, graph="area", color_mode="background_solid"))
+
+add(23, "Plans per Browser",
+    "Average planner tabs open per active browser.",
+    [query("sum(sf_client_tabs%s) / sum(sf_active_clients%s)" % (J, J), "Plans")],
+    stat(BLUE, color_mode="value", decimals=1))
+
+add(24, "Factories per Browser",
+    "Average factories per active browser. The rough answer to how big a plan people actually build.",
+    [query("sum(sf_client_factories_total%s) / sum(sf_active_clients%s)" % (J, J), "Factories")],
+    stat(BLUE, color_mode="value", decimals=1))
+
+add(25, "Plans Over Time, Local vs Cloud",
+    "Stacked. The cloud band growing against the local band is sync adoption.",
+    [query("sum by (kind) (sf_client_tabs%s)" % J, "{{kind}}")],
+    timeseries(fill=25, stack="normal"))
+
+add(26, "Factories in Browsers Over Time",
+    "Total factories across active browsers.",
+    [query("sum(sf_client_factories_total%s)" % J, "Factories")],
+    timeseries(fill=18, fixed="blue", points="never", width=3))
+
+# --------------------------------------------------- server side: rooms, users
+add(30, "Registered Accounts",
+    "Rows in the users collection.",
+    [query("sum(sf_users_total%s)" % J, "Accounts")],
+    stat(GREY, color_mode="background_solid", graph="area"))
+
+add(31, "Synced Plans",
+    "Live rooms on the server, tombstoned ones excluded.",
+    [query("sum(sf_rooms_total%s)" % J, "Synced plans")],
+    stat(BLUE))
+
+add(32, "Shared Plans",
+    "Synced plans that have an invite link allocated.",
+    [query('sum(sf_rooms_total%s)' % sel('shared="true"'), "Shared")],
+    stat([{"value": 0, "color": "blue"}]))
+
+add(33, "Share Rate",
+    "What fraction of synced plans have been shared with somebody.",
+    [query("sum(sf_rooms_total%s) / sum(sf_rooms_total%s)" % (sel('shared="true"'), J), "Shared")],
+    stat([{"value": 0, "color": "blue"}, {"value": 0.1, "color": "green"}],
+         unit="percentunit", minmax=(0, 1)))
+
+add(34, "Plan Access",
+    "One row per person-to-plan link. Creating a plan gives you one; joining somebody's shared plan gives you another. So this is plans plus extra people on them.",
+    [query("sum(sf_room_members_total%s)" % J, "Access grants")],
+    stat(GREEN))
+
+add(38, "Collaborators",
+    "People editing plans they do not own: access grants minus plans. This is the number that says whether sharing is actually being used, rather than just available.",
+    [query("clamp_min(sum(sf_room_members_total%s) - sum(sf_rooms_total%s), 0)" % (J, J), "Collaborators")],
+    stat([{"value": 0, "color": "#6a6a6a"}, {"value": 1, "color": "green"}]))
+
+add(35, "Factories per Synced Plan",
+    "sf_room_factories_total / sf_rooms_total.",
+    [query("sum(sf_room_factories_total%s) / sum(sf_rooms_total%s)" % (J, J), "Factories")],
+    stat(BLUE, color_mode="value", decimals=1))
+
+add(36, "Synced Plans Over Time",
+    "Stacked by whether the plan has an invite link.",
+    [query("sum by (shared) (sf_rooms_total%s)" % J, "{{shared}}")],
+    timeseries(fill=25, stack="normal"))
+
+add(37, "Accounts and Access Over Time",
+    "All three grow in normal use. Access falling without accounts falling is the sweeper clearing deleted plans.",
+    [query("sum(sf_users_total%s)" % J, "Accounts", "A"),
+     query("sum(sf_room_members_total%s)" % J, "Access grants", "B"),
+     query("sum(sf_rooms_total%s)" % J, "Synced plans", "C")],
+    timeseries(fill=10))
+
+# ------------------------------------------------------------- edits and activity
+# Note the shape of the 24h expression. sf_room_revisions is a gauge, not a counter,
+# because deleting a plan removes its edits from the sum, so increase() is invalid
+# here. The offset difference is the gauge-appropriate form, clamped because a
+# deletion can otherwise make it negative.
+EDITS_24H = "clamp_min(sum(sf_room_revisions%s) - sum(sf_room_revisions%s offset 24h), 0)" % (J, J)
+
+add(60, "Edits, All Time",
+    "Accepted edits summed across live plans. Falls when a plan is deleted, because those edits no longer exist; that is why it is a gauge rather than a counter.",
+    [query("sum(sf_room_revisions%s)" % J, "Edits")],
+    stat(BLUE, graph="area", color_mode="background_solid"))
+
+add(61, "Edits, Last 24h",
+    "The change over 24 hours, clamped at zero. A large deletion will read as a flat zero for a day; that is the known cost of sourcing this from a gauge.",
+    [query(EDITS_24H, "Edits")],
+    stat([{"value": 0, "color": "#6a6a6a"}, {"value": 1, "color": "green"}], graph="area"))
+
+add(62, "Edits Over Time",
+    "The cumulative line. The strongest single indicator of whether the planner is being used.",
+    [query("sum(sf_room_revisions%s)" % J, "Edits")],
+    timeseries(fill=18, fixed="blue", points="never", width=3))
+
+add(63, "Edits per 24h, Over Time",
+    "Rolling 24-hour edit count. Any window works by changing the offset in the query.",
+    [query(EDITS_24H, "Edits in 24h")],
+    timeseries(fill=25, fixed="green", points="never"))
+
+add(64, "Active Accounts",
+    "Accounts whose last accepted edit falls inside each window. Signing in, creating a plan and joining one are not edits and do not count.",
+    [query('sum(sf_active_accounts%s)' % sel('window="1h"'), "1 hour", "A"),
+     query('sum(sf_active_accounts%s)' % sel('window="24h"'), "24 hours", "B"),
+     query('sum(sf_active_accounts%s)' % sel('window="7d"'), "7 days", "C"),
+     query('sum(sf_active_accounts%s)' % sel('window="14d"'), "14 days", "D"),
+     query('sum(sf_active_accounts%s)' % sel('window="30d"'), "30 days", "E")],
+    stat(GREEN, color_mode="value", text_mode="value_and_name"))
+
+add(65, "Active Accounts Over Time",
+    "The windows plotted together. The 30-day line is thin for the first month after release: it is seeded from an activity log that is trimmed per plan, so early history is partial.",
+    [query("sum by (window) (sf_active_accounts%s)" % J, "{{window}}")],
+    timeseries(fill=8))
+
+add(66, "Stickiness",
+    "Accounts active in a day against those active in a month. High means people come back; low means they visit once.",
+    [query('sum(sf_active_accounts%s) / sum(sf_active_accounts%s)'
+           % (sel('window="24h"'), sel('window="30d"')), "Daily over monthly")],
+    stat([{"value": 0, "color": "red"}, {"value": 0.1, "color": "#EAB839"}, {"value": 0.25, "color": "green"}],
+         unit="percentunit", minmax=(0, 1)))
+
+# ------------------------------------------------------------- biggest and busiest
+add(70, "Biggest Plans",
+    "The largest synced plans by factory count, with the account that owns each. Top 20 only.",
+    [query("sort_desc(sf_room_factories%s)" % J, "{{owner}} · {{room_id}}", instant=True)],
+    bargauge(display_name="${__field.labels.owner} · ${__field.labels.room_id}"))
+
+add(71, "Busiest Accounts",
+    "Accepted edits per account. Approximate by design: the count is written after the edit commits and is allowed to fail, and it starts from zero at release rather than being backfilled. Top 20 only.",
+    [query("sort_desc(sf_user_edits%s)" % J, "{{username}}", instant=True)],
+    bargauge(display_name="${__field.labels.username}"))
+
+add(72, "Accounts With the Most Factories",
+    "Factories summed over the synced plans each account created. Top 20 only.",
+    [query("sort_desc(sf_user_factories%s)" % J, "{{username}}", instant=True)],
+    bargauge(display_name="${__field.labels.username}"))
+
+add(73, "Largest Plan",
+    "Factory count of the biggest single synced plan.",
+    [query("max(sf_room_factories%s)" % J, "Factories")],
+    stat(BLUE, color_mode="value"))
+
+# ------------------------------------------------------------ client versions
+add(40, "Browsers by Build",
+    'Active browsers by the build they are running. Anything the version pattern does not recognise counts under "other".',
+    [query("sort_desc(sum by (version) (sf_clients_by_version%s))" % J, "{{version}}", instant=True)],
+    bargauge(display_name="${__field.labels.version}"))
+
+add(41, "Build Adoption Over Time",
+    "Stacked. After a release, watch the old band drain. While it is still wide, a breaking change will hurt.",
+    [query("sum by (version) (sf_clients_by_version%s)" % J, "{{version}}")],
+    timeseries(fill=25, stack="normal"))
+
+add(42, "On an Unrecognised Build",
+    'Browsers reporting a version the label pattern refused. Expect zero. Anything sustained means either a bad build string or somebody poking the endpoint.',
+    [query('sum(sf_clients_by_version%s) or vector(0)' % sel('version="other"'), "Other")],
+    stat([{"value": 0, "color": "green"}, {"value": 1, "color": "#EAB839"}, {"value": 10, "color": "red"}]))
+
+# ------------------------------------------------------------ collection health
+add(50, "Scrape Up",
+    "Prometheus's own view of whether this target answered. 0 means the endpoint is unreachable, the token is wrong, or the build has no /metrics route.",
+    [query('min(up%s)' % J, "Up")],
+    stat([{"value": 0, "color": "red"}, {"value": 1, "color": "green"}]))
+
+add(51, "Scrape Duration",
+    "How long the endpoint takes to answer. The database gauges are cached for 10s, so most scrapes are cheap and one in every few does real work.",
+    [query('max(scrape_duration_seconds%s)' % J, "Duration")],
+    stat(GREEN, unit="s", color_mode="value", decimals=3))
+
+add(52, "Collection Health Over Time",
+    "Both lines should sit flat at 1. Scrape up dropping is a transport or auth problem; database readable dropping means Mongo is unreachable and the room and account gauges are stale rather than zero.",
+    [query('min(up%s)' % J, "Scrape up", "A"),
+     query("min(sf_metrics_database_up%s)" % J, "Database readable", "B")],
+    timeseries(fill=10, minmax=(0, 1), decimals=0))
+
+
+def item(x, y, w, h, pid):
+    return {
+        "kind": "GridLayoutItem",
+        "spec": {"x": x, "y": y, "width": w, "height": h,
+                 "element": {"kind": "ElementReference", "name": "panel-%d" % pid}},
+    }
+
+
+def row(title, items):
+    return {
+        "kind": "RowsLayoutRow",
+        "spec": {"title": title, "collapse": False,
+                 "layout": {"kind": "GridLayout", "spec": {"items": items}}},
+    }
+
+
+# Row titles say where the numbers come from, because the two sources behave completely
+# differently and nothing on a panel itself reveals which it is. Anything marked "browsers"
+# is the heartbeat: it expires 15 minutes after a tab closes and reads zero overnight.
+# Anything marked "database" is permanent and survives a restart.
+rows = [
+    row("👥 Live Right Now · from browsers, 15 min window", [
+        item(0, 0, 5, 4, 1), item(5, 0, 5, 4, 2), item(10, 0, 4, 4, 3),
+        item(14, 0, 5, 4, 4), item(19, 0, 5, 4, 5),
+    ]),
+    row("✏️ Edits and Activity · from the database", [
+        item(0, 0, 5, 4, 60), item(5, 0, 5, 4, 61), item(10, 0, 4, 4, 66),
+        item(14, 0, 10, 4, 64),
+        item(0, 4, 12, 8, 62), item(12, 4, 12, 8, 63),
+        item(0, 12, 24, 8, 65),
+    ]),
+    row("🏆 Biggest and Busiest · from the database", [
+        item(0, 0, 4, 4, 73),
+        item(0, 4, 12, 10, 70), item(12, 0, 12, 10, 71),
+        item(12, 10, 12, 10, 72),
+    ]),
+    row("🏭 Synced Plans and Accounts · from the database", [
+        item(0, 0, 4, 4, 30), item(4, 0, 4, 4, 31), item(8, 0, 4, 4, 32),
+        item(12, 0, 4, 4, 33), item(16, 0, 4, 4, 34), item(20, 0, 4, 4, 38),
+        item(0, 4, 4, 4, 35),
+        item(4, 4, 10, 8, 36), item(14, 4, 10, 8, 37),
+    ]),
+    row("📈 Browsers Over Time · from browsers, 15 min window", [
+        item(0, 0, 12, 8, 10), item(12, 0, 12, 8, 11), item(0, 8, 24, 4, 12),
+    ]),
+    row("🗂️ Plans in Browsers · from browsers, includes local plans", [
+        item(0, 0, 6, 4, 20), item(6, 0, 6, 4, 21), item(12, 0, 6, 4, 22),
+        item(18, 0, 3, 4, 23), item(21, 0, 3, 4, 24),
+        item(0, 4, 12, 8, 25), item(12, 4, 12, 8, 26),
+    ]),
+    row("🏷️ Client Builds · from browsers", [
+        item(0, 0, 12, 8, 40), item(12, 0, 12, 8, 41), item(0, 8, 6, 4, 42),
+    ]),
+    row("🩺 Collection Health", [
+        item(0, 0, 6, 4, 50), item(0, 4, 6, 4, 51), item(6, 0, 18, 8, 52),
+    ]),
+]
+
+dashboard = {
+    "apiVersion": "dashboard.grafana.app/v2",
+    "kind": "Dashboard",
+    "metadata": {"name": NAME, "namespace": "default"},
+    "spec": {
+        "annotations": [{
+            "kind": "AnnotationQuery",
+            "spec": {
+                "query": {"kind": "DataQuery", "group": "grafana", "version": "v0",
+                          "datasource": {"name": "-- Grafana --"}, "spec": {}},
+                "enable": True, "hide": True, "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts", "builtIn": True,
+            },
+        }],
+        "cursorSync": "Crosshair",
+        "description": ("Satisfactory Factories planner usage. Server-derived room and account "
+                        "gauges, plus an anonymous browser heartbeat that counts local plans and "
+                        "signed-out users the server cannot see. Every query is pinned to "
+                        'job="%s"; production and preview export the same metric names.' % JOB),
+        "editable": True,
+        "elements": elements,
+        "layout": {"kind": "RowsLayout", "spec": {"rows": rows}},
+        "links": [],
+        "liveNow": False,
+        "preload": False,
+        "tags": ["satisfactory-factories", "planner", "telemetry"],
+        "timeSettings": {
+            "timezone": "browser", "from": "now-24h", "to": "now", "autoRefresh": "30s",
+            "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+            "hideTimepicker": False, "fiscalYearStartMonth": 0,
+        },
+        "title": "Satisfactory Factories — Planner Metrics" + TITLE_SUFFIX,
+        "variables": [],
+    },
+}
+
+print(json.dumps(dashboard, indent=2, ensure_ascii=False))

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -1,0 +1,4797 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "satisfactory-factories-metrics-preview",
+    "namespace": "default"
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true
+        }
+      }
+    ],
+    "cursorSync": "Crosshair",
+    "description": "Satisfactory Factories planner usage. Server-derived room and account gauges, plus an anonymous browser heartbeat that counts local plans and signed-out users the server cannot see. Every query is pinned to job=\"satisfactory-factories-preview\"; production and preview export the same metric names.",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "Active Browsers",
+          "description": "Browsers that sent a heartbeat in the last 15 minutes. Counts local-only and signed-out users, who are invisible to the server otherwise.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_clients{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Active",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Signed In vs Signed Out",
+          "description": "Whether somebody is signed in. Never who.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_clients{job=\"satisfactory-factories-preview\",signed_in=\"true\"})",
+                        "legendFormat": "Signed in",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_clients{job=\"satisfactory-factories-preview\",signed_in=\"false\"})",
+                        "legendFormat": "Signed out",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Live Sockets",
+          "description": "Open realtime connections. One socket carries every synced tab in a browser, so this is below the active-browser count by design.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_ws_connections{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Sockets",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "id": 4,
+          "title": "Signed-in Share",
+          "description": "What fraction of active browsers have an account signed in.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_clients{job=\"satisfactory-factories-preview\",signed_in=\"true\"}) / sum(sf_active_clients{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Signed in",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 0.2,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 0.4,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "id": 5,
+          "title": "Database Readable",
+          "description": "1 when the last scrape read Mongo. At 0 the room and account gauges are frozen at their last values, not actually zero. This is the one to alert on.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "min(sf_metrics_database_up{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Database",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-10": {
+        "kind": "Panel",
+        "spec": {
+          "id": 10,
+          "title": "Active Browsers Over Time",
+          "description": "Stacked, so the total height is every active browser.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (signed_in) (sf_active_clients{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{signed_in}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-11": {
+        "kind": "Panel",
+        "spec": {
+          "id": 11,
+          "title": "Live Sockets Over Time",
+          "description": "Realtime connections held open.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_ws_connections{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Sockets",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max(max_over_time(sf_ws_connections{job=\"satisfactory-factories-preview\"}[24h]))",
+                        "legendFormat": "24h peak",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 15,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-12": {
+        "kind": "Panel",
+        "spec": {
+          "id": 12,
+          "title": "Records",
+          "description": "Now, and the 24 hour average and peak. Built from subqueries over the scrape series.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_clients{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Browsers now",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "avg_over_time(sum(sf_active_clients{job=\"satisfactory-factories-preview\"})[24h:5m])",
+                        "legendFormat": "24h avg browsers",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max_over_time(sum(sf_active_clients{job=\"satisfactory-factories-preview\"})[24h:5m])",
+                        "legendFormat": "24h peak browsers",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max(max_over_time(sf_ws_connections{job=\"satisfactory-factories-preview\"}[24h]))",
+                        "legendFormat": "24h peak sockets",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-20": {
+        "kind": "Panel",
+        "spec": {
+          "id": 20,
+          "title": "Plans Open in Browsers",
+          "description": "Planner tabs, not browser tabs. Local plans never reach the server, so this is the only place they are counted.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_tabs{job=\"satisfactory-factories-preview\",kind=\"local\"})",
+                        "legendFormat": "Local",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_tabs{job=\"satisfactory-factories-preview\",kind=\"cloud\"})",
+                        "legendFormat": "Cloud",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-21": {
+        "kind": "Panel",
+        "spec": {
+          "id": 21,
+          "title": "Cloud Share of Plans",
+          "description": "What fraction of open plans are synced rather than local only. The headline adoption number for syncing.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_tabs{job=\"satisfactory-factories-preview\",kind=\"cloud\"}) / sum(sf_client_tabs{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Synced",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 0.25,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 0.5,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-22": {
+        "kind": "Panel",
+        "spec": {
+          "id": 22,
+          "title": "Factories in Browsers",
+          "description": "Factories summed across active browsers, local plans included.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Factories",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-23": {
+        "kind": "Panel",
+        "spec": {
+          "id": 23,
+          "title": "Plans per Browser",
+          "description": "Average planner tabs open per active browser.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_tabs{job=\"satisfactory-factories-preview\"}) / sum(sf_active_clients{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Plans",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-24": {
+        "kind": "Panel",
+        "spec": {
+          "id": 24,
+          "title": "Factories per Browser",
+          "description": "Average factories per active browser. The rough answer to how big a plan people actually build.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_factories_total{job=\"satisfactory-factories-preview\"}) / sum(sf_active_clients{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Factories",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-25": {
+        "kind": "Panel",
+        "spec": {
+          "id": 25,
+          "title": "Plans Over Time, Local vs Cloud",
+          "description": "Stacked. The cloud band growing against the local band is sync adoption.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (kind) (sf_client_tabs{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{kind}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-26": {
+        "kind": "Panel",
+        "spec": {
+          "id": 26,
+          "title": "Factories in Browsers Over Time",
+          "description": "Total factories across active browsers.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Factories",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "fixed",
+                    "fixedColor": "blue"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 18,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 3,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-30": {
+        "kind": "Panel",
+        "spec": {
+          "id": 30,
+          "title": "Registered Accounts",
+          "description": "Rows in the users collection.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_users_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Accounts",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-31": {
+        "kind": "Panel",
+        "spec": {
+          "id": 31,
+          "title": "Synced Plans",
+          "description": "Live rooms on the server, tombstoned ones excluded.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Synced plans",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-32": {
+        "kind": "Panel",
+        "spec": {
+          "id": 32,
+          "title": "Shared Plans",
+          "description": "Synced plans that have an invite link allocated.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories-preview\",shared=\"true\"})",
+                        "legendFormat": "Shared",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-33": {
+        "kind": "Panel",
+        "spec": {
+          "id": 33,
+          "title": "Share Rate",
+          "description": "What fraction of synced plans have been shared with somebody.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories-preview\",shared=\"true\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Shared",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      },
+                      {
+                        "value": 0.1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-34": {
+        "kind": "Panel",
+        "spec": {
+          "id": 34,
+          "title": "Plan Access",
+          "description": "One row per person-to-plan link. Creating a plan gives you one; joining somebody's shared plan gives you another. So this is plans plus extra people on them.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_members_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Access grants",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-38": {
+        "kind": "Panel",
+        "spec": {
+          "id": 38,
+          "title": "Collaborators",
+          "description": "People editing plans they do not own: access grants minus plans. This is the number that says whether sharing is actually being used, rather than just available.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "clamp_min(sum(sf_room_members_total{job=\"satisfactory-factories-preview\"}) - sum(sf_rooms_total{job=\"satisfactory-factories-preview\"}), 0)",
+                        "legendFormat": "Collaborators",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-35": {
+        "kind": "Panel",
+        "spec": {
+          "id": 35,
+          "title": "Factories per Synced Plan",
+          "description": "sf_room_factories_total / sf_rooms_total.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Factories",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-36": {
+        "kind": "Panel",
+        "spec": {
+          "id": 36,
+          "title": "Synced Plans Over Time",
+          "description": "Stacked by whether the plan has an invite link.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (shared) (sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{shared}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-37": {
+        "kind": "Panel",
+        "spec": {
+          "id": 37,
+          "title": "Accounts and Access Over Time",
+          "description": "All three grow in normal use. Access falling without accounts falling is the sweeper clearing deleted plans.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_users_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Accounts",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_members_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Access grants",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Synced plans",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-60": {
+        "kind": "Panel",
+        "spec": {
+          "id": 60,
+          "title": "Edits, All Time",
+          "description": "Accepted edits summed across live plans. Falls when a plan is deleted, because those edits no longer exist; that is why it is a gauge rather than a counter.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_revisions{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Edits",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-61": {
+        "kind": "Panel",
+        "spec": {
+          "id": 61,
+          "title": "Edits, Last 24h",
+          "description": "The change over 24 hours, clamped at zero. A large deletion will read as a flat zero for a day; that is the known cost of sourcing this from a gauge.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "clamp_min(sum(sf_room_revisions{job=\"satisfactory-factories-preview\"}) - sum(sf_room_revisions{job=\"satisfactory-factories-preview\"} offset 24h), 0)",
+                        "legendFormat": "Edits",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-62": {
+        "kind": "Panel",
+        "spec": {
+          "id": 62,
+          "title": "Edits Over Time",
+          "description": "The cumulative line. The strongest single indicator of whether the planner is being used.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_revisions{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Edits",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "fixed",
+                    "fixedColor": "blue"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 18,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 3,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-63": {
+        "kind": "Panel",
+        "spec": {
+          "id": 63,
+          "title": "Edits per 24h, Over Time",
+          "description": "Rolling 24-hour edit count. Any window works by changing the offset in the query.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "clamp_min(sum(sf_room_revisions{job=\"satisfactory-factories-preview\"}) - sum(sf_room_revisions{job=\"satisfactory-factories-preview\"} offset 24h), 0)",
+                        "legendFormat": "Edits in 24h",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "fixed",
+                    "fixedColor": "green"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-64": {
+        "kind": "Panel",
+        "spec": {
+          "id": 64,
+          "title": "Active Accounts",
+          "description": "Accounts whose last accepted edit falls inside each window. Signing in, creating a plan and joining one are not edits and do not count.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"1h\"})",
+                        "legendFormat": "1 hour",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"14d\"})",
+                        "legendFormat": "14 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-65": {
+        "kind": "Panel",
+        "spec": {
+          "id": 65,
+          "title": "Active Accounts Over Time",
+          "description": "The windows plotted together. The 30-day line is thin for the first month after release: it is seeded from an activity log that is trimmed per plan, so early history is partial.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (window) (sf_active_accounts{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{window}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-66": {
+        "kind": "Panel",
+        "spec": {
+          "id": 66,
+          "title": "Stickiness",
+          "description": "Accounts active in a day against those active in a month. High means people come back; low means they visit once.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"24h\"}) / sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "Daily over monthly",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 0.1,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 0.25,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-70": {
+        "kind": "Panel",
+        "spec": {
+          "id": 70,
+          "title": "Biggest Plans",
+          "description": "The largest synced plans by factory count, with the account that owns each. Top 20 only.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sf_room_factories{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{owner}} · {{room_id}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.owner} · ${__field.labels.room_id}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-71": {
+        "kind": "Panel",
+        "spec": {
+          "id": 71,
+          "title": "Busiest Accounts",
+          "description": "Accepted edits per account. Approximate by design: the count is written after the edit commits and is allowed to fail, and it starts from zero at release rather than being backfilled. Top 20 only.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sf_user_edits{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{username}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.username}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-72": {
+        "kind": "Panel",
+        "spec": {
+          "id": 72,
+          "title": "Accounts With the Most Factories",
+          "description": "Factories summed over the synced plans each account created. Top 20 only.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sf_user_factories{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{username}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.username}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-73": {
+        "kind": "Panel",
+        "spec": {
+          "id": 73,
+          "title": "Largest Plan",
+          "description": "Factory count of the biggest single synced plan.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max(sf_room_factories{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Factories",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-40": {
+        "kind": "Panel",
+        "spec": {
+          "id": 40,
+          "title": "Browsers by Build",
+          "description": "Active browsers by the build they are running. Anything the version pattern does not recognise counts under \"other\".",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sum by (version) (sf_clients_by_version{job=\"satisfactory-factories-preview\"}))",
+                        "legendFormat": "{{version}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.version}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-41": {
+        "kind": "Panel",
+        "spec": {
+          "id": 41,
+          "title": "Build Adoption Over Time",
+          "description": "Stacked. After a release, watch the old band drain. While it is still wide, a breaking change will hurt.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (version) (sf_clients_by_version{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{version}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-42": {
+        "kind": "Panel",
+        "spec": {
+          "id": 42,
+          "title": "On an Unrecognised Build",
+          "description": "Browsers reporting a version the label pattern refused. Expect zero. Anything sustained means either a bad build string or somebody poking the endpoint.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_clients_by_version{job=\"satisfactory-factories-preview\",version=\"other\"}) or vector(0)",
+                        "legendFormat": "Other",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 1,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 10,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-50": {
+        "kind": "Panel",
+        "spec": {
+          "id": 50,
+          "title": "Scrape Up",
+          "description": "Prometheus's own view of whether this target answered. 0 means the endpoint is unreachable, the token is wrong, or the build has no /metrics route.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "min(up{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Up",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-51": {
+        "kind": "Panel",
+        "spec": {
+          "id": 51,
+          "title": "Scrape Duration",
+          "description": "How long the endpoint takes to answer. The database gauges are cached for 10s, so most scrapes are cheap and one in every few does real work.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max(scrape_duration_seconds{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Duration",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-52": {
+        "kind": "Panel",
+        "spec": {
+          "id": 52,
+          "title": "Collection Health Over Time",
+          "description": "Both lines should sit flat at 1. Scrape up dropping is a transport or auth problem; database readable dropping means Mongo is unreachable and the room and account gauges are stale rather than zero.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "min(up{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Scrape up",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "min(sf_metrics_database_up{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Database readable",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "decimals": 0,
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "👥 Live Right Now · from browsers, 15 min window",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-1"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 5,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-2"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 10,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-3"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 14,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-4"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 19,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-5"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "✏️ Edits and Activity · from the database",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-60"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 5,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-61"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 10,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-66"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 14,
+                        "y": 0,
+                        "width": 10,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-64"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-62"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-63"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 12,
+                        "width": 24,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-65"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🏆 Biggest and Busiest · from the database",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-73"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-70"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-71"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 10,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-72"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🏭 Synced Plans and Accounts · from the database",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-30"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 4,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-31"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 8,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-32"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-33"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 16,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-34"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 20,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-38"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-35"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 4,
+                        "y": 4,
+                        "width": 10,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-36"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 14,
+                        "y": 4,
+                        "width": 10,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-37"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "📈 Browsers Over Time · from browsers, 15 min window",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-10"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-11"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 8,
+                        "width": 24,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-12"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🗂️ Plans in Browsers · from browsers, includes local plans",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-20"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 6,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-21"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-22"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 18,
+                        "y": 0,
+                        "width": 3,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-23"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 21,
+                        "y": 0,
+                        "width": 3,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-24"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-25"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-26"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🏷️ Client Builds · from browsers",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-40"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-41"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 8,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-42"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🩺 Collection Health",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-50"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-51"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 6,
+                        "y": 0,
+                        "width": 18,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-52"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "satisfactory-factories",
+      "planner",
+      "telemetry"
+    ],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-24h",
+      "to": "now",
+      "autoRefresh": "30s",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Satisfactory Factories — Planner Metrics (Preview)",
+    "variables": []
+  }
+}

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -1,0 +1,4797 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "satisfactory-factories-metrics",
+    "namespace": "default"
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true
+        }
+      }
+    ],
+    "cursorSync": "Crosshair",
+    "description": "Satisfactory Factories planner usage. Server-derived room and account gauges, plus an anonymous browser heartbeat that counts local plans and signed-out users the server cannot see. Every query is pinned to job=\"satisfactory-factories\"; production and preview export the same metric names.",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "Active Browsers",
+          "description": "Browsers that sent a heartbeat in the last 15 minutes. Counts local-only and signed-out users, who are invisible to the server otherwise.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_clients{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Active",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Signed In vs Signed Out",
+          "description": "Whether somebody is signed in. Never who.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_clients{job=\"satisfactory-factories\",signed_in=\"true\"})",
+                        "legendFormat": "Signed in",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_clients{job=\"satisfactory-factories\",signed_in=\"false\"})",
+                        "legendFormat": "Signed out",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Live Sockets",
+          "description": "Open realtime connections. One socket carries every synced tab in a browser, so this is below the active-browser count by design.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_ws_connections{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Sockets",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "id": 4,
+          "title": "Signed-in Share",
+          "description": "What fraction of active browsers have an account signed in.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_clients{job=\"satisfactory-factories\",signed_in=\"true\"}) / sum(sf_active_clients{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Signed in",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 0.2,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 0.4,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "id": 5,
+          "title": "Database Readable",
+          "description": "1 when the last scrape read Mongo. At 0 the room and account gauges are frozen at their last values, not actually zero. This is the one to alert on.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "min(sf_metrics_database_up{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Database",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-10": {
+        "kind": "Panel",
+        "spec": {
+          "id": 10,
+          "title": "Active Browsers Over Time",
+          "description": "Stacked, so the total height is every active browser.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (signed_in) (sf_active_clients{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{signed_in}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-11": {
+        "kind": "Panel",
+        "spec": {
+          "id": 11,
+          "title": "Live Sockets Over Time",
+          "description": "Realtime connections held open.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_ws_connections{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Sockets",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max(max_over_time(sf_ws_connections{job=\"satisfactory-factories\"}[24h]))",
+                        "legendFormat": "24h peak",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 15,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-12": {
+        "kind": "Panel",
+        "spec": {
+          "id": 12,
+          "title": "Records",
+          "description": "Now, and the 24 hour average and peak. Built from subqueries over the scrape series.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_clients{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Browsers now",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "avg_over_time(sum(sf_active_clients{job=\"satisfactory-factories\"})[24h:5m])",
+                        "legendFormat": "24h avg browsers",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max_over_time(sum(sf_active_clients{job=\"satisfactory-factories\"})[24h:5m])",
+                        "legendFormat": "24h peak browsers",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max(max_over_time(sf_ws_connections{job=\"satisfactory-factories\"}[24h]))",
+                        "legendFormat": "24h peak sockets",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-20": {
+        "kind": "Panel",
+        "spec": {
+          "id": 20,
+          "title": "Plans Open in Browsers",
+          "description": "Planner tabs, not browser tabs. Local plans never reach the server, so this is the only place they are counted.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_tabs{job=\"satisfactory-factories\",kind=\"local\"})",
+                        "legendFormat": "Local",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_tabs{job=\"satisfactory-factories\",kind=\"cloud\"})",
+                        "legendFormat": "Cloud",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-21": {
+        "kind": "Panel",
+        "spec": {
+          "id": 21,
+          "title": "Cloud Share of Plans",
+          "description": "What fraction of open plans are synced rather than local only. The headline adoption number for syncing.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_tabs{job=\"satisfactory-factories\",kind=\"cloud\"}) / sum(sf_client_tabs{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Synced",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 0.25,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 0.5,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-22": {
+        "kind": "Panel",
+        "spec": {
+          "id": 22,
+          "title": "Factories in Browsers",
+          "description": "Factories summed across active browsers, local plans included.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Factories",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-23": {
+        "kind": "Panel",
+        "spec": {
+          "id": 23,
+          "title": "Plans per Browser",
+          "description": "Average planner tabs open per active browser.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_tabs{job=\"satisfactory-factories\"}) / sum(sf_active_clients{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Plans",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-24": {
+        "kind": "Panel",
+        "spec": {
+          "id": 24,
+          "title": "Factories per Browser",
+          "description": "Average factories per active browser. The rough answer to how big a plan people actually build.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_factories_total{job=\"satisfactory-factories\"}) / sum(sf_active_clients{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Factories",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-25": {
+        "kind": "Panel",
+        "spec": {
+          "id": 25,
+          "title": "Plans Over Time, Local vs Cloud",
+          "description": "Stacked. The cloud band growing against the local band is sync adoption.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (kind) (sf_client_tabs{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{kind}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-26": {
+        "kind": "Panel",
+        "spec": {
+          "id": 26,
+          "title": "Factories in Browsers Over Time",
+          "description": "Total factories across active browsers.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_client_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Factories",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "fixed",
+                    "fixedColor": "blue"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 18,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 3,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-30": {
+        "kind": "Panel",
+        "spec": {
+          "id": 30,
+          "title": "Registered Accounts",
+          "description": "Rows in the users collection.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_users_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Accounts",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-31": {
+        "kind": "Panel",
+        "spec": {
+          "id": 31,
+          "title": "Synced Plans",
+          "description": "Live rooms on the server, tombstoned ones excluded.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Synced plans",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-32": {
+        "kind": "Panel",
+        "spec": {
+          "id": 32,
+          "title": "Shared Plans",
+          "description": "Synced plans that have an invite link allocated.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories\",shared=\"true\"})",
+                        "legendFormat": "Shared",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-33": {
+        "kind": "Panel",
+        "spec": {
+          "id": 33,
+          "title": "Share Rate",
+          "description": "What fraction of synced plans have been shared with somebody.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories\",shared=\"true\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Shared",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      },
+                      {
+                        "value": 0.1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-34": {
+        "kind": "Panel",
+        "spec": {
+          "id": 34,
+          "title": "Plan Access",
+          "description": "One row per person-to-plan link. Creating a plan gives you one; joining somebody's shared plan gives you another. So this is plans plus extra people on them.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_members_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Access grants",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-38": {
+        "kind": "Panel",
+        "spec": {
+          "id": 38,
+          "title": "Collaborators",
+          "description": "People editing plans they do not own: access grants minus plans. This is the number that says whether sharing is actually being used, rather than just available.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "clamp_min(sum(sf_room_members_total{job=\"satisfactory-factories\"}) - sum(sf_rooms_total{job=\"satisfactory-factories\"}), 0)",
+                        "legendFormat": "Collaborators",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-35": {
+        "kind": "Panel",
+        "spec": {
+          "id": 35,
+          "title": "Factories per Synced Plan",
+          "description": "sf_room_factories_total / sf_rooms_total.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_factories_total{job=\"satisfactory-factories\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Factories",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-36": {
+        "kind": "Panel",
+        "spec": {
+          "id": 36,
+          "title": "Synced Plans Over Time",
+          "description": "Stacked by whether the plan has an invite link.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (shared) (sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{shared}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-37": {
+        "kind": "Panel",
+        "spec": {
+          "id": 37,
+          "title": "Accounts and Access Over Time",
+          "description": "All three grow in normal use. Access falling without accounts falling is the sweeper clearing deleted plans.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_users_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Accounts",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_members_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Access grants",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Synced plans",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-60": {
+        "kind": "Panel",
+        "spec": {
+          "id": 60,
+          "title": "Edits, All Time",
+          "description": "Accepted edits summed across live plans. Falls when a plan is deleted, because those edits no longer exist; that is why it is a gauge rather than a counter.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_revisions{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Edits",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-61": {
+        "kind": "Panel",
+        "spec": {
+          "id": 61,
+          "title": "Edits, Last 24h",
+          "description": "The change over 24 hours, clamped at zero. A large deletion will read as a flat zero for a day; that is the known cost of sourcing this from a gauge.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "clamp_min(sum(sf_room_revisions{job=\"satisfactory-factories\"}) - sum(sf_room_revisions{job=\"satisfactory-factories\"} offset 24h), 0)",
+                        "legendFormat": "Edits",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-62": {
+        "kind": "Panel",
+        "spec": {
+          "id": 62,
+          "title": "Edits Over Time",
+          "description": "The cumulative line. The strongest single indicator of whether the planner is being used.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_revisions{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Edits",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "fixed",
+                    "fixedColor": "blue"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 18,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 3,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-63": {
+        "kind": "Panel",
+        "spec": {
+          "id": 63,
+          "title": "Edits per 24h, Over Time",
+          "description": "Rolling 24-hour edit count. Any window works by changing the offset in the query.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "clamp_min(sum(sf_room_revisions{job=\"satisfactory-factories\"}) - sum(sf_room_revisions{job=\"satisfactory-factories\"} offset 24h), 0)",
+                        "legendFormat": "Edits in 24h",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "fixed",
+                    "fixedColor": "green"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-64": {
+        "kind": "Panel",
+        "spec": {
+          "id": 64,
+          "title": "Active Accounts",
+          "description": "Accounts whose last accepted edit falls inside each window. Signing in, creating a plan and joining one are not edits and do not count.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"1h\"})",
+                        "legendFormat": "1 hour",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"14d\"})",
+                        "legendFormat": "14 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-65": {
+        "kind": "Panel",
+        "spec": {
+          "id": 65,
+          "title": "Active Accounts Over Time",
+          "description": "The windows plotted together. The 30-day line is thin for the first month after release: it is seeded from an activity log that is trimmed per plan, so early history is partial.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (window) (sf_active_accounts{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{window}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-66": {
+        "kind": "Panel",
+        "spec": {
+          "id": 66,
+          "title": "Stickiness",
+          "description": "Accounts active in a day against those active in a month. High means people come back; low means they visit once.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"24h\"}) / sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "Daily over monthly",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 0.1,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 0.25,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-70": {
+        "kind": "Panel",
+        "spec": {
+          "id": 70,
+          "title": "Biggest Plans",
+          "description": "The largest synced plans by factory count, with the account that owns each. Top 20 only.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sf_room_factories{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{owner}} · {{room_id}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.owner} · ${__field.labels.room_id}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-71": {
+        "kind": "Panel",
+        "spec": {
+          "id": 71,
+          "title": "Busiest Accounts",
+          "description": "Accepted edits per account. Approximate by design: the count is written after the edit commits and is allowed to fail, and it starts from zero at release rather than being backfilled. Top 20 only.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sf_user_edits{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{username}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.username}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-72": {
+        "kind": "Panel",
+        "spec": {
+          "id": 72,
+          "title": "Accounts With the Most Factories",
+          "description": "Factories summed over the synced plans each account created. Top 20 only.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sf_user_factories{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{username}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.username}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-73": {
+        "kind": "Panel",
+        "spec": {
+          "id": 73,
+          "title": "Largest Plan",
+          "description": "Factory count of the biggest single synced plan.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max(sf_room_factories{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Factories",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-40": {
+        "kind": "Panel",
+        "spec": {
+          "id": 40,
+          "title": "Browsers by Build",
+          "description": "Active browsers by the build they are running. Anything the version pattern does not recognise counts under \"other\".",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sum by (version) (sf_clients_by_version{job=\"satisfactory-factories\"}))",
+                        "legendFormat": "{{version}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.version}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-41": {
+        "kind": "Panel",
+        "spec": {
+          "id": 41,
+          "title": "Build Adoption Over Time",
+          "description": "Stacked. After a release, watch the old band drain. While it is still wide, a breaking change will hurt.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (version) (sf_clients_by_version{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{version}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-42": {
+        "kind": "Panel",
+        "spec": {
+          "id": 42,
+          "title": "On an Unrecognised Build",
+          "description": "Browsers reporting a version the label pattern refused. Expect zero. Anything sustained means either a bad build string or somebody poking the endpoint.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_clients_by_version{job=\"satisfactory-factories\",version=\"other\"}) or vector(0)",
+                        "legendFormat": "Other",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 1,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 10,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-50": {
+        "kind": "Panel",
+        "spec": {
+          "id": 50,
+          "title": "Scrape Up",
+          "description": "Prometheus's own view of whether this target answered. 0 means the endpoint is unreachable, the token is wrong, or the build has no /metrics route.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "min(up{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Up",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-51": {
+        "kind": "Panel",
+        "spec": {
+          "id": 51,
+          "title": "Scrape Duration",
+          "description": "How long the endpoint takes to answer. The database gauges are cached for 10s, so most scrapes are cheap and one in every few does real work.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max(scrape_duration_seconds{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Duration",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-52": {
+        "kind": "Panel",
+        "spec": {
+          "id": 52,
+          "title": "Collection Health Over Time",
+          "description": "Both lines should sit flat at 1. Scrape up dropping is a transport or auth problem; database readable dropping means Mongo is unreachable and the room and account gauges are stale rather than zero.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "min(up{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Scrape up",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "min(sf_metrics_database_up{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Database readable",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "decimals": 0,
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "👥 Live Right Now · from browsers, 15 min window",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-1"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 5,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-2"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 10,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-3"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 14,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-4"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 19,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-5"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "✏️ Edits and Activity · from the database",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-60"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 5,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-61"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 10,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-66"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 14,
+                        "y": 0,
+                        "width": 10,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-64"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-62"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-63"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 12,
+                        "width": 24,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-65"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🏆 Biggest and Busiest · from the database",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-73"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-70"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-71"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 10,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-72"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🏭 Synced Plans and Accounts · from the database",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-30"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 4,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-31"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 8,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-32"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-33"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 16,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-34"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 20,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-38"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-35"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 4,
+                        "y": 4,
+                        "width": 10,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-36"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 14,
+                        "y": 4,
+                        "width": 10,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-37"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "📈 Browsers Over Time · from browsers, 15 min window",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-10"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-11"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 8,
+                        "width": 24,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-12"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🗂️ Plans in Browsers · from browsers, includes local plans",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-20"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 6,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-21"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-22"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 18,
+                        "y": 0,
+                        "width": 3,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-23"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 21,
+                        "y": 0,
+                        "width": 3,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-24"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-25"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-26"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🏷️ Client Builds · from browsers",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-40"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-41"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 8,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-42"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🩺 Collection Health",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-50"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-51"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 6,
+                        "y": 0,
+                        "width": 18,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-52"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "satisfactory-factories",
+      "planner",
+      "telemetry"
+    ],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-24h",
+      "to": "now",
+      "autoRefresh": "30s",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Satisfactory Factories — Planner Metrics",
+    "variables": []
+  }
+}


### PR DESCRIPTION
# ⚠️ MANUAL STEPS

**Nothing breaks on deploy if you do none of this.** The new metrics simply appear on `/metrics` and the dashboards are already in Grafana. But two things want doing.

### 1. Re-apply the dashboards (they gained 12 panels)

The JSON now lives in the repo at [`docs/grafana/`](docs/grafana/). To update the two already applied, `PUT` each to `.../dashboards/<metadata.name>` carrying the current `resourceVersion`. Full recipe in [`docs/grafana/README.md`](docs/grafana/README.md).

**I will do this myself once this merges and preview redeploys**, so you only need to touch it if you want it sooner.

### 2. Nothing else

No new env var, no migration to run, no schema change needing downtime. The `lastActiveAt` backfill runs itself at boot and is safe to repeat.

---

## What this adds

Answers to the ten questions raised in conversation. The metrics in #627 answer "what is happening right now", and half of them come from the browser heartbeat and expire 15 minutes after a tab closes. **These read Mongo, never expire, and survive a restart.**

| # | Question | Metric |
| --- | --- | --- |
| 1 | Factories monitored | `sf_room_factories_total` *(existing)* |
| 2 | Plans monitored | `sf_rooms_total` *(existing)* |
| 3 | Biggest plans | `sf_room_factories{room_id,owner}` |
| 4 | Busiest users | `sf_user_edits{username}` |
| 5 | Users with most factories | `sf_user_factories{username}` |
| 6 | Active accounts 24h/7d/14d/30d | `sf_active_accounts{window}` |
| 7 | Active within 1h | `sf_active_accounts{window="1h"}` |
| 8 | "Memberships" means nothing | Renamed **Plan Access**, plus a **Collaborators** panel |
| 9 | Local tabs, 15 min | `sf_client_tabs{kind="local"}` *(existing)* |
| 10 | Edits, 24h and cumulative | `sf_room_revisions` |

## The three decisions worth reviewing

**Edits are a gauge, not a counter.** `Room.revision` already counts accepted edits exactly (verified: `sum(revision)` = 84, op rows = 84). So `sf_room_revisions` sums it at scrape time. **No new writes, no persisted counter, no seed.** The cost is that it *falls* when a plan is deleted, because those edits genuinely no longer exist. The 24h panel is therefore `clamp_min(x - (x offset 24h), 0)` and not `increase()`, which is only valid on counters.

The first design was a persisted counter incremented "in the same transaction path". That is impossible here: **this backend has no transactions and Mongo runs standalone**. Removing the mechanism was better than working around it.

**`lastActiveAt` uses `$max`, never `$set`.** Ops queue per *room* (`enqueue(op.roomId, ...)`), so one person editing two rooms has no global ordering, and a post-commit write for the earlier op can land after the later one. `$set` would move the timestamp backwards. `$max` cannot, and as a bonus it makes the boot backfill safe to repeat, so that needs no marker or lock.

**`editCount` is approximate and says so in its help text.** `$inc` is atomic, so nothing is lost to concurrency; what is lost is the occasional post-commit write that never ran, because no metric may cost somebody their edit. Use it for ranking. `sf_room_revisions` is the exact number.

## Privacy and access

`sf_room_factories`, `sf_user_edits` and `sf_user_factories` carry **usernames and plan ids**. Deliberate: the operator looking at data the service already stores, in a different viewer.

`docs/telemetry.md` is unchanged and stays accurate. It describes what browsers *send*, and usernames are not in the heartbeat and will not be.

The top-20 caps bound what leaves the database **per scrape**. They do **not** bound Prometheus cardinality over the retention window: every username that ever enters the top 20 keeps a series for 90 days after it drops out. At this service's size that is tens of series. The earlier claim that "only the handful worth acting on ever leaves the database" was wrong and has been removed.

`docs/deployment.md` now states plainly that **the token is the access control**, that the compose files publish the API port on all host interfaces, and that an application-level private-address guard was considered and **rejected** because behind Docker and a tunnel it can pass public traffic while appearing to block it. A guard that fails open is worse than none.

## Two reviews, both RETHINK

The plan went through Codex twice and came back RETHINK both times. Ledger ids `1429710bd8fb` and `fb628bf6d7d3`. Round one killed the counter design outright. Round two found two real bugs and a gap:

- the backfill did not filter to `kind: 'op'`, so somebody who merely **joined** a plan would have been recorded as having edited one, contradicting the metric's own definition
- `$set` could move `lastActiveAt` backwards
- the dashboard generator was not in the repository at all

All three are fixed here, the third by committing [`docs/grafana/`](docs/grafana/). The full plan and both response tables are in [`.claude/plans/planner-usage-metrics-v2.md`](.claude/plans/planner-usage-metrics-v2.md).

## Caching

Two groups now, because the new aggregations are heavier than four counts.

| Group | Contents | TTL |
| --- | --- | --- |
| cheap | room counts, users, access grants, `sum(revision)` | 15s |
| expensive | three top-20 aggregations, five account windows | 120s |

With **in-flight coalescing**, so two scrapes arriving on expiry share one query instead of both running it. A failed load keeps the last good values and reports `sf_metrics_database_up 0` rather than blanking the panel. The top-N gauges are reset before repopulating on a successful refresh and left completely alone on a failed one, or an entry that dropped out would report its last value forever.

## Verification

| Gate | Result |
| --- | --- |
| `backend` vitest | **394 passed**, 29 files |
| `backend` tsc | clean |
| `common` vitest | **111 passed** |
| `web` vitest | **3027 passed**, 1 skipped |
| `web` vue-tsc | clean |
| `pnpm lint-check` | exit 0 |
| All 54 dashboard queries | validated against live Prometheus, **0 syntax errors, 0 duplicate series** |
| Metric names, code vs dashboard | **15 = 15**, none missing, none orphaned |

**38 new tests.** The ones worth naming:

- an op **still applies** when the editor stamp throws, and the room revision still bumps
- `lastActiveAt` never moves backwards
- the backfill ignores `joined`, `created` and `renamed`
- the backfill is safe to run twice and never lowers a live value
- `sf_room_revisions` falls on deletion, which is the documented behaviour
- a room whose `createdBy` is not a valid ObjectId does not fail the whole scrape
- an entry leaving the top 20 stops being exported
- ties break deterministically across two scrapes
- the cache coalesces concurrent callers into one load and keeps the last good value on failure

## Not in scope

Alerting rules, `collectDefaultMetrics`, and any change to the browser heartbeat or its 15-minute window.
