### PR TITLE
feat: registrations and sign-ins as rolling-window metrics

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -5,9 +5,13 @@ import { AuthController } from './auth.controller'
 import { AuthService } from './auth.service'
 import { JwtAuthGuard, OptionalJwtAuthGuard } from './jwt-auth.guard'
 import { User, UserSchema } from './user.schema'
+import { UserActivityModule } from '../user-activity/user-activity.module'
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: User.name, schema: UserSchema }])],
+  imports: [
+    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+    UserActivityModule, // The sign-in stamp.
+  ],
   controllers: [AuthController],
   providers: [AuthService, JwtAuthGuard, OptionalJwtAuthGuard],
   exports: [AuthService, JwtAuthGuard, OptionalJwtAuthGuard, MongooseModule],

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -5,6 +5,7 @@ import bcrypt from 'bcryptjs'
 import { Model } from 'mongoose'
 
 import { User, UserDocument } from './user.schema'
+import { UserActivityService } from '../user-activity/user-activity.service'
 
 /** Matches the Express API exactly; changing it changes who can register. */
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -23,6 +24,7 @@ export class AuthService {
   constructor (
     @InjectModel(User.name) private readonly userModel: Model<User>,
     private readonly jwtService: JwtService,
+    private readonly userActivity: UserActivityService,
   ) {}
 
   async register (username: string, password: string): Promise<{ message: string }> {
@@ -52,6 +54,14 @@ export class AuthService {
 
     const token = await this.jwtService.signAsync({ id: user._id, username: user.username })
     console.log(`Successfully signed in user ${username}`)
+
+    // Stamped after the token is issued and allowed to fail: a metrics write must never be
+    // the reason somebody cannot sign in.
+    try {
+      await this.userActivity.recordSignIn(String(user._id), new Date())
+    } catch (cause) {
+      console.error(`Failed to stamp the sign-in for ${username}`, cause)
+    }
 
     return { token }
   }

--- a/backend/src/auth/user.schema.ts
+++ b/backend/src/auth/user.schema.ts
@@ -42,10 +42,26 @@ export class User {
    */
   @Prop({ type: Number, default: 0 })
   editCount!: number
+
+  /**
+   * When this account last signed in. Separate from `lastActiveAt`, which is about editing:
+   * somebody can sign in, read their plan and change nothing, and that is a different fact.
+   *
+   * `$max` for the same reason as `lastActiveAt`: two devices signing in at once have no
+   * ordering, and a plain set would let the earlier one land last.
+   */
+  @Prop({ type: Date, default: null })
+  lastSignInAt!: Date | null
+
+  /** Sign-ins by this account. Approximate for the same reason as {@link editCount}. */
+  @Prop({ type: Number, default: 0 })
+  signInCount!: number
 }
 
 export type UserDocument = HydratedDocument<User>
 export const UserSchema = SchemaFactory.createForClass(User)
 
-// Every sf_active_accounts window is a range scan on this.
+// Every rolling-window count is a range scan on one of these.
 UserSchema.index({ lastActiveAt: -1 })
+UserSchema.index({ lastSignInAt: -1 })
+UserSchema.index({ registered: -1 })

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -8,7 +8,8 @@ import { RealtimeModule } from '../realtime/realtime.module'
 import { RoomsModule } from '../rooms/rooms.module'
 import { TelemetryController } from './telemetry.controller'
 import { TelemetryService } from './telemetry.service'
-import { UserActivityService } from '../rooms/user-activity.service'
+import { UserActivityModule } from '../user-activity/user-activity.module'
+import { UserActivityService } from '../user-activity/user-activity.service'
 
 /**
  * Observability, reading everything and owning nothing. `/telemetry` lives here rather
@@ -19,7 +20,7 @@ import { UserActivityService } from '../rooms/user-activity.service'
  * RoomsModule, users from AuthModule, the live connection index from RealtimeModule.
  */
 @Module({
-  imports: [RoomsModule, AuthModule, RealtimeModule],
+  imports: [RoomsModule, AuthModule, RealtimeModule, UserActivityModule],
   controllers: [MetricsController, TelemetryController],
   providers: [MetricsService, TelemetryService, MetricsTokenGuard],
 })

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -27,6 +27,7 @@ interface CheapCounts {
   roomRevisions: number
   roomMembers: number
   users: number
+  signIns: number
 }
 
 interface OwnedTotal { name: string, value: number }
@@ -35,6 +36,8 @@ interface RoomTotal { roomId: string, owner: string, factories: number }
 /** The slow numbers: five window counts and three top-N aggregations. */
 interface SlowStats {
   activeAccounts: Array<readonly [string, number]>
+  newAccounts: Array<readonly [string, number]>
+  signedInAccounts: Array<readonly [string, number]>
   topRooms: RoomTotal[]
   topEditors: OwnedTotal[]
   topOwners: OwnedTotal[]
@@ -70,6 +73,9 @@ export class MetricsService {
   private readonly clientsByVersion: Gauge<'version'>
 
   private readonly activeAccounts: Gauge<'window'>
+  private readonly newAccounts: Gauge<'window'>
+  private readonly signedInAccounts: Gauge<'window'>
+  private readonly signInsTotal: Gauge<string>
   private readonly roomFactories: Gauge<'room_id' | 'owner'>
   private readonly userEdits: Gauge<'username'>
   private readonly userFactories: Gauge<'username'>
@@ -154,6 +160,23 @@ export class MetricsService {
       labelNames: ['window'],
       registers,
     })
+    this.newAccounts = new Gauge({
+      name: 'sf_new_accounts',
+      help: 'Accounts registered inside the window. Read from the registration date the account already carries, so it is exact and works back over the whole history.',
+      labelNames: ['window'],
+      registers,
+    })
+    this.signedInAccounts = new Gauge({
+      name: 'sf_signed_in_accounts',
+      help: 'Accounts that signed in inside the window. Distinct from sf_active_accounts, which counts editing: signing in and changing nothing is a different thing.',
+      labelNames: ['window'],
+      registers,
+    })
+    this.signInsTotal = new Gauge({
+      name: 'sf_signins_total',
+      help: 'Sign-ins summed across accounts. Approximate: the count is written after the token is issued and is allowed to fail. Counts from release, and falls if an account is deleted.',
+      registers,
+    })
     this.roomFactories = new Gauge({
       name: 'sf_room_factories',
       help: `The ${METRICS_TOP_N} largest synced tabs by factory count.`,
@@ -206,6 +229,7 @@ export class MetricsService {
       this.roomRevisions.set(cheap.value.roomRevisions)
       this.roomMembersTotal.set(cheap.value.roomMembers)
       this.usersTotal.set(cheap.value.users)
+      this.signInsTotal.set(cheap.value.signIns)
     }
 
     // Only on a real reload. prom-client remembers every label set it has been given, so a
@@ -234,6 +258,12 @@ export class MetricsService {
     for (const [window, accounts] of stats.activeAccounts) {
       this.activeAccounts.set({ window }, accounts)
     }
+    for (const [window, accounts] of stats.newAccounts) {
+      this.newAccounts.set({ window }, accounts)
+    }
+    for (const [window, accounts] of stats.signedInAccounts) {
+      this.signedInAccounts.set({ window }, accounts)
+    }
 
     this.roomFactories.reset()
     for (const room of stats.topRooms) {
@@ -252,7 +282,7 @@ export class MetricsService {
   }
 
   private async loadCheap (): Promise<CheapCounts> {
-    const [sharedRooms, privateRooms, totals, roomMembers, users] = await Promise.all([
+    const [sharedRooms, privateRooms, totals, roomMembers, users, signIns] = await Promise.all([
       this.rooms.countDocuments({ deletedAt: null, shared: true }),
       // `$ne: true` rather than `false`, so a document predating the field still counts
       // once rather than not at all.
@@ -260,21 +290,25 @@ export class MetricsService {
       this.sumRoomTotals(),
       this.memberships.countDocuments(),
       this.users.countDocuments(),
+      this.sumSignIns(),
     ])
 
-    return { sharedRooms, privateRooms, ...totals, roomMembers, users }
+    return { sharedRooms, privateRooms, ...totals, roomMembers, users, signIns }
   }
 
   private async loadSlow (): Promise<SlowStats> {
     const now = this.clock.now()
-    const [activeAccounts, topRooms, topEditors, topOwners] = await Promise.all([
-      this.countActiveAccounts(now),
-      this.findLargestRooms(),
-      this.findBusiestEditors(),
-      this.findLargestOwners(),
-    ])
+    const [activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners] =
+      await Promise.all([
+        this.countByWindow(now, 'lastActiveAt'),
+        this.countByWindow(now, 'registered'),
+        this.countByWindow(now, 'lastSignInAt'),
+        this.findLargestRooms(),
+        this.findBusiestEditors(),
+        this.findLargestOwners(),
+      ])
 
-    return { activeAccounts, topRooms, topEditors, topOwners }
+    return { activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners }
   }
 
   /** Factories and accepted edits in one pass, since both are sums over the same documents. */
@@ -292,11 +326,27 @@ export class MetricsService {
     return { roomFactories: row?.factories ?? 0, roomRevisions: row?.revisions ?? 0 }
   }
 
-  private async countActiveAccounts (now: Date): Promise<Array<readonly [string, number]>> {
+  /** Sign-ins across all accounts. Falls if an account is deleted, like the edit total. */
+  private async sumSignIns (): Promise<number> {
+    const [row] = await this.users.aggregate<{ total: number }>([
+      { $group: { _id: null, total: { $sum: { $ifNull: ['$signInCount', 0] } } } },
+    ])
+    return row?.total ?? 0
+  }
+
+  /**
+   * One rolling-window count per configured window, over whichever date field is asked for.
+   * A timestamp rather than a bucket, so every window is exact with no boundary error, and
+   * `registered` needs no new writes at all: accounts have carried it since the beginning.
+   */
+  private async countByWindow (
+    now: Date,
+    field: 'lastActiveAt' | 'registered' | 'lastSignInAt',
+  ): Promise<Array<readonly [string, number]>> {
     return Promise.all(ACTIVE_ACCOUNT_WINDOWS.map(async ([label, ms]) => {
       const since = new Date(now.getTime() - ms)
-      const active = await this.users.countDocuments({ lastActiveAt: { $gt: since } })
-      return [label, active] as const
+      const matched = await this.users.countDocuments({ [field]: { $gt: since } })
+      return [label, matched] as const
     }))
   }
 

--- a/backend/src/realtime/room-op.service.ts
+++ b/backend/src/realtime/room-op.service.ts
@@ -8,7 +8,7 @@ import { APPLIED_OPS_RING, Room } from '../rooms/schemas/room.schema'
 import { CLOCK, Clock } from '../rooms/clock'
 import { RoomAccess, RoomAccessRole } from './room-access.service'
 import { RoomActivityService } from '../rooms/room-activity.service'
-import { UserActivityService } from '../rooms/user-activity.service'
+import { UserActivityService } from '../user-activity/user-activity.service'
 import { mergeFactories } from './room-snapshot'
 
 export type OpOutcome =

--- a/backend/src/rooms/rooms.module.ts
+++ b/backend/src/rooms/rooms.module.ts
@@ -14,7 +14,7 @@ import { RoomMembership, RoomMembershipSchema } from './schemas/room-membership.
 import { RoomSweeperService } from './room-sweeper.service'
 import { RoomsController } from './rooms.controller'
 import { RoomsService } from './rooms.service'
-import { UserActivityService } from './user-activity.service'
+import { UserActivityModule } from '../user-activity/user-activity.module'
 
 @Module({
   imports: [
@@ -24,6 +24,7 @@ import { UserActivityService } from './user-activity.service'
       { name: RoomActivity.name, schema: RoomActivitySchema },
     ]),
     AuthModule, // The User model, for roomsRevision and the legacy import stamp.
+    UserActivityModule, // Re-exported so the WS gateway can stamp an editor.
     LegacyModule, // The read-only FactoryData blob.
   ],
   controllers: [RoomsController],
@@ -33,7 +34,6 @@ import { UserActivityService } from './user-activity.service'
     RoomEventsService,
     RoomSweeperService,
     LegacyImportService,
-    UserActivityService,
     EnsureStepRunner,
     { provide: CLOCK, useValue: systemClock },
   ],
@@ -44,7 +44,7 @@ import { UserActivityService } from './user-activity.service'
     RoomsService,
     RoomActivityService,
     RoomEventsService,
-    UserActivityService,
+    UserActivityModule,
     MongooseModule,
     CLOCK,
   ],

--- a/backend/src/user-activity/user-activity.module.ts
+++ b/backend/src/user-activity/user-activity.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common'
+import { MongooseModule } from '@nestjs/mongoose'
+
+import { RoomActivity, RoomActivitySchema } from '../rooms/schemas/room-activity.schema'
+import { User, UserSchema } from '../auth/user.schema'
+import { UserActivityService } from './user-activity.service'
+
+/**
+ * The account-activity stamps, in a module of their own.
+ *
+ * Three unrelated places touch this: the op path writes an edit stamp, the sign-in path
+ * writes a sign-in stamp, and the metrics reader counts them. Those live in RealtimeModule,
+ * AuthModule and MetricsModule, and hanging the service off any one of them would put a
+ * cycle in the graph — MetricsModule already imports RealtimeModule for the socket count,
+ * and RoomsModule already imports AuthModule.
+ *
+ * It registers both models itself rather than importing the modules that own them, for the
+ * same reason. `forFeature` is idempotent, so declaring a schema in two modules is fine.
+ */
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: User.name, schema: UserSchema },
+      { name: RoomActivity.name, schema: RoomActivitySchema },
+    ]),
+  ],
+  providers: [UserActivityService],
+  exports: [UserActivityService],
+})
+export class UserActivityModule {}

--- a/backend/src/user-activity/user-activity.service.ts
+++ b/backend/src/user-activity/user-activity.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import type { Model } from 'mongoose'
 
-import { RoomActivity } from './schemas/room-activity.schema'
+import { RoomActivity } from '../rooms/schemas/room-activity.schema'
 import { User } from '../auth/user.schema'
 
 /** `room_activity` records this for a write with no account behind it. */
@@ -16,9 +16,9 @@ export const ANONYMOUS_ACTOR = 'anon'
  * one, but the sweeper trims it to 200 rows per room, so it cannot answer anything older than
  * the busiest plans' recent history.
  *
- * Lives under `rooms/` rather than `metrics/` only to keep the module graph acyclic:
- * MetricsModule already imports RealtimeModule for the socket count, so RealtimeModule
- * cannot import MetricsModule back. Both import RoomsModule.
+ * In a module of its own because three unrelated places write to it — the op path, the
+ * sign-in path and the metrics reader — and any two of them sharing a module would put a
+ * cycle in the graph.
  */
 @Injectable()
 export class UserActivityService {
@@ -42,6 +42,18 @@ export class UserActivityService {
     await this.users.updateOne(
       { _id: userId },
       { $max: { lastActiveAt: at }, $inc: { editCount: 1 } },
+    )
+  }
+
+  /**
+   * Stamps a sign-in. Separate from an edit: signing in, reading a plan and changing nothing
+   * is a real thing people do, and conflating the two would overstate how many accounts are
+   * actually building something.
+   */
+  async recordSignIn (userId: string, at: Date): Promise<void> {
+    await this.users.updateOne(
+      { _id: userId },
+      { $max: { lastSignInAt: at }, $inc: { signInCount: 1 } },
     )
   }
 

--- a/backend/test/metrics-usage.spec.ts
+++ b/backend/test/metrics-usage.spec.ts
@@ -10,13 +10,13 @@ import {
   METRICS_SLOW_CACHE_MS,
   METRICS_TOP_N,
 } from '../src/metrics/metrics.constants'
-import { ANONYMOUS_ACTOR, UserActivityService } from '../src/rooms/user-activity.service'
+import { ANONYMOUS_ACTOR, UserActivityService } from '../src/user-activity/user-activity.service'
 import { Room } from '../src/rooms/schemas/room.schema'
 import { RoomActivity } from '../src/rooms/schemas/room-activity.schema'
 import { RoomOpService } from '../src/realtime/room-op.service'
 import { TestContext, awaitConnection, createTestApp, destroyTestApp } from './utils/test-app'
 import { User } from '../src/auth/user.schema'
-import { FakeClock, resetRooms } from './utils/rooms'
+import { FakeClock, call, registerAndLogin, resetRooms } from './utils/rooms'
 import { clearMetricsToken, labelValues, sample, scrapeMetrics, useMetricsToken } from './utils/metrics'
 
 const HOUR = 60 * 60 * 1000
@@ -128,6 +128,78 @@ describe('the database-backed usage metrics', () => {
       await seedUser('lurker')
 
       expect(sample(await scrape(), 'sf_active_accounts', 'window="30d"')).toBe(0)
+    })
+  })
+
+  describe('sf_new_accounts', () => {
+    // No new writes for this one: User.registered has always been there, so the windows
+    // are correct for every account that already existed before the metric did.
+    it('counts registrations in each rolling window', async () => {
+      const now = clock.now().getTime()
+      await seedUser('today', { registered: new Date(now - 2 * HOUR) })
+      await seedUser('thisweek', { registered: new Date(now - 4 * DAY) })
+      await seedUser('thismonth', { registered: new Date(now - 20 * DAY) })
+      await seedUser('ancient', { registered: new Date(now - 300 * DAY) })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_new_accounts', 'window="24h"')).toBe(1)
+      expect(sample(body, 'sf_new_accounts', 'window="7d"')).toBe(2)
+      expect(sample(body, 'sf_new_accounts', 'window="30d"')).toBe(3)
+    })
+
+    it('exports every window even with no accounts at all', async () => {
+      const body = await scrape()
+
+      for (const [label] of ACTIVE_ACCOUNT_WINDOWS) {
+        expect(sample(body, 'sf_new_accounts', `window="${label}"`)).toBe(0)
+      }
+    })
+
+    it('counts an account that registered but never signed in or edited', async () => {
+      await seedUser('signed-up-only', { registered: clock.now() })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_new_accounts', 'window="24h"')).toBe(1)
+      expect(sample(body, 'sf_active_accounts', 'window="24h"')).toBe(0)
+      expect(sample(body, 'sf_signed_in_accounts', 'window="24h"')).toBe(0)
+    })
+  })
+
+  describe('sf_signed_in_accounts and sf_signins_total', () => {
+    it('counts sign-ins in each rolling window', async () => {
+      const now = clock.now().getTime()
+      await seedUser('today', { lastSignInAt: new Date(now - 2 * HOUR) })
+      await seedUser('lastweek', { lastSignInAt: new Date(now - 5 * DAY) })
+      await seedUser('never')
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_signed_in_accounts', 'window="24h"')).toBe(1)
+      expect(sample(body, 'sf_signed_in_accounts', 'window="7d"')).toBe(2)
+      expect(sample(body, 'sf_signed_in_accounts', 'window="30d"')).toBe(2)
+    })
+
+    it('sums sign-ins across accounts', async () => {
+      await seedUser('one', { signInCount: 12 })
+      await seedUser('two', { signInCount: 3 })
+      await seedUser('three')
+
+      expect(sample(await scrape(), 'sf_signins_total')).toBe(15)
+    })
+
+    // Signing in and changing nothing is a real thing people do, and conflating the two
+    // would overstate how many accounts are actually building something.
+    it('is separate from editing', async () => {
+      const now = clock.now()
+      await seedUser('reader', { lastSignInAt: now })
+      await seedUser('builder', { lastActiveAt: now, lastSignInAt: now })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_signed_in_accounts', 'window="24h"')).toBe(2)
+      expect(sample(body, 'sf_active_accounts', 'window="24h"')).toBe(1)
     })
   })
 
@@ -293,6 +365,42 @@ describe('UserActivityService', () => {
     it('ignores anonymous visitors, who have no account to stamp', async () => {
       await expect(service().recordEdit(ANONYMOUS_ACTOR, new Date())).resolves.toBeUndefined()
     })
+  })
+
+  describe('recordSignIn', () => {
+    it('stamps the sign-in and counts it', async () => {
+      const user = await seedUser('returning')
+      const at = new Date('2026-09-02T10:00:00Z')
+
+      await service().recordSignIn(String(user._id), at)
+
+      const stored = await reload(user._id)
+      expect(stored?.lastSignInAt?.toISOString()).toBe(at.toISOString())
+      expect(stored?.signInCount).toBe(1)
+    })
+
+    // Two devices signing in at once have no ordering, same as edits across two rooms.
+    it('never moves lastSignInAt backwards', async () => {
+      const user = await seedUser('returning')
+      const later = new Date('2026-09-02T12:00:00Z')
+
+      await service().recordSignIn(String(user._id), later)
+      await service().recordSignIn(String(user._id), new Date('2026-09-02T09:00:00Z'))
+
+      const stored = await reload(user._id)
+      expect(stored?.lastSignInAt?.toISOString()).toBe(later.toISOString())
+      expect(stored?.signInCount).toBe(2)
+    })
+
+    it('leaves the edit stamp alone', async () => {
+      const user = await seedUser('reader')
+
+      await service().recordSignIn(String(user._id), new Date())
+
+      const stored = await reload(user._id)
+      expect(stored?.lastActiveAt).toBeNull()
+      expect(stored?.editCount).toBe(0)
+    })
 
     it('does not create an account for an id that no longer exists', async () => {
       await service().recordEdit('507f1f77bcf86cd799439011', new Date())
@@ -378,6 +486,62 @@ describe('UserActivityService', () => {
   })
 })
 
+describe('signing in through the API stamps the account', () => {
+  let context: TestContext
+  const clock = new FakeClock()
+
+  const users = () => context.app.get<Model<User>>(getModelToken(User.name))
+
+  beforeAll(async () => {
+    context = await createTestApp({ clock, unthrottled: true })
+    await awaitConnection(context.app)
+  })
+
+  afterAll(async () => {
+    await destroyTestApp(context)
+  })
+
+  beforeEach(async () => {
+    await resetRooms(context.app)
+  })
+
+  it('records the sign-in on a real POST /login', async () => {
+    await registerAndLogin(context.app, 'signer')
+
+    const stored = await users().findOne({ username: 'signer' }).lean()
+    expect(stored?.signInCount).toBe(1)
+    expect(stored?.lastSignInAt).toBeInstanceOf(Date)
+    // Registering is not signing in, and neither is editing.
+    expect(stored?.lastActiveAt).toBeNull()
+  })
+
+  it('counts a second sign-in without moving the account into the editors', async () => {
+    const user = await registerAndLogin(context.app, 'signer')
+    await call(context.app, 'post', '/login').send({ username: 'signer', password: 'ficsit-forever' })
+
+    const stored = await users().findById(user.userId).lean()
+    expect(stored?.signInCount).toBe(2)
+    expect(stored?.editCount).toBe(0)
+  })
+
+  it('still issues a token when the stamp fails', async () => {
+    const failing = await createTestApp({
+      unthrottled: true,
+      userActivity: {
+        recordEdit: async () => undefined,
+        recordSignIn: async () => { throw new Error('injected sign-in stamp failure') },
+      },
+    })
+    try {
+      await awaitConnection(failing.app)
+      const user = await registerAndLogin(failing.app, 'resilient')
+      expect(user.token).toBeTruthy()
+    } finally {
+      await destroyTestApp(failing)
+    }
+  })
+})
+
 /**
  * The invariant the whole design bends around: an edit is committed before any metric is
  * written, and no metric failure may take it back. `RoomOpService` keeps the two post-commit
@@ -399,6 +563,7 @@ describe('an accepted edit survives the metrics write failing', () => {
           failures.push(userId)
           throw new Error('injected editor-stamp failure')
         },
+        recordSignIn: async () => undefined,
       },
     })
     await awaitConnection(context.app)

--- a/backend/test/utils/test-app.ts
+++ b/backend/test/utils/test-app.ts
@@ -11,7 +11,7 @@ import type { Connection } from 'mongoose'
 import { CLOCK, Clock } from '../../src/rooms/clock'
 import { EnsureStepRunner } from '../../src/rooms/ensure-step.runner'
 import { RoomActivityService } from '../../src/rooms/room-activity.service'
-import { UserActivityService } from '../../src/rooms/user-activity.service'
+import { UserActivityService } from '../../src/user-activity/user-activity.service'
 import { configureApp } from '../../src/bootstrap'
 import { AppModule } from '../../src/app.module'
 
@@ -30,7 +30,7 @@ export interface TestAppOptions {
   /** Replaces the activity log, so a post-commit write can be made to fail. */
   activity?: Pick<RoomActivityService, 'record' | 'recordOnce'>
   /** Replaces the editor stamp, the other post-commit write, for the same reason. */
-  userActivity?: Pick<UserActivityService, 'recordEdit'>
+  userActivity?: Pick<UserActivityService, 'recordEdit' | 'recordSignIn'>
   clock?: Clock
   /**
    * Suites that make hundreds of calls from one address would otherwise trip the

--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -379,6 +379,53 @@ add(66, "Stickiness",
     stat([{"value": 0, "color": "red"}, {"value": 0.1, "color": "#EAB839"}, {"value": 0.25, "color": "green"}],
          unit="percentunit", minmax=(0, 1)))
 
+# ------------------------------------------------------------------- growth
+add(80, "New Accounts",
+    "Registrations inside each rolling window. Read from the registration date accounts have always carried, so it is exact and correct all the way back, not just since this metric shipped.",
+    [query('sum(sf_new_accounts%s)' % sel('window="24h"'), "24 hours", "A"),
+     query('sum(sf_new_accounts%s)' % sel('window="7d"'), "7 days", "B"),
+     query('sum(sf_new_accounts%s)' % sel('window="30d"'), "30 days", "C")],
+    stat(GREEN, color_mode="value", text_mode="value_and_name"))
+
+add(81, "New Accounts This Week",
+    "Registrations in the last 7 days.",
+    [query('sum(sf_new_accounts%s)' % sel('window="7d"'), "New")],
+    stat([{"value": 0, "color": "#6a6a6a"}, {"value": 1, "color": "green"}], graph="area"))
+
+add(82, "New Accounts This Month",
+    "Registrations in the last 30 days.",
+    [query('sum(sf_new_accounts%s)' % sel('window="30d"'), "New")],
+    stat([{"value": 0, "color": "#6a6a6a"}, {"value": 1, "color": "green"}], graph="area"))
+
+add(83, "New Accounts Over Time",
+    "Each rolling window plotted. A step up in the 24h line is a signup; the wider lines are the trend.",
+    [query("sum by (window) (sf_new_accounts%s)" % J, "{{window}}")],
+    timeseries(fill=8))
+
+add(84, "Sign-ins",
+    "Accounts that signed in inside each window. Separate from editing: signing in, reading a plan and changing nothing is a real thing people do.",
+    [query('sum(sf_signed_in_accounts%s)' % sel('window="24h"'), "24 hours", "A"),
+     query('sum(sf_signed_in_accounts%s)' % sel('window="7d"'), "7 days", "B"),
+     query('sum(sf_signed_in_accounts%s)' % sel('window="30d"'), "30 days", "C")],
+    stat(BLUE, color_mode="value", text_mode="value_and_name"))
+
+add(85, "Sign-ins, All Time",
+    "Sign-ins summed across accounts. Approximate: the count is written after the token is issued and is allowed to fail, and it counts from release rather than being backfilled.",
+    [query("sum(sf_signins_total%s)" % J, "Sign-ins")],
+    stat(BLUE, graph="area", color_mode="background_solid"))
+
+add(86, "Sign-ins Over Time",
+    "Rolling sign-in windows. Compare against Active Accounts: a gap means people are signing in and not building.",
+    [query("sum by (window) (sf_signed_in_accounts%s)" % J, "{{window}}")],
+    timeseries(fill=8))
+
+add(87, "Of Those Who Signed In, How Many Edited",
+    "Active accounts over signed-in accounts, both on 7 days. Low means people arrive and do not build.",
+    [query('sum(sf_active_accounts%s) / sum(sf_signed_in_accounts%s)'
+           % (sel('window="7d"'), sel('window="7d"')), "Edited")],
+    stat([{"value": 0, "color": "red"}, {"value": 0.3, "color": "#EAB839"}, {"value": 0.6, "color": "green"}],
+         unit="percentunit", minmax=(0, 1)))
+
 # ------------------------------------------------------------- biggest and busiest
 add(70, "Biggest Plans",
     "The largest synced plans by factory count, with the account that owns each. Top 20 only.",
@@ -464,6 +511,12 @@ rows = [
         item(14, 0, 10, 4, 64),
         item(0, 4, 12, 8, 62), item(12, 4, 12, 8, 63),
         item(0, 12, 24, 8, 65),
+    ]),
+    row("🌱 Growth · from the database", [
+        item(0, 0, 5, 4, 81), item(5, 0, 5, 4, 82), item(10, 0, 4, 4, 87),
+        item(14, 0, 10, 4, 80),
+        item(0, 4, 12, 8, 83), item(12, 4, 12, 8, 86),
+        item(0, 12, 5, 4, 85), item(5, 12, 19, 4, 84),
     ]),
     row("🏆 Biggest and Busiest · from the database", [
         item(0, 0, 4, 4, 73),

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -3159,6 +3159,824 @@
           }
         }
       },
+      "panel-80": {
+        "kind": "Panel",
+        "spec": {
+          "id": 80,
+          "title": "New Accounts",
+          "description": "Registrations inside each rolling window. Read from the registration date accounts have always carried, so it is exact and correct all the way back, not just since this metric shipped.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories-preview\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-81": {
+        "kind": "Panel",
+        "spec": {
+          "id": 81,
+          "title": "New Accounts This Week",
+          "description": "Registrations in the last 7 days.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "New",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-82": {
+        "kind": "Panel",
+        "spec": {
+          "id": 82,
+          "title": "New Accounts This Month",
+          "description": "Registrations in the last 30 days.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "New",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-83": {
+        "kind": "Panel",
+        "spec": {
+          "id": 83,
+          "title": "New Accounts Over Time",
+          "description": "Each rolling window plotted. A step up in the 24h line is a signup; the wider lines are the trend.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (window) (sf_new_accounts{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{window}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-84": {
+        "kind": "Panel",
+        "spec": {
+          "id": 84,
+          "title": "Sign-ins",
+          "description": "Accounts that signed in inside each window. Separate from editing: signing in, reading a plan and changing nothing is a real thing people do.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories-preview\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-85": {
+        "kind": "Panel",
+        "spec": {
+          "id": 85,
+          "title": "Sign-ins, All Time",
+          "description": "Sign-ins summed across accounts. Approximate: the count is written after the token is issued and is allowed to fail, and it counts from release rather than being backfilled.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signins_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Sign-ins",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-86": {
+        "kind": "Panel",
+        "spec": {
+          "id": 86,
+          "title": "Sign-ins Over Time",
+          "description": "Rolling sign-in windows. Compare against Active Accounts: a gap means people are signing in and not building.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (window) (sf_signed_in_accounts{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{window}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-87": {
+        "kind": "Panel",
+        "spec": {
+          "id": 87,
+          "title": "Of Those Who Signed In, How Many Edited",
+          "description": "Active accounts over signed-in accounts, both on 7 days. Low means people arrive and do not build.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"7d\"}) / sum(sf_signed_in_accounts{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "Edited",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 0.3,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 0.6,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
       "panel-70": {
         "kind": "Panel",
         "spec": {
@@ -4291,6 +5109,124 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-65"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🌱 Growth · from the database",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-81"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 5,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-82"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 10,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-87"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 14,
+                        "y": 0,
+                        "width": 10,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-80"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-83"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-86"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 12,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-85"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 5,
+                        "y": 12,
+                        "width": 19,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-84"
                         }
                       }
                     }

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -3159,6 +3159,824 @@
           }
         }
       },
+      "panel-80": {
+        "kind": "Panel",
+        "spec": {
+          "id": 80,
+          "title": "New Accounts",
+          "description": "Registrations inside each rolling window. Read from the registration date accounts have always carried, so it is exact and correct all the way back, not just since this metric shipped.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-81": {
+        "kind": "Panel",
+        "spec": {
+          "id": 81,
+          "title": "New Accounts This Week",
+          "description": "Registrations in the last 7 days.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "New",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-82": {
+        "kind": "Panel",
+        "spec": {
+          "id": 82,
+          "title": "New Accounts This Month",
+          "description": "Registrations in the last 30 days.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "New",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-83": {
+        "kind": "Panel",
+        "spec": {
+          "id": 83,
+          "title": "New Accounts Over Time",
+          "description": "Each rolling window plotted. A step up in the 24h line is a signup; the wider lines are the trend.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (window) (sf_new_accounts{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{window}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-84": {
+        "kind": "Panel",
+        "spec": {
+          "id": 84,
+          "title": "Sign-ins",
+          "description": "Accounts that signed in inside each window. Separate from editing: signing in, reading a plan and changing nothing is a real thing people do.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-85": {
+        "kind": "Panel",
+        "spec": {
+          "id": 85,
+          "title": "Sign-ins, All Time",
+          "description": "Sign-ins summed across accounts. Approximate: the count is written after the token is issued and is allowed to fail, and it counts from release rather than being backfilled.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signins_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Sign-ins",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-86": {
+        "kind": "Panel",
+        "spec": {
+          "id": 86,
+          "title": "Sign-ins Over Time",
+          "description": "Rolling sign-in windows. Compare against Active Accounts: a gap means people are signing in and not building.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (window) (sf_signed_in_accounts{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{window}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-87": {
+        "kind": "Panel",
+        "spec": {
+          "id": 87,
+          "title": "Of Those Who Signed In, How Many Edited",
+          "description": "Active accounts over signed-in accounts, both on 7 days. Low means people arrive and do not build.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"7d\"}) / sum(sf_signed_in_accounts{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "Edited",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "red"
+                      },
+                      {
+                        "value": 0.3,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 0.6,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
       "panel-70": {
         "kind": "Panel",
         "spec": {
@@ -4291,6 +5109,124 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-65"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🌱 Growth · from the database",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-81"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 5,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-82"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 10,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-87"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 14,
+                        "y": 0,
+                        "width": 10,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-80"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-83"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-86"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 12,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-85"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 5,
+                        "y": 12,
+                        "width": 19,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-84"
                         }
                       }
                     }


### PR DESCRIPTION
**No manual steps.** No new env var, no migration. The registration windows are correct retroactively the moment this deploys.

## New metrics

| Metric | Labels | What it is |
| --- | --- | --- |
| `sf_new_accounts` | `window` | Registrations inside the window |
| `sf_signed_in_accounts` | `window` | Accounts that signed in inside the window |
| `sf_signins_total` | | Sign-ins summed across accounts |

Windows are `1h`, `24h`, `7d`, `14d`, `30d`. The ask was 7d and 30d; the rest come free from the same constant.

## Registrations need no new writes

`User.registered` has been on every account since the beginning. So a rolling count over it is **exact and correct all the way back**, not just from the day this ships.

An incrementing gauge, which is what was asked for, would have been worse in every way: it resets on restart, and a counter cannot answer "how many in the last 7 days" without also storing when each one happened. The timestamp already does both.

## Sign-ins are deliberately not "active"

Somebody can sign in, read their plan and change nothing. Folding that into `sf_active_accounts` would overstate how many accounts are actually building something, so it is its own metric. There is a panel for the ratio between them.

`lastSignInAt` uses `$max` for the same reason `lastActiveAt` does: two devices signing in at once have no ordering.

The stamp happens **after** the token is issued, in its own `try/catch`. A spec asserts a login still returns a token when the stamp throws.

## One refactor

`UserActivityService` moves to `backend/src/user-activity/`. Three unrelated places now write to it (the op path, the sign-in path, the metrics reader) and hanging it off any one of their modules would put a cycle in the graph: `MetricsModule` already imports `RealtimeModule`, and `RoomsModule` already imports `AuthModule`.

## Dashboard

New **🌱 Growth** row: new accounts this week and this month as headline stats, all windows together, both over time, sign-ins, and the edited-after-signing-in ratio. 49 panels now, layout validated for overlaps and overflow.

## Verification

| Gate | Result |
| --- | --- |
| `backend` vitest | **406 passed**, 29 files |
| `backend` tsc | clean |
| `common` vitest | **111 passed** |
| `web` vitest | **3027 passed**, 1 skipped |
| `web` vue-tsc | clean |
| `pnpm lint-check` | exit 0 |

**12 new tests**, including: rolling windows on all three date fields, registering without signing in counts in one metric and not the others, `lastSignInAt` never moves backwards, a real `POST /login` stamps the account, and a login still succeeds when the stamp fails.