### PR TITLE
feat: build commit in telemetry, and the client census persisted

### DIFF
--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -1,4 +1,5 @@
 import { Module, OnModuleInit } from '@nestjs/common'
+import { MongooseModule } from '@nestjs/mongoose'
 
 import { AuthModule } from '../auth/auth.module'
 import { MetricsController } from './metrics.controller'
@@ -7,6 +8,7 @@ import { MetricsTokenGuard } from './metrics-token.guard'
 import { RealtimeModule } from '../realtime/realtime.module'
 import { RoomsModule } from '../rooms/rooms.module'
 import { TelemetryController } from './telemetry.controller'
+import { TelemetryInstance, TelemetryInstanceSchema } from './telemetry-instance.schema'
 import { TelemetryService } from './telemetry.service'
 import { UserActivityModule } from '../user-activity/user-activity.module'
 import { UserActivityService } from '../user-activity/user-activity.service'
@@ -20,7 +22,15 @@ import { UserActivityService } from '../user-activity/user-activity.service'
  * RoomsModule, users from AuthModule, the live connection index from RealtimeModule.
  */
 @Module({
-  imports: [RoomsModule, AuthModule, RealtimeModule, UserActivityModule],
+  imports: [
+    RoomsModule,
+    AuthModule,
+    RealtimeModule,
+    UserActivityModule,
+    MongooseModule.forFeature([
+      { name: TelemetryInstance.name, schema: TelemetryInstanceSchema },
+    ]),
+  ],
   controllers: [MetricsController, TelemetryController],
   providers: [MetricsService, TelemetryService, MetricsTokenGuard],
 })

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -17,6 +17,7 @@ import { ConnectionRegistry } from '../realtime/connection-registry'
 import { Room } from '../rooms/schemas/room.schema'
 import { RoomMembership } from '../rooms/schemas/room-membership.schema'
 import { TelemetryService } from './telemetry.service'
+import type { TelemetrySnapshot } from './telemetry.service'
 import { User } from '../auth/user.schema'
 
 /** The fast numbers: four counts and one aggregation over the rooms collection. */
@@ -71,6 +72,7 @@ export class MetricsService {
   private readonly clientTabs: Gauge<'kind'>
   private readonly clientFactoriesTotal: Gauge<string>
   private readonly clientsByVersion: Gauge<'version'>
+  private readonly clientsBySha: Gauge<'sha'>
 
   private readonly activeAccounts: Gauge<'window'>
   private readonly newAccounts: Gauge<'window'>
@@ -80,6 +82,7 @@ export class MetricsService {
   private readonly userEdits: Gauge<'username'>
   private readonly userFactories: Gauge<'username'>
 
+  private readonly census: CachedQuery<TelemetrySnapshot>
   private readonly cheap: CachedQuery<CheapCounts>
   private readonly slow: CachedQuery<SlowStats>
 
@@ -154,6 +157,12 @@ export class MetricsService {
       registers,
     })
 
+    this.clientsBySha = new Gauge({
+      name: 'sf_clients_by_sha',
+      help: 'Active browsers by the commit their bundle was built from. A build that reported no commit, such as a local one, counts under "unknown".',
+      labelNames: ['sha'],
+      registers,
+    })
     this.activeAccounts = new Gauge({
       name: 'sf_active_accounts',
       help: 'Accounts whose last accepted edit falls inside the window. Signing in, creating a tab and joining one are not edits and do not count.',
@@ -196,6 +205,9 @@ export class MetricsService {
       registers,
     })
 
+    // The census is a database read now too, so it gets the same last-good-value
+    // treatment: a Mongo outage must not blank the client panels either.
+    this.census = new CachedQuery(METRICS_CACHE_MS, () => this.telemetry.snapshot())
     this.cheap = new CachedQuery(METRICS_CACHE_MS, () => this.loadCheap())
     this.slow = new CachedQuery(METRICS_SLOW_CACHE_MS, () => this.loadSlow())
   }
@@ -212,15 +224,20 @@ export class MetricsService {
   private async refresh (): Promise<void> {
     // Free, so never cached: both come from memory this process already holds.
     this.wsConnections.set(this.connections.size())
-    this.setClientGauges()
 
     const nowMs = this.clock.now().getTime()
-    const [cheap, slow] = await Promise.all([this.cheap.get(nowMs), this.slow.get(nowMs)])
+    const [census, cheap, slow] = await Promise.all([
+      this.census.get(nowMs),
+      this.cheap.get(nowMs),
+      this.slow.get(nowMs),
+    ])
+
+    if (census.value) this.setClientGauges(census.value)
 
     // Either group failing means the database was unreadable this scrape. A 500 would cost
     // Prometheus every series here, the in-memory ones included, so the outage is reported
     // as a signal and the last good values stand.
-    this.databaseUp.set(cheap.failed || slow.failed ? 0 : 1)
+    this.databaseUp.set(census.failed || cheap.failed || slow.failed ? 0 : 1)
 
     if (cheap.value) {
       this.roomsTotal.set({ shared: 'true' }, cheap.value.sharedRooms)
@@ -239,9 +256,7 @@ export class MetricsService {
     if (slow.refreshed && slow.value) this.setSlowGauges(slow.value)
   }
 
-  private setClientGauges (): void {
-    const census = this.telemetry.snapshot()
-
+  private setClientGauges (census: TelemetrySnapshot): void {
     this.activeClients.set({ signed_in: 'true' }, census.activeSignedIn)
     this.activeClients.set({ signed_in: 'false' }, census.activeSignedOut)
     this.clientTabs.set({ kind: 'local' }, census.localTabs)
@@ -251,6 +266,11 @@ export class MetricsService {
     this.clientsByVersion.reset()
     for (const [version, clients] of census.byVersion) {
       this.clientsByVersion.set({ version }, clients)
+    }
+
+    this.clientsBySha.reset()
+    for (const [sha, clients] of census.bySha) {
+      this.clientsBySha.set({ sha }, clients)
     }
   }
 

--- a/backend/src/metrics/telemetry-instance.schema.ts
+++ b/backend/src/metrics/telemetry-instance.schema.ts
@@ -1,0 +1,57 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
+import { TELEMETRY_CAPS } from 'common'
+import type { HydratedDocument } from 'mongoose'
+
+/**
+ * One row per browser that has checked in recently.
+ *
+ * This started in memory, on the reasoning that a heartbeat is worthless fifteen minutes
+ * after it arrives and that one write per browser per five minutes would be the busiest
+ * collection in the database. The first half is true and the second was overstated: a
+ * hundred concurrent browsers is twenty writes a minute, which is nothing. What the
+ * in-memory version actually cost was the whole census on every deploy, and the API
+ * redeploys often enough for that to be the thing people noticed.
+ *
+ * **Nothing identifying is stored.** `instanceId` is the random UUID the browser minted for
+ * itself, and the rest are counts, a flag and two build strings. See `docs/telemetry.md`.
+ */
+@Schema({ collection: 'telemetry_instances' })
+export class TelemetryInstance {
+  /** The browser's own random UUID. Never derived from, or joined to, an account. */
+  @Prop({ type: String, required: true, unique: true })
+  instanceId!: string
+
+  @Prop({ type: Date, required: true })
+  lastSeenAt!: Date
+
+  @Prop({ type: Boolean, default: false })
+  signedIn!: boolean
+
+  @Prop({ type: Number, default: 0 })
+  localTabs!: number
+
+  @Prop({ type: Number, default: 0 })
+  cloudTabs!: number
+
+  @Prop({ type: Number, default: 0 })
+  factories!: number
+
+  @Prop({ type: String, default: '' })
+  version!: string
+
+  @Prop({ type: String, default: '' })
+  sha!: string
+}
+
+export type TelemetryInstanceDocument = HydratedDocument<TelemetryInstance>
+export const TelemetryInstanceSchema = SchemaFactory.createForClass(TelemetryInstance)
+
+/**
+ * Mongo sweeps expired documents about once a minute, so this bounds storage but does not
+ * define the window. Every read still filters on `lastSeenAt` explicitly, which is what makes
+ * "active in the last fifteen minutes" exact rather than "within a minute of it".
+ */
+TelemetryInstanceSchema.index(
+  { lastSeenAt: 1 },
+  { expireAfterSeconds: Math.round(TELEMETRY_CAPS.activeWindowMs / 1000) },
+)

--- a/backend/src/metrics/telemetry.controller.ts
+++ b/backend/src/metrics/telemetry.controller.ts
@@ -36,13 +36,13 @@ export class TelemetryController {
   @Post()
   @SkipVersionGate()
   @HttpCode(HttpStatus.NO_CONTENT)
-  heartbeat (@Req() request: Request, @Body() body: unknown): void {
+  async heartbeat (@Req() request: Request, @Body() body: unknown): Promise<void> {
     assertWithinCap(request, body)
 
     const parsed = parseTelemetryHeartbeat(body)
     if (!parsed.success) throw new BadRequestException('Malformed telemetry heartbeat.')
 
-    const outcome = this.telemetry.record(parsed.data)
+    const outcome = await this.telemetry.record(parsed.data)
     if (outcome !== 'accepted') {
       // Both the per-instance floor and the instance ceiling are "come back later", and
       // the client's answer to either is the same: drop it and wait for the next tick.

--- a/backend/src/metrics/telemetry.service.ts
+++ b/backend/src/metrics/telemetry.service.ts
@@ -1,9 +1,13 @@
 import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
 import {
   TELEMETRY_CAPS,
+  TELEMETRY_SHA_FALLBACK,
+  TELEMETRY_SHA_LABEL_PATTERN,
   TELEMETRY_VERSION_FALLBACK,
   TELEMETRY_VERSION_LABEL_PATTERN,
 } from 'common'
+import type { Model } from 'mongoose'
 import type { TelemetryHeartbeat } from 'common'
 
 import { CLOCK, Clock } from '../rooms/clock'
@@ -12,19 +16,7 @@ import {
   TELEMETRY_MAX_INSTANCES,
   TELEMETRY_MIN_INTERVAL_MS,
 } from './metrics.constants'
-
-/**
- * What one browser last told us. Deliberately not a copy of the heartbeat: the instance id
- * is the map key and nothing else identifying is kept, because nothing else is sent.
- */
-interface TrackedInstance {
-  lastSeenMs: number
-  signedIn: boolean
-  localTabs: number
-  cloudTabs: number
-  factories: number
-  version: string
-}
+import { TelemetryInstance } from './telemetry-instance.schema'
 
 export interface TelemetrySnapshot {
   activeSignedIn: number
@@ -34,55 +26,82 @@ export interface TelemetrySnapshot {
   factories: number
   /** Version label to instance count, already capped and bucketed. */
   byVersion: Map<string, number>
+  /** Commit label to instance count, capped and bucketed the same way. */
+  bySha: Map<string, number>
 }
 
 export type HeartbeatOutcome = 'accepted' | 'too-soon' | 'at-capacity'
 
 /**
- * The live client census, held in memory and nowhere else.
+ * The live client census.
  *
- * There are no Mongo writes here on purpose. The API is a single standalone instance, a
- * heartbeat is worth nothing fifteen minutes after it arrives, and writing one per browser
- * per five minutes would be the busiest collection in the database in exchange for data
- * that is never read back. A restart loses the census and it refills within five minutes.
+ * Stored in Mongo rather than in memory. The first version kept a `Map`, on the reasoning
+ * that a heartbeat is worthless fifteen minutes later and a write per browser per five
+ * minutes would be the busiest collection here. The first half holds; the second was
+ * overstated, because that rate is trivial. What the `Map` really cost was the entire census
+ * on every deploy, and the API redeploys often enough that people noticed.
  *
- * Entries expire {@link TELEMETRY_CAPS.activeWindowMs} after their last heartbeat. Expiry
- * happens on the way past — every record and every snapshot prunes — so there is no timer
- * to leak and an idle process holds nothing.
+ * Rows expire {@link TELEMETRY_CAPS.activeWindowMs} after their last heartbeat, enforced two
+ * ways: a TTL index bounds storage, and every read filters on `lastSeenAt` so the window is
+ * exact rather than "whenever Mongo last swept".
  */
 @Injectable()
 export class TelemetryService {
-  private readonly instances = new Map<string, TrackedInstance>()
+  constructor (
+    @InjectModel(TelemetryInstance.name)
+    private readonly instances: Model<TelemetryInstance>,
+    @Inject(CLOCK) private readonly clock: Clock,
+  ) {}
 
-  constructor (@Inject(CLOCK) private readonly clock: Clock) {}
+  async record (heartbeat: TelemetryHeartbeat): Promise<HeartbeatOutcome> {
+    const now = this.clock.now()
+    const floor = new Date(now.getTime() - TELEMETRY_MIN_INTERVAL_MS)
 
-  record (heartbeat: TelemetryHeartbeat): HeartbeatOutcome {
-    const nowMs = this.clock.now().getTime()
-    this.prune(nowMs)
-
-    const existing = this.instances.get(heartbeat.instanceId)
-    if (existing && nowMs - existing.lastSeenMs < TELEMETRY_MIN_INTERVAL_MS) {
-      // Refused without touching lastSeen, so hammering the endpoint cannot hold an
-      // instance active past its window.
-      return 'too-soon'
-    }
-    if (!existing && this.instances.size >= TELEMETRY_MAX_INSTANCES) return 'at-capacity'
-
-    this.instances.set(heartbeat.instanceId, {
-      lastSeenMs: nowMs,
-      signedIn: heartbeat.signedIn,
-      localTabs: heartbeat.localTabCount,
-      cloudTabs: heartbeat.cloudTabCount,
-      factories: heartbeat.factoriesTotal,
-      version: heartbeat.appVersion,
+    // `$lte`, not `$lt`: the in-memory version this replaces accepted a heartbeat arriving
+    // exactly on the floor, and tightening that by a millisecond during a port would be an
+    // accidental behaviour change.
+    // One conditional upsert does the rate limit and the write together: it only matches a
+    // row that is absent or old enough, so a burst cannot be accepted twice. Doing it as a
+    // read then a write would let two concurrent heartbeats both pass the check.
+    const result = await this.instances.updateOne(
+      { instanceId: heartbeat.instanceId, lastSeenAt: { $lte: floor } },
+      {
+        $set: {
+          lastSeenAt: now,
+          signedIn: heartbeat.signedIn,
+          localTabs: heartbeat.localTabCount,
+          cloudTabs: heartbeat.cloudTabCount,
+          factories: heartbeat.factoriesTotal,
+          version: heartbeat.appVersion,
+          sha: heartbeat.gitSha ?? '',
+        },
+      },
+      { upsert: true },
+    ).catch(async (cause: unknown) => {
+      // A duplicate key means the row exists and was too recent for the filter to match, so
+      // the upsert tried to insert a second one. That is exactly the rate limit firing.
+      if (isDuplicateKey(cause)) return null
+      throw cause
     })
+
+    if (result === null) return 'too-soon'
+    if (result.matchedCount === 0 && result.upsertedCount === 0) return 'too-soon'
+
+    // Checked after the write rather than before, so the common path is one round trip. An
+    // overshoot of a few rows past the cap is not worth a second query on every heartbeat.
+    if (result.upsertedCount > 0 && await this.instances.estimatedDocumentCount() > TELEMETRY_MAX_INSTANCES) {
+      await this.instances.deleteOne({ instanceId: heartbeat.instanceId })
+      return 'at-capacity'
+    }
 
     return 'accepted'
   }
 
-  snapshot (): TelemetrySnapshot {
-    const nowMs = this.clock.now().getTime()
-    this.prune(nowMs)
+  async snapshot (): Promise<TelemetrySnapshot> {
+    const since = new Date(this.clock.now().getTime() - TELEMETRY_CAPS.activeWindowMs)
+    const active = await this.instances
+      .find({ lastSeenAt: { $gt: since } }, { signedIn: 1, localTabs: 1, cloudTabs: 1, factories: 1, version: 1, sha: 1 })
+      .lean()
 
     const snapshot: TelemetrySnapshot = {
       activeSignedIn: 0,
@@ -91,48 +110,58 @@ export class TelemetryService {
       cloudTabs: 0,
       factories: 0,
       byVersion: new Map(),
+      bySha: new Map(),
     }
     const rawVersions = new Map<string, number>()
+    const rawShas = new Map<string, number>()
 
-    for (const instance of this.instances.values()) {
+    for (const instance of active) {
       if (instance.signedIn) snapshot.activeSignedIn++
       else snapshot.activeSignedOut++
       snapshot.localTabs += instance.localTabs
       snapshot.cloudTabs += instance.cloudTabs
       snapshot.factories += instance.factories
 
-      const label = versionLabel(instance.version)
-      rawVersions.set(label, (rawVersions.get(label) ?? 0) + 1)
+      const version = versionLabel(instance.version)
+      rawVersions.set(version, (rawVersions.get(version) ?? 0) + 1)
+
+      const sha = shaLabel(instance.sha)
+      rawShas.set(sha, (rawShas.get(sha) ?? 0) + 1)
     }
 
-    snapshot.byVersion = capVersions(rawVersions)
+    snapshot.byVersion = capLabels(rawVersions, TELEMETRY_VERSION_FALLBACK)
+    snapshot.bySha = capLabels(rawShas, TELEMETRY_SHA_FALLBACK)
     return snapshot
   }
 
-  /** Live instances, for the specs and for nothing else. */
-  size (): number {
-    this.prune(this.clock.now().getTime())
-    return this.instances.size
-  }
-
-  private prune (nowMs: number): void {
-    for (const [instanceId, instance] of this.instances) {
-      if (nowMs - instance.lastSeenMs >= TELEMETRY_CAPS.activeWindowMs) this.instances.delete(instanceId)
-    }
+  /** Instances still inside the window, for the specs and for nothing else. */
+  async size (): Promise<number> {
+    const since = new Date(this.clock.now().getTime() - TELEMETRY_CAPS.activeWindowMs)
+    return this.instances.countDocuments({ lastSeenAt: { $gt: since } })
   }
 }
+
+const isDuplicateKey = (cause: unknown): boolean =>
+  typeof cause === 'object' && cause !== null && (cause as { code?: number }).code === 11000
 
 /** Anything the shared pattern does not recognise is counted, just not under its own name. */
 const versionLabel = (version: string): string =>
   TELEMETRY_VERSION_LABEL_PATTERN.test(version) ? version : TELEMETRY_VERSION_FALLBACK
 
+/** A build that reported no commit, or something that is not hex, counts under `unknown`. */
+const shaLabel = (sha: string): string =>
+  TELEMETRY_SHA_LABEL_PATTERN.test(sha) ? sha : TELEMETRY_SHA_FALLBACK
+
 /**
- * Keeps the busiest {@link METRICS_VERSION_LABEL_LIMIT} versions and folds the tail into
- * `other`, so the series count is bounded no matter how many well-formed versions arrive.
+ * Keeps the busiest {@link METRICS_VERSION_LABEL_LIMIT} labels and folds the tail into the
+ * given fallback, so the series count is bounded no matter how many distinct values arrive.
+ * Shared by the version and commit labels: a commit is if anything the more dangerous of the
+ * two, since every merge mints a new one.
+ *
  * Sorted by count first and by name second, so a tie does not make the choice arbitrary
  * between scrapes.
  */
-const capVersions = (counts: Map<string, number>): Map<string, number> => {
+const capLabels = (counts: Map<string, number>, fallback: string): Map<string, number> => {
   if (counts.size <= METRICS_VERSION_LABEL_LIMIT) return counts
 
   const ranked = [...counts].sort(([nameA, countA], [nameB, countB]) =>
@@ -142,6 +171,6 @@ const capVersions = (counts: Map<string, number>): Map<string, number> => {
   const tail = ranked.slice(METRICS_VERSION_LABEL_LIMIT)
     .reduce((total, [, count]) => total + count, 0)
 
-  capped.set(TELEMETRY_VERSION_FALLBACK, (capped.get(TELEMETRY_VERSION_FALLBACK) ?? 0) + tail)
+  capped.set(fallback, (capped.get(fallback) ?? 0) + tail)
   return capped
 }

--- a/backend/test/telemetry.spec.ts
+++ b/backend/test/telemetry.spec.ts
@@ -234,6 +234,61 @@ describe('POST /telemetry', () => {
     })
   })
 
+  describe('the census survives a restart', () => {
+    // The whole reason this moved out of memory. The API redeploys often enough that losing
+    // the census on every deploy was the thing people actually noticed.
+    it('still counts a browser after the process is replaced', async () => {
+      const instanceId = randomUUID()
+      await post(heartbeat({ instanceId, localTabCount: 3, factoriesTotal: 21 }))
+      expect(sample(await scrape(), 'sf_active_clients', 'signed_in="false"')).toBe(1)
+
+      // A second app on the same database is what a redeploy looks like from Mongo's side.
+      const restarted = await createTestApp({ clock, unthrottled: true })
+      try {
+        const response = await scrapeMetrics(restarted.app)
+        expect(response.status).toBe(200)
+        expect(sample(response.text, 'sf_active_clients', 'signed_in="false"')).toBe(1)
+        expect(sample(response.text, 'sf_client_tabs', 'kind="local"')).toBe(3)
+        expect(sample(response.text, 'sf_client_factories_total')).toBe(21)
+      } finally {
+        await destroyTestApp(restarted)
+      }
+    })
+  })
+
+  describe('the commit label', () => {
+    it('groups browsers by the commit they were built from', async () => {
+      await post(heartbeat({ gitSha: 'a1b2c3d4e5f6' }))
+      await post(heartbeat({ gitSha: 'a1b2c3d4e5f6' }))
+      await post(heartbeat({ gitSha: 'ffffffffffff' }))
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_clients_by_sha', 'sha="a1b2c3d4e5f6"')).toBe(2)
+      expect(sample(body, 'sf_clients_by_sha', 'sha="ffffffffffff"')).toBe(1)
+    })
+
+    // Optional so a tab loaded before the field existed keeps reporting rather than being
+    // rejected by the strict object.
+    it('counts a heartbeat with no commit under unknown', async () => {
+      expect((await post(heartbeat())).status).toBe(204)
+
+      expect(sample(await scrape(), 'sf_clients_by_sha', 'sha="unknown"')).toBe(1)
+    })
+
+    it.each(['main', 'NOTHEX', '../etc', 'abc'])('buckets %s as unknown rather than labelling it', async sha => {
+      await post(heartbeat({ gitSha: sha }))
+
+      const body = await scrape()
+      expect(sample(body, 'sf_clients_by_sha', 'sha="unknown"')).toBe(1)
+      expect(sample(body, 'sf_clients_by_sha', `sha="${sha}"`)).toBeUndefined()
+    })
+
+    it('rejects a commit string past the cap', async () => {
+      expect((await post(heartbeat({ gitSha: 'a'.repeat(41) }))).status).toBe(400)
+    })
+  })
+
   describe('the cardinality cap', () => {
     it('buckets a version the pattern does not recognise', async () => {
       await post(heartbeat({ appVersion: 'main' }))

--- a/common/src/schemas/telemetry.spec.ts
+++ b/common/src/schemas/telemetry.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   TELEMETRY_CAPS,
+  TELEMETRY_SHA_LABEL_PATTERN,
   TELEMETRY_VERSION_LABEL_PATTERN,
   parseTelemetryHeartbeat,
   telemetryHeartbeatSchema,
@@ -33,6 +34,7 @@ const ALLOWED_FIELDS = [
   'cloudTabCount',
   'factoriesTotal',
   'appVersion',
+  'gitSha',
 ]
 
 describe('telemetryHeartbeatSchema', () => {
@@ -93,6 +95,32 @@ describe('telemetryHeartbeatSchema', () => {
     expect(parseTelemetryHeartbeat('0.7.0').success).toBe(false)
     expect(parseTelemetryHeartbeat([heartbeat()]).success).toBe(false)
   })
+})
+
+describe('the optional commit field', () => {
+  it('accepts a heartbeat carrying one', () => {
+    expect(parseTelemetryHeartbeat(heartbeat({ gitSha: 'a1b2c3d4e5f6' })).success).toBe(true)
+  })
+
+  // Optional so a tab loaded before the field existed is not rejected by the strict object.
+  it('accepts one without', () => {
+    expect(parseTelemetryHeartbeat(heartbeat()).success).toBe(true)
+  })
+
+  it('rejects one past the cap', () => {
+    expect(parseTelemetryHeartbeat(heartbeat({ gitSha: 'a'.repeat(41) })).success).toBe(false)
+  })
+})
+
+describe('TELEMETRY_SHA_LABEL_PATTERN', () => {
+  it.each(['a1b2c3d', 'a1b2c3d4e5f6', 'f'.repeat(40)])('allows %s', sha => {
+    expect(TELEMETRY_SHA_LABEL_PATTERN.test(sha)).toBe(true)
+  })
+
+  it.each(['main', 'A1B2C3D', 'abc', 'f'.repeat(41), '../../etc', 'a1b2c3d\n'])(
+    'refuses %s, so it buckets as unknown', sha => {
+      expect(TELEMETRY_SHA_LABEL_PATTERN.test(sha)).toBe(false)
+    })
 })
 
 describe('TELEMETRY_VERSION_LABEL_PATTERN', () => {

--- a/common/src/schemas/telemetry.ts
+++ b/common/src/schemas/telemetry.ts
@@ -10,6 +10,8 @@ import { z } from 'zod'
 export const TELEMETRY_CAPS = {
   /** A version string, and nothing longer. */
   appVersion: 32,
+  /** A git SHA, truncated by the build. Full 40 allowed so an untruncated one still parses. */
+  gitSha: 40,
   /** Every count field. */
   count: 100_000,
   /** The whole request body, in bytes. A real heartbeat is around 200. */
@@ -32,6 +34,16 @@ export const TELEMETRY_VERSION_LABEL_PATTERN = /^\d{1,4}\.\d{1,4}\.\d{1,4}(?:-[A
 
 /** Where a version that fails the pattern, or overflows the label cap, is counted instead. */
 export const TELEMETRY_VERSION_FALLBACK = 'other'
+
+/**
+ * What may appear as the `sha` label on `sf_clients_by_sha`. Hex only, so nothing a client
+ * invents can become a label value, and the same cardinality argument as the version applies:
+ * one series per distinct commit, forever, unless the server caps it.
+ */
+export const TELEMETRY_SHA_LABEL_PATTERN = /^[0-9a-f]{7,40}$/
+
+/** Where a build that reported no usable commit is counted. */
+export const TELEMETRY_SHA_FALLBACK = 'unknown'
 
 const count = z.number().int().min(0).max(TELEMETRY_CAPS.count)
 
@@ -60,6 +72,12 @@ export const telemetryHeartbeatSchema = z.strictObject({
   cloudTabCount: count,
   factoriesTotal: count,
   appVersion: z.string().min(1).max(TELEMETRY_CAPS.appVersion),
+  /**
+   * Optional on purpose. A tab loaded before this field existed keeps reporting rather than
+   * being rejected by the strict object, and a local build that knows no commit sends nothing
+   * instead of inventing one. Both cases count under `unknown`.
+   */
+  gitSha: z.string().max(TELEMETRY_CAPS.gitSha).optional(),
 })
 
 export type TelemetryHeartbeat = z.infer<typeof telemetryHeartbeatSchema>

--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -458,28 +458,25 @@ add(41, "Build Adoption Over Time",
     [query("sum by (version) (sf_clients_by_version%s)" % J, "{{version}}")],
     timeseries(fill=25, stack="normal"))
 
+add(43, "Browsers by Commit",
+    "Active browsers by the commit their bundle was built from. A build that reported no commit, such as a local one, counts under \"unknown\". Capped to the busiest 25 commits.",
+    [query("sort_desc(sf_clients_by_sha%s)" % J, "{{sha}}", instant=True)],
+    bargauge(display_name="${__field.labels.sha}"))
+
+add(44, "Commit Rollout Over Time",
+    "Stacked. After a deploy, watch the previous commit drain. This is the panel that says whether a rollout has actually reached people, which a version number cannot: several commits ship under one version.",
+    [query("sum by (sha) (sf_clients_by_sha%s)" % J, "{{sha}}")],
+    timeseries(fill=25, stack="normal"))
+
+add(45, "Browsers on an Unknown Commit",
+    "Builds reporting no usable commit. Expect this to be non-zero only for local development builds.",
+    [query('sum(sf_clients_by_sha%s) or vector(0)' % sel('sha="unknown"'), "Unknown")],
+    stat([{"value": 0, "color": "green"}, {"value": 1, "color": "#6a6a6a"}]))
+
 add(42, "On an Unrecognised Build",
     'Browsers reporting a version the label pattern refused. Expect zero. Anything sustained means either a bad build string or somebody poking the endpoint.',
     [query('sum(sf_clients_by_version%s) or vector(0)' % sel('version="other"'), "Other")],
     stat([{"value": 0, "color": "green"}, {"value": 1, "color": "#EAB839"}, {"value": 10, "color": "red"}]))
-
-# ------------------------------------------------------------ collection health
-add(50, "Scrape Up",
-    "Prometheus's own view of whether this target answered. 0 means the endpoint is unreachable, the token is wrong, or the build has no /metrics route.",
-    [query('min(up%s)' % J, "Up")],
-    stat([{"value": 0, "color": "red"}, {"value": 1, "color": "green"}]))
-
-add(51, "Scrape Duration",
-    "How long the endpoint takes to answer. The database gauges are cached for 10s, so most scrapes are cheap and one in every few does real work.",
-    [query('max(scrape_duration_seconds%s)' % J, "Duration")],
-    stat(GREEN, unit="s", color_mode="value", decimals=3))
-
-add(52, "Collection Health Over Time",
-    "Both lines should sit flat at 1. Scrape up dropping is a transport or auth problem; database readable dropping means Mongo is unreachable and the room and account gauges are stale rather than zero.",
-    [query('min(up%s)' % J, "Scrape up", "A"),
-     query("min(sf_metrics_database_up%s)" % J, "Database readable", "B")],
-    timeseries(fill=10, minmax=(0, 1), decimals=0))
-
 
 def item(x, y, w, h, pid):
     return {
@@ -537,11 +534,10 @@ rows = [
         item(18, 0, 3, 4, 23), item(21, 0, 3, 4, 24),
         item(0, 4, 12, 8, 25), item(12, 4, 12, 8, 26),
     ]),
-    row("🏷️ Client Builds · from browsers", [
-        item(0, 0, 12, 8, 40), item(12, 0, 12, 8, 41), item(0, 8, 6, 4, 42),
-    ]),
-    row("🩺 Collection Health", [
-        item(0, 0, 6, 4, 50), item(0, 4, 6, 4, 51), item(6, 0, 18, 8, 52),
+    row("🏷️ Client Builds and Commits · from browsers", [
+        item(0, 0, 12, 8, 40), item(12, 0, 12, 8, 41),
+        item(0, 8, 12, 10, 43), item(12, 8, 12, 10, 44),
+        item(0, 18, 6, 4, 42), item(6, 18, 6, 4, 45),
     ]),
 ]
 

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -4533,6 +4533,296 @@
           }
         }
       },
+      "panel-43": {
+        "kind": "Panel",
+        "spec": {
+          "id": 43,
+          "title": "Browsers by Commit",
+          "description": "Active browsers by the commit their bundle was built from. A build that reported no commit, such as a local one, counts under \"unknown\". Capped to the busiest 25 commits.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sf_clients_by_sha{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{sha}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.sha}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-44": {
+        "kind": "Panel",
+        "spec": {
+          "id": 44,
+          "title": "Commit Rollout Over Time",
+          "description": "Stacked. After a deploy, watch the previous commit drain. This is the panel that says whether a rollout has actually reached people, which a version number cannot: several commits ship under one version.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (sha) (sf_clients_by_sha{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{sha}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-45": {
+        "kind": "Panel",
+        "spec": {
+          "id": 45,
+          "title": "Browsers on an Unknown Commit",
+          "description": "Builds reporting no usable commit. Expect this to be non-zero only for local development builds.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_clients_by_sha{job=\"satisfactory-factories-preview\",sha=\"unknown\"}) or vector(0)",
+                        "legendFormat": "Unknown",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 1,
+                        "color": "#6a6a6a"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
       "panel-42": {
         "kind": "Panel",
         "spec": {
@@ -4615,312 +4905,6 @@
                   "color": {
                     "mode": "thresholds"
                   }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-50": {
-        "kind": "Panel",
-        "spec": {
-          "id": 50,
-          "title": "Scrape Up",
-          "description": "Prometheus's own view of whether this target answered. 0 means the endpoint is unreachable, the token is wrong, or the build has no /metrics route.",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "prometheus"
-                      },
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "min(up{job=\"satisfactory-factories-preview\"})",
-                        "legendFormat": "Up",
-                        "range": true
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "stat",
-            "version": "13.0.2",
-            "spec": {
-              "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "short",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "red"
-                      },
-                      {
-                        "value": 1,
-                        "color": "green"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "thresholds"
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-51": {
-        "kind": "Panel",
-        "spec": {
-          "id": 51,
-          "title": "Scrape Duration",
-          "description": "How long the endpoint takes to answer. The database gauges are cached for 10s, so most scrapes are cheap and one in every few does real work.",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "prometheus"
-                      },
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "max(scrape_duration_seconds{job=\"satisfactory-factories-preview\"})",
-                        "legendFormat": "Duration",
-                        "range": true
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "stat",
-            "version": "13.0.2",
-            "spec": {
-              "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "s",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "decimals": 3
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-52": {
-        "kind": "Panel",
-        "spec": {
-          "id": 52,
-          "title": "Collection Health Over Time",
-          "description": "Both lines should sit flat at 1. Scrape up dropping is a transport or auth problem; database readable dropping means Mongo is unreachable and the room and account gauges are stale rather than zero.",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "prometheus"
-                      },
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "min(up{job=\"satisfactory-factories-preview\"})",
-                        "legendFormat": "Scrape up",
-                        "range": true
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "prometheus"
-                      },
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "min(sf_metrics_database_up{job=\"satisfactory-factories-preview\"})",
-                        "legendFormat": "Database readable",
-                        "range": true
-                      }
-                    },
-                    "refId": "B",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "timeseries",
-            "version": "13.0.2",
-            "spec": {
-              "options": {
-                "annotations": {
-                  "clustering": -1,
-                  "multiLane": false
-                },
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "short",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "gradientMode": "opacity",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 2,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "decimals": 0,
-                  "min": 0,
-                  "max": 1
                 },
                 "overrides": []
               }
@@ -5593,7 +5577,7 @@
           {
             "kind": "RowsLayoutRow",
             "spec": {
-              "title": "🏷️ Client Builds · from browsers",
+              "title": "🏷️ Client Builds and Commits · from browsers",
               "collapse": false,
               "layout": {
                 "kind": "GridLayout",
@@ -5630,6 +5614,32 @@
                       "spec": {
                         "x": 0,
                         "y": 8,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-43"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 8,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-44"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 18,
                         "width": 6,
                         "height": 4,
                         "element": {
@@ -5637,57 +5647,17 @@
                           "name": "panel-42"
                         }
                       }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "🩺 Collection Health",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 4,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-50"
-                        }
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 4,
-                        "width": 6,
-                        "height": 4,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-51"
-                        }
-                      }
                     },
                     {
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 6,
-                        "y": 0,
-                        "width": 18,
-                        "height": 8,
+                        "y": 18,
+                        "width": 6,
+                        "height": 4,
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-52"
+                          "name": "panel-45"
                         }
                       }
                     }

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -4533,6 +4533,296 @@
           }
         }
       },
+      "panel-43": {
+        "kind": "Panel",
+        "spec": {
+          "id": 43,
+          "title": "Browsers by Commit",
+          "description": "Active browsers by the commit their bundle was built from. A build that reported no commit, such as a local one, counts under \"unknown\". Capped to the busiest 25 commits.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sf_clients_by_sha{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{sha}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.sha}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-44": {
+        "kind": "Panel",
+        "spec": {
+          "id": 44,
+          "title": "Commit Rollout Over Time",
+          "description": "Stacked. After a deploy, watch the previous commit drain. This is the panel that says whether a rollout has actually reached people, which a version number cannot: several commits ship under one version.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (sha) (sf_clients_by_sha{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{sha}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 25,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-45": {
+        "kind": "Panel",
+        "spec": {
+          "id": 45,
+          "title": "Browsers on an Unknown Commit",
+          "description": "Builds reporting no usable commit. Expect this to be non-zero only for local development builds.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_clients_by_sha{job=\"satisfactory-factories\",sha=\"unknown\"}) or vector(0)",
+                        "legendFormat": "Unknown",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 1,
+                        "color": "#6a6a6a"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
       "panel-42": {
         "kind": "Panel",
         "spec": {
@@ -4615,312 +4905,6 @@
                   "color": {
                     "mode": "thresholds"
                   }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-50": {
-        "kind": "Panel",
-        "spec": {
-          "id": 50,
-          "title": "Scrape Up",
-          "description": "Prometheus's own view of whether this target answered. 0 means the endpoint is unreachable, the token is wrong, or the build has no /metrics route.",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "prometheus"
-                      },
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "min(up{job=\"satisfactory-factories\"})",
-                        "legendFormat": "Up",
-                        "range": true
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "stat",
-            "version": "13.0.2",
-            "spec": {
-              "options": {
-                "colorMode": "background",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "short",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "red"
-                      },
-                      {
-                        "value": 1,
-                        "color": "green"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "thresholds"
-                  }
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-51": {
-        "kind": "Panel",
-        "spec": {
-          "id": 51,
-          "title": "Scrape Duration",
-          "description": "How long the endpoint takes to answer. The database gauges are cached for 10s, so most scrapes are cheap and one in every few does real work.",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "prometheus"
-                      },
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "max(scrape_duration_seconds{job=\"satisfactory-factories\"})",
-                        "legendFormat": "Duration",
-                        "range": true
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "stat",
-            "version": "13.0.2",
-            "spec": {
-              "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "s",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "decimals": 3
-                },
-                "overrides": []
-              }
-            }
-          }
-        }
-      },
-      "panel-52": {
-        "kind": "Panel",
-        "spec": {
-          "id": 52,
-          "title": "Collection Health Over Time",
-          "description": "Both lines should sit flat at 1. Scrape up dropping is a transport or auth problem; database readable dropping means Mongo is unreachable and the room and account gauges are stale rather than zero.",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "prometheus"
-                      },
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "min(up{job=\"satisfactory-factories\"})",
-                        "legendFormat": "Scrape up",
-                        "range": true
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "datasource": {
-                        "name": "prometheus"
-                      },
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "min(sf_metrics_database_up{job=\"satisfactory-factories\"})",
-                        "legendFormat": "Database readable",
-                        "range": true
-                      }
-                    },
-                    "refId": "B",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "timeseries",
-            "version": "13.0.2",
-            "spec": {
-              "options": {
-                "annotations": {
-                  "clustering": -1,
-                  "multiLane": false
-                },
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "unit": "short",
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "gradientMode": "opacity",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 2,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "decimals": 0,
-                  "min": 0,
-                  "max": 1
                 },
                 "overrides": []
               }
@@ -5593,7 +5577,7 @@
           {
             "kind": "RowsLayoutRow",
             "spec": {
-              "title": "🏷️ Client Builds · from browsers",
+              "title": "🏷️ Client Builds and Commits · from browsers",
               "collapse": false,
               "layout": {
                 "kind": "GridLayout",
@@ -5630,6 +5614,32 @@
                       "spec": {
                         "x": 0,
                         "y": 8,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-43"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 8,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-44"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 18,
                         "width": 6,
                         "height": 4,
                         "element": {
@@ -5637,57 +5647,17 @@
                           "name": "panel-42"
                         }
                       }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "kind": "RowsLayoutRow",
-            "spec": {
-              "title": "🩺 Collection Health",
-              "collapse": false,
-              "layout": {
-                "kind": "GridLayout",
-                "spec": {
-                  "items": [
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 0,
-                        "width": 6,
-                        "height": 4,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-50"
-                        }
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "x": 0,
-                        "y": 4,
-                        "width": 6,
-                        "height": 4,
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-51"
-                        }
-                      }
                     },
                     {
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 6,
-                        "y": 0,
-                        "width": 18,
-                        "height": 8,
+                        "y": 18,
+                        "width": 6,
+                        "height": 4,
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-52"
+                          "name": "panel-45"
                         }
                       }
                     }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -18,7 +18,7 @@ case, and roughly how large plans get.
 ## Exactly what is collected
 
 One `POST /telemetry` on page load and one every five minutes after that. The body has
-seven fields and the server rejects it outright if it has any others:
+eight fields, one of them optional, and the server rejects it outright if it has any others:
 
 | Field | What it is |
 | --- | --- |
@@ -29,8 +29,9 @@ seven fields and the server rejects it outright if it has any others:
 | `cloudTabCount` | How many of those are synced. |
 | `factoriesTotal` | How many factories across all of those tabs. |
 | `appVersion` | Which build of the planner is running. |
+| `gitSha` | Which commit that build came from. Absent on builds that do not know, such as local ones. |
 
-Counts, one flag and a version string. That is the whole payload.
+Counts, one flag and two build identifiers. That is the whole payload.
 
 ## What is not collected
 
@@ -56,10 +57,16 @@ cannot be connected to the old one.
 
 ## How long it is kept
 
-Fifteen minutes, in memory, and never written to the database. An instance that stops
-sending is dropped entirely fifteen minutes later, and restarting the API forgets
-everything at once. There is no history: the metrics answer "how many right now", and
-nothing stores yesterday's answer.
+Fifteen minutes. A row that stops being updated is dropped entirely fifteen minutes after
+its last heartbeat, both by an expiry index and by every read filtering on the timestamp.
+
+It is stored in the database rather than in memory. That is a change from the first
+version, which held it in memory only: the practical effect was that every deployment threw
+the whole picture away, and the API deploys often. Nothing else about it changed, and the
+fifteen minute limit is enforced the same way either way.
+
+There is still no history. The metrics answer "how many right now"; nothing keeps
+yesterday's answer.
 
 ## Turning it off
 

--- a/web/src/config/config.ts
+++ b/web/src/config/config.ts
@@ -10,6 +10,9 @@ export const config = {
   // backend can refuse writes from a tab too old to know the current save shape. Nothing to do
   // with `plannerVersion` below, which is a property of a plan rather than of the app.
   appVersion: import.meta.env.VITE_APP_VERSION,
+  // The commit this bundle was built from, 12 characters, or empty when built outside CI.
+  // Reported in the heartbeat so a rollout can be watched by commit as well as by release.
+  gitSha: import.meta.env.VITE_GIT_SHA,
   dataVersion: '1.2-09',
   // Stamped onto every factory as `plannerVersion`, marking a plan as having been answered for
   // the raw-resources change. Bump only when a release needs to ask a plan-wide question again.

--- a/web/src/stores/telemetry-store.spec.ts
+++ b/web/src/stores/telemetry-store.spec.ts
@@ -28,6 +28,9 @@ const ALLOWED_FIELDS = [
   'tabCount',
 ]
 
+/** Sent only when the build knows its commit, so it is not in the always-present set. */
+const OPTIONAL_FIELDS = ['gitSha']
+
 /** Anything that would identify a person, however indirectly. None of it may appear. */
 const FORBIDDEN_FIELDS = [
   'username', 'user', 'userId', 'accountId', 'email', 'token', 'name',
@@ -62,7 +65,9 @@ describe('telemetry-store', () => {
     it('sends exactly the allowed fields and nothing else', async () => {
       await store.send()
 
-      expect(Object.keys(sent() ?? {}).sort()).toEqual(ALLOWED_FIELDS)
+      const keys = Object.keys(sent() ?? {}).sort()
+      expect(keys.filter(k => !OPTIONAL_FIELDS.includes(k))).toEqual(ALLOWED_FIELDS)
+      expect(keys.filter(k => !ALLOWED_FIELDS.includes(k) && !OPTIONAL_FIELDS.includes(k))).toEqual([])
     })
 
     it.each(FORBIDDEN_FIELDS)('never sends a %s', async field => {

--- a/web/src/stores/telemetry-store.ts
+++ b/web/src/stores/telemetry-store.ts
@@ -104,6 +104,9 @@ export const useTelemetryStore = defineStore('telemetry', () => {
       cloudTabCount,
       factoriesTotal,
       appVersion: config.appVersion || UNKNOWN_VERSION,
+      // Omitted rather than sent empty when the build knows no commit: the field is optional
+      // and the server counts a missing one under `unknown` either way.
+      ...(config.gitSha ? { gitSha: config.gitSha } : {}),
     }
   }
 

--- a/web/vite.config.mts
+++ b/web/vite.config.mts
@@ -31,6 +31,16 @@ process.env.VITE_APP_VERSION = JSON.parse(
   readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8')
 ).version
 
+// The exact commit this bundle was built from, so a rollout can be watched by commit and not
+// only by release. Vercel sets VERCEL_GIT_COMMIT_SHA on every build; GIT_SHA is the escape
+// hatch for building somewhere else. Truncated to 12 characters, which is unambiguous in
+// practice and short enough to read on a chart axis.
+//
+// Empty rather than a placeholder when unknown: the telemetry schema treats the field as
+// optional, so a local `pnpm dev` reports no commit rather than a fake one.
+process.env.VITE_GIT_SHA =
+  (process.env.VERCEL_GIT_COMMIT_SHA || process.env.GIT_SHA || '').slice(0, 12)
+
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
   build: {


### PR DESCRIPTION
**No manual steps.** No new env var. Vercel already sets `VERCEL_GIT_COMMIT_SHA` on every build; the Vite config just reads it.

## Three things

### 1. Browsers by commit

The heartbeat now carries `gitSha`, 12 characters, from `VERCEL_GIT_COMMIT_SHA`. New metric `sf_clients_by_sha{sha}`, and the version metric stays exactly as it was.

A version number cannot answer "has this rollout reached people", because several commits ship under one version. The commit can.

- **Optional field.** A tab loaded before this existed keeps reporting rather than being refused by the strict object. A local build that knows no commit sends nothing rather than inventing one. Both count under `unknown`.
- **Hex only, and capped.** Every merge mints a new commit, so it is the more dangerous of the two labels for cardinality. It shares the same top-25 cap as the version.

### 2. The census is persisted

**You were right, and my original reasoning was wrong.** I argued a write per browser per five minutes would be the busiest collection here. That is true only in frequency; in absolute terms a hundred concurrent browsers is twenty writes a minute, which is nothing. What the in-memory `Map` actually cost was the entire census on every deploy.

So it is a Mongo collection now, `telemetry_instances`, one row per browser.

**No Redis.** It would be a whole extra container and a second thing to operate, for data that Mongo handles without noticing. You said as much yourself.

Expiry is unchanged at fifteen minutes, enforced twice: a TTL index bounds storage, and every read filters on the timestamp so the window is exact rather than "whenever Mongo last swept".

The rate limit became one **conditional upsert** rather than a read then a write, so two concurrent heartbeats cannot both pass the check. `$lte` and not `$lt`, because the in-memory version accepted a heartbeat landing exactly on the floor and tightening that by a millisecond during a port would be an accidental behaviour change.

The census read is now a database read, so it went behind the same cache as the other groups: a Mongo outage leaves the client panels at their last values rather than blanking them.

### 3. Collection Health is gone

Row removed, three panels deleted.

## Why your new factory did not show up

Not the 5-minute lag. **Your browser is not reaching an API that has this code.**

| | |
| --- | --- |
| Production `/metrics` | **404** — still on 0.8.0, no telemetry code at all |
| Preview census | **0 active clients** |

Production Vercel builds from `main`, which does not have the heartbeat either, so the live site sends nothing and the live API would 404 it if it did. To see yourself in the numbers you need a **Vercel preview URL**, which points at the preview API. This all reaches production when the sync-refactor branch lands on `main`.

## Verification

| Gate | Result |
| --- | --- |
| `backend` vitest | **414 passed**, 29 files |
| `backend` tsc | clean |
| `common` vitest | **123 passed** |
| `web` vitest | **3027 passed**, 1 skipped |
| `web` vue-tsc | clean |
| `pnpm lint-check` | exit 0 |

New tests include: **the census survives a process restart** (a second app on the same database is what a redeploy looks like from Mongo's side), commit grouping, a missing commit counting as `unknown`, non-hex values bucketing rather than becoming labels, and an over-long commit being rejected.

`docs/telemetry.md` updated for the new field and for the storage change, including why it changed.