### PR TITLE
feat(repo): configurable local dev ports via `pnpm dev --port`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ pnpm dev --port 3100         # web on 3100, API left on 3001
 pnpm dev:web --port 3100     # same flag on the single-server scripts
 ```
 
-`WEB_PORT` and `API_PORT` do the same job as environment variables, and the flag wins over them. Under the hood `scripts/dev.mjs` also has to tell each half where the other went: the web app gets `VITE_API_URL` so its API calls and its sync socket follow, and the API gets the new web origin appended to `CORS_EXTRA_ORIGINS`, without which every request fails preflight and every socket upgrade 403s. Nothing outside local dev reads either of those two ports.
+`WEB_PORT` and `API_PORT` do the same job as environment variables, and the flag wins over them. One behaviour change comes with this on the default ports too: a dev server launched through `pnpm dev` now fails if its port is taken instead of quietly moving to the next free one, which for the web app is the API's.
+
+Under the hood `scripts/dev.mjs` also has to tell each half where the other went: the web app gets `VITE_API_URL` so its API calls and its sync socket follow, and the API gets the new web origin appended to `CORS_EXTRA_ORIGINS`, without which every request fails preflight and every socket upgrade 403s. Nothing outside local dev reads either of those two ports.
 
 The e2e suite (`pnpm test:e2e`) is deliberately **not** movable and asserts 3000/3001 are free before it starts. It builds the real client, and a built client bakes its API URL in.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pnpm install   # installs web + backend + parsing
 pnpm dev       # starts Mongo (Docker), then the backend + frontend together
 ```
 
-`pnpm dev` runs the frontend on http://localhost:3000 and the backend on http://localhost:3001 in parallel (their logs are interleaved in the one terminal). The backend requires Docker to be running. `backend/.env` is committed with working local defaults, so there is nothing to create — just be aware those credentials are for local dev only.
+`pnpm dev` runs the frontend on http://localhost:3000 and the backend on http://localhost:3001 in parallel (their logs are interleaved in the one terminal). If something else on your machine already has those, `pnpm dev --port 3100,3101` moves both for that run; see [Ports](#ports). The backend requires Docker to be running. `backend/.env` is committed with working local defaults, so there is nothing to create — just be aware those credentials are for local dev only.
 
 If you only want to work on the planner — which is most of the time — `pnpm dev:web` is enough and needs no Docker.
 
@@ -56,6 +56,7 @@ For anything specific to a single component, see its own README — linked from 
 | Command | Description |
 | --- | --- |
 | `pnpm dev` | Bring up the Mongo container, then run the backend + frontend dev servers in parallel |
+| `pnpm dev [--port <web>[,<api>]]` | The same, on ports of your choosing instead of 3000/3001 |
 | `pnpm dev:web` | Run only the frontend dev server |
 | `pnpm dev:backend` | Bring up Mongo, then run only the backend dev server |
 | `pnpm dev:parsing` | Run the parser |
@@ -70,9 +71,22 @@ The reason there is only one lockfile is `sharedWorkspaceLockfile: true` in `pnp
 You can still run commands from inside a single package if you prefer — `cd web && pnpm dev` works fine. What you don't need is a per-package `pnpm install`: the root install has already put `node_modules` in place for all three. If you do want to install just one package's dependencies, use `pnpm install --filter web` from anywhere in the workspace rather than `cd`-ing in.
 
 ### Ports
-**The port allocation is 3000 for the web app and 3001 for the API, everywhere** — local dev, the container, the host, and behind the tunnel. Treat those two as fixed; anything else that wants a port should move rather than pushing the API off 3001.
+**Everywhere the app is deployed, the allocation is 3000 for the web app and 3001 for the API, and those two are fixed.** That covers the container, the `EXPOSE`, both sides of every compose mapping, the host port, and the tunnel's origin. Anything else that wants a port should move rather than pushing the API off 3001, and moving one layer means moving all of them: `618e944` put the app on 3010 and left everything else at 3001, which produced a container nothing upstream could reach.
 
-> One known overlap: `web/testing/global-setup.ts` serves the test `gameData.json` on 3001 too, and it *silently skips startup* if the port is taken — so running `pnpm test` in `web/` while the backend is up makes the suite fetch game data from the API, get a 404, and fail confusingly. It is rare enough to live with: stop the backend first, or start it elsewhere with `PORT=3011 pnpm dev:backend` (the frontend's dev API URL is hardcoded to 3001, so only do that when you're not exercising save/load). If it does start to bite, move **the test fixture** to a port of its own — say 3005 — rather than moving the API.
+Local dev is the one exception, and only because a dev server has nothing upstream of it. `pnpm dev` still defaults to 3000/3001, and `--port` moves both for one run:
+
+```sh
+pnpm dev                     # 3000 + 3001, as before
+pnpm dev --port 3100,3101    # web on 3100, API on 3101
+pnpm dev --port 3100         # web on 3100, API left on 3001
+pnpm dev:web --port 3100     # same flag on the single-server scripts
+```
+
+`WEB_PORT` and `API_PORT` do the same job as environment variables, and the flag wins over them. Under the hood `scripts/dev.mjs` also has to tell each half where the other went: the web app gets `VITE_API_URL` so its API calls and its sync socket follow, and the API gets the new web origin appended to `CORS_EXTRA_ORIGINS`, without which every request fails preflight and every socket upgrade 403s. Nothing outside local dev reads either of those two ports.
+
+The e2e suite (`pnpm test:e2e`) is deliberately **not** movable and asserts 3000/3001 are free before it starts. It builds the real client, and a built client bakes its API URL in.
+
+> One known overlap: `web/testing/global-setup.ts` serves the test `gameData.json` on 3001 too, and it *silently skips startup* if the port is taken — so running `pnpm test` in `web/` while the backend is up makes the suite fetch game data from the API, get a 404, and fail confusingly. Stop the backend first, or start it elsewhere with `pnpm dev --port 3000,3011`, which now points the frontend at 3011 as well so save/load keeps working. If it starts to bite often, move **the test fixture** to a port of its own — say 3005 — rather than moving the API.
 
 ### Deployment
 New versions are trunked to `main` branch. Once `main` has been pushed, GitHub Actions will create a release then deploy the frontend to Vercel, and build a docker image of the backend which is published to Docker Hub and pulled onto my personal server automatically.

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -12,7 +12,8 @@ import { configureApp } from './bootstrap'
 // reason production survived is that it was still running an older image.
 //
 // Overridable because web's vitest fixture server also binds 3001
-// (web/testing/global-setup.ts). Nothing deployed sets it.
+// (web/testing/global-setup.ts), and because `pnpm dev --port` sets it to move
+// local dev off the default pair. Nothing deployed sets it.
 const PORT = Number(process.env.PORT) || 3001
 
 const bootstrap = async (): Promise<void> => {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,7 +72,8 @@ still there as a break-glass path and says so at the top.
   and the only reason production survived is that it was still running an image
   from before that commit; the first rebuild would have published a container
   nothing upstream could reach. `PORT` can override the app's port for local work
-  (web's vitest fixture also binds 3001), but nothing deployed sets it.
+  (web's vitest fixture also binds 3001, and `pnpm dev --port` sets it to move a
+  local run off the default pair), but nothing deployed sets it.
 - **The WebSocket gateway shares that same port and process.** Realtime sync is
   served at `/ws` on 3001 — no second port, no second container, no extra compose
   entry. What it does need is a tunnel that forwards the `Upgrade` header;

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "pnpm": ">=11.3.0"
   },
   "scripts": {
-    "dev": "pnpm db:up && pnpm --parallel --filter web --filter backend run dev",
-    "dev:web": "pnpm --filter web run dev",
-    "dev:backend": "pnpm db:up && pnpm --filter backend run dev",
+    "dev": "node scripts/dev.mjs all",
+    "dev:web": "node scripts/dev.mjs web",
+    "dev:backend": "node scripts/dev.mjs backend",
     "dev:parsing": "pnpm --filter parsing run dev",
     "db:up": "pnpm --filter backend run db:up",
     "db:down": "pnpm --filter backend run db:down",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// Launches the dev servers, optionally somewhere other than 3000/3001.
+//
+// Local dev only. Every deployed port is still fixed and load-bearing — see the
+// Ports section of the README before touching anything outside this file.
+
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import process from 'node:process'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+const DEFAULT_WEB_PORT = 3000
+const DEFAULT_API_PORT = 3001
+
+const USAGE = `Usage: pnpm dev [--port <web>[,<api>]]
+
+  pnpm dev                       web on ${DEFAULT_WEB_PORT}, API on ${DEFAULT_API_PORT}
+  pnpm dev --port 3100,3101      web on 3100, API on 3101
+  pnpm dev --port 3100           web on 3100, API left on ${DEFAULT_API_PORT}
+
+WEB_PORT and API_PORT (or PORT, the API's existing name) do the same thing as
+environment variables; the flag wins over both.`
+
+const fail = message => {
+  console.error(`${message}\n\n${USAGE}`)
+  process.exit(1)
+}
+
+const parsePort = (value, label) => {
+  const port = Number(value)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    fail(`"${value}" is not a usable ${label} port.`)
+  }
+  return port
+}
+
+/**
+ * `--port 3100,3101` is web,API; a lone number moves only the web app.
+ *
+ * PORT is read only when this run actually starts the API, because it keeps
+ * `PORT=3011 pnpm dev:backend` working as documented, and because the puppeteer
+ * harnesses under web/testing/browser use the same name for the *web* port.
+ */
+const resolvePorts = (argv, env, { servesApi }) => {
+  const apiFromEnv = env.API_PORT || (servesApi ? env.PORT : undefined)
+  const fromEnv = {
+    web: env.WEB_PORT ? parsePort(env.WEB_PORT, 'web') : DEFAULT_WEB_PORT,
+    api: apiFromEnv ? parsePort(apiFromEnv, 'API') : DEFAULT_API_PORT,
+  }
+
+  const flag = argv.indexOf('--port')
+  if (flag === -1) return fromEnv
+
+  const raw = argv[flag + 1]
+  if (!raw || raw.startsWith('-')) fail('--port needs a value.')
+
+  const [web, api] = raw.split(',')
+  return {
+    web: parsePort(web, 'web'),
+    api: api === undefined ? fromEnv.api : parsePort(api, 'API'),
+  }
+}
+
+/**
+ * Moving a port is three changes, not one. The web app has to be told where the
+ * API went — VITE_API_URL is the one lever that beats every default in
+ * web/src/config/config.ts, and the sync socket URL is derived from it. The API
+ * has to be told the web app moved, or every request fails preflight and every
+ * WS upgrade 403s against WEB_ORIGINS in backend/src/config/cors.ts.
+ *
+ * Both are left alone on the default ports, so an unflagged run hands the child
+ * processes exactly the environment they got before this script existed.
+ */
+const devEnv = (ports, env, { servesApi }) => {
+  const next = { ...env, WEB_PORT: String(ports.web), API_PORT: String(ports.api) }
+  if (servesApi) next.PORT = String(ports.api)
+
+  if (ports.api !== DEFAULT_API_PORT && !env.VITE_API_URL) {
+    next.VITE_API_URL = `http://localhost:${ports.api}`
+  }
+  // Appended rather than assigned: a value already in the environment is
+  // somebody's preview origin and outlives this run.
+  if (ports.web !== DEFAULT_WEB_PORT) {
+    next.CORS_EXTRA_ORIGINS = [env.CORS_EXTRA_ORIGINS, `http://localhost:${ports.web}`]
+      .filter(Boolean)
+      .join(',')
+  }
+  return next
+}
+
+const run = (args, env) => new Promise((resolve, reject) => {
+  const child = spawn('pnpm', args, { cwd: REPO_ROOT, env, stdio: 'inherit' })
+  child.on('error', reject)
+  child.on('exit', code => resolve(code ?? 1))
+})
+
+const TARGETS = {
+  web: {
+    steps: [['--filter', 'web', 'run', 'dev']],
+    servesWeb: true,
+    servesApi: false,
+  },
+  backend: {
+    steps: [['db:up'], ['--filter', 'backend', 'run', 'dev']],
+    servesWeb: false,
+    servesApi: true,
+  },
+  all: {
+    steps: [['db:up'], ['--parallel', '--filter', 'web', '--filter', 'backend', 'run', 'dev']],
+    servesWeb: true,
+    servesApi: true,
+  },
+}
+
+const main = async () => {
+  const argv = process.argv.slice(2)
+  const target = TARGETS[argv[0]]
+  if (!target) fail(`Unknown target "${argv[0] ?? ''}".`)
+
+  const ports = resolvePorts(argv, process.env, target)
+  if (target.servesWeb && target.servesApi && ports.web === ports.api) {
+    fail(`The web app and the API cannot share port ${ports.web}.`)
+  }
+
+  const env = devEnv(ports, process.env, target)
+
+  if (target.servesWeb) console.log(`Web app: http://localhost:${ports.web}`)
+  if (target.servesApi) console.log(`API:     http://localhost:${ports.api}`)
+  // dev:web against an API somewhere else is a legitimate combination, so say so.
+  if (target.servesWeb && !target.servesApi && env.VITE_API_URL) {
+    console.log(`API:     ${env.VITE_API_URL} (not started here)`)
+  }
+
+  for (const step of target.steps) {
+    const code = await run(step, env)
+    if (code !== 0) process.exit(code)
+  }
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -70,8 +70,8 @@ const resolvePorts = (argv, env, { servesApi }) => {
  * has to be told the web app moved, or every request fails preflight and every
  * WS upgrade 403s against WEB_ORIGINS in backend/src/config/cors.ts.
  *
- * Both are left alone on the default ports, so an unflagged run hands the child
- * processes exactly the environment they got before this script existed.
+ * Both are left alone on the default ports, so an unflagged run reaches the same
+ * API URL and the same origin allowlist it did before this script existed.
  */
 const devEnv = (ports, env, { servesApi }) => {
   const next = { ...env, WEB_PORT: String(ports.web), API_PORT: String(ports.api) }

--- a/web/vite.config.mts
+++ b/web/vite.config.mts
@@ -122,7 +122,12 @@ export default defineConfig(() => ({
     ],
   },
   server: {
-    port: 3000,
+    // 3000 unless a dev moved it for one run with `pnpm dev --port`; see
+    // scripts/dev.mjs. Playwright passes --port on the CLI, which wins over this.
+    port: Number(process.env.WEB_PORT) || 3000,
+    // A moved port was also handed to the API as an allowed origin, so drifting
+    // to the next free one would silently cost CORS. Fail instead.
+    strictPort: Boolean(process.env.WEB_PORT),
   },
   test: {
     globals: true,

--- a/web/vite.config.mts
+++ b/web/vite.config.mts
@@ -122,11 +122,13 @@ export default defineConfig(() => ({
     ],
   },
   server: {
-    // 3000 unless a dev moved it for one run with `pnpm dev --port`; see
-    // scripts/dev.mjs. Playwright passes --port on the CLI, which wins over this.
+    // 3000 unless a dev moved it for one run with `pnpm dev --port`. Playwright
+    // passes --port on the CLI, which wins over this.
     port: Number(process.env.WEB_PORT) || 3000,
-    // A moved port was also handed to the API as an allowed origin, so drifting
-    // to the next free one would silently cost CORS. Fail instead.
+    // scripts/dev.mjs always sets WEB_PORT, so every scripted dev run fails on a
+    // taken port rather than drifting to the next free one. A moved port was
+    // handed to the API as an allowed origin, and on the default pair the next
+    // free port is the API's own.
     strictPort: Boolean(process.env.WEB_PORT),
   },
   test: {


### PR DESCRIPTION
## Manual steps

None. Nothing to set and nothing to migrate. `pnpm dev` with no flag still starts on 3000 and 3001.

## What this adds

An IDE or another project sitting on 3000 currently leaves the planner with nowhere to run. This adds a flag that moves both dev servers for one run:

```sh
pnpm dev                     # 3000 + 3001, as before
pnpm dev --port 3100,3101    # web on 3100, API on 3101
pnpm dev --port 3100         # web on 3100, API left on 3001
pnpm dev:web --port 3100     # the single-server scripts take it too
```

`WEB_PORT` and `API_PORT` do the same job as environment variables, and the flag wins over them. `pnpm dev`, `pnpm dev:web` and `pnpm dev:backend` all keep their existing ports with no flag; the one behaviour change on that path is `strictPort`, covered below.

## Why a script rather than two env vars

Moving a port is three changes, and the two that are not `server.port` stay invisible until something 403s:

1. Vite's `server.port` (`web/vite.config.mts`).
2. The web app has to be told where the API went. `VITE_API_URL` already beats every other default in `web/src/config/config.ts`, and `syncSocketUrl()` derives the WS URL from it, so that one variable moves the REST calls and the socket together. That is why I used the existing lever instead of inventing a second one.
3. The API has to be told the web app moved, or every request fails CORS preflight and every WS upgrade 403s against `WEB_ORIGINS`.

Threading `--port` through `pnpm --parallel --filter` and doing that derivation inside a `package.json` string is not something I want to maintain, so `scripts/dev.mjs` parses the flag, derives the environment, and then delegates to the same `pnpm --filter` invocations that were in `package.json` before. Process management, interleaved logs and Ctrl-C are still pnpm's job.

## The CORS call

I reused `CORS_EXTRA_ORIGINS` instead of teaching `backend/src/config/cors.ts` about a dev web port.

- It already exists for exactly this problem (the preview API sets it because Vercel hostnames cannot be enumerated in advance), it is already unit tested, and it is already documented.
- The alternative puts an environment lever on the deployed allowlist for something only local dev will ever use. `WEB_ORIGINS` is the boundary for both the HTTP allowlist and the WS upgrade check, and I would rather it stay a static list.

Two details in how the script uses it:

- It **appends** rather than assigns, so a value already in the environment survives the run.
- It only touches the variable when the web port is not 3000, so on the default ports the API's origin allowlist is exactly the static list it was before.

## Other arguable calls

- **`PORT` is read as the API port only on runs that actually start the API.** `PORT=3011 pnpm dev:backend` was documented in the README and still works. I deliberately did not extend it to `dev:web`, because the puppeteer harnesses in `web/testing/browser/` already use `PORT` to mean the *web* port and I did not want a third meaning for it.
- **`strictPort` is on for every scripted dev run, including the default ports.** This is the one behaviour change on the no-flag path, so calling it out: `pnpm dev` now fails if 3000 is taken instead of quietly moving to the next free port. I think that is the right trade. A moved port has been handed to the API as an allowed origin, so drifting off it costs CORS on a server that looks like it started fine; and on the default pair the next free port after 3000 is 3001, so the old behaviour was the web app wandering onto the API's port. `cd web && pnpm dev` does not go through the script and keeps the old behaviour. It is documented in the README's Ports section.
- **`--port 3100,3100` is rejected** rather than turning into a confusing bind failure halfway through startup.
- **`scripts/` is outside every package's lint and test scope.** `pnpm lint-check` is `pnpm --recursive run lint-check`, so a root directory is not covered, and there is no root ESLint config or test runner to hang one off. I checked the file by hand against `web/eslint.config.mjs` (`web/node_modules/.bin/eslint --no-ignore --config web/eslint.config.mjs scripts/dev.mjs`, clean), but nothing will catch drift. A root ESLint config is a reasonable follow-up; it felt like more change than this feature deserves.

## Nothing deployed moved

`docker-compose-server.yml` (3001), `docker-compose-preview.yml` (3002), the Dockerfile `EXPOSE` and the tunnel origin are all untouched. The README's Ports section now separates the deployed allocation, which is still fixed and still carries the `618e944` warning about moving one layer and not the rest, from local dev, which is not. The existing warning about the vitest fixture on 3001 is kept, and its workaround is better than it was: `pnpm dev --port 3000,3011` now points the frontend at 3011 too, so save/load keeps working while the fixture has 3001 to itself.

The e2e suite keeps its fixed 3000/3001 and still asserts they are free before it starts. It builds the real client, and a built client bakes its API URL in.

## Validation

| Gate | Result |
| --- | --- |
| `backend` | 442 tests pass, `tsc --noEmit` clean |
| `common` | 143 tests pass, `tsc --noEmit` clean |
| `web` | 3046 pass / 1 skipped, `vue-tsc --noEmit` clean |
| root | `pnpm lint-check` 0 errors |
| `pnpm test:e2e` | 45 passed (6.6m), still on its fixed 3000/3001 |

### Moved ports

`pnpm dev --port 3100,3101`:

```
$ node scripts/dev.mjs all --port 3100,3101
Web app: http://localhost:3100
API:     http://localhost:3101
web dev:   ➜  Local:   http://localhost:3100/
backend dev: Webserver running at http://localhost:3101/
```

Preflight and the upgrade, from the moved web origin:

```
$ curl -i -X OPTIONS http://localhost:3101/rooms \
    -H 'Origin: http://localhost:3100' \
    -H 'Access-Control-Request-Method: GET' \
    -H 'Access-Control-Request-Headers: x-app-version,authorization'
HTTP/1.1 204 No Content
Access-Control-Allow-Origin: http://localhost:3100
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Headers: Content-Type,Authorization,X-App-Version

$ curl -i --http1.1 -H 'Connection: Upgrade' -H 'Upgrade: websocket' \
    -H 'Sec-WebSocket-Version: 13' -H 'Sec-WebSocket-Key: ...' \
    -H 'Origin: http://localhost:3100' http://localhost:3101/ws
HTTP/1.1 101 Switching Protocols
```

An origin that is not on the list is still refused, so the allowlist has been extended rather than opened: `OPTIONS` from `http://localhost:9999` comes back with no `Access-Control-Allow-Origin` header, and the same WS upgrade gets `403 Forbidden`.

From the page itself on `http://localhost:3100`, the app's own requests go to 3101 and the socket connects:

```
OPTIONS http://localhost:3101/version   -> 204
OPTIONS http://localhost:3101/health    -> 204
OPTIONS http://localhost:3101/telemetry -> 204
GET     http://localhost:3101/version   -> 200
GET     http://localhost:3101/health    -> 200 {"status":"ok","database":{"state":"connected","status":"ok"}}
new WebSocket('ws://localhost:3101/ws') -> open
```

The planner rendered normally and the console had no CORS or `Access-Control` message of any kind.

### Default ports

`pnpm dev` with no flag:

```
$ node scripts/dev.mjs all
Web app: http://localhost:3000
API:     http://localhost:3001
web dev:   ➜  Local:   http://localhost:3000/
backend dev: Webserver running at http://localhost:3001/
```

The page on `http://localhost:3000` calls 3001 for `/version`, `/health` and `/telemetry`, all preflights 204, `/health` 200, and the socket opens on `ws://localhost:3001/ws`. The pre-existing `GET http://localhost:3001/gameData.json -> 404` from the dev-only parser probe still happens and still falls back, unchanged.

### strictPort

With one `pnpm dev:web` already holding 3000, a second one stops instead of taking 3001:

```
$ pnpm dev:web
error when starting dev server:
Error: Port 3000 is already in use
Exit status 1
```

