### PR TITLE
fix(grafana): fault counts drifted while nothing was happening

### DIFF
--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -380,48 +380,62 @@ add(66, "Stickiness",
          unit="percentunit", minmax=(0, 1)))
 
 # ------------------------------------------------------------------------ faults
-# Counters, so every panel here is a rate or an increase rather than a level. Two metrics
-# on purpose: sf_events_total is per cause, sf_http_errors_total is per response, and one
-# incident can legitimately appear in both. Never add them together.
+# Counters, so every panel here is an increase over a window rather than a level. Two
+# metrics on purpose: sf_events_total is per cause, sf_http_errors_total is per response,
+# and one incident can legitimately appear in both. Never add them together.
+#
+# Every count is wrapped in round(), and that is not cosmetic. increase() extrapolates to
+# the range boundaries, so a counter that jumped once and went flat reports a drifting
+# non-integer: measured live at 4.05, 4.11, 4.05 over ninety seconds while the underlying
+# value never left 4. On a stat panel that reads as continuous activity when nothing at all
+# is happening, which is exactly how this was first reported as a bug.
+#
+# round(increase(...)) rather than the offset trick used for edits: these counters reset on
+# every deploy, increase() handles a reset natively, and an offset or min_over_time would
+# measure from the post-restart low and undercount. Edits come from the database and never
+# reset, so they can afford the other form.
+#
+# Round the outermost aggregate, then filter with `> 0`, so an extrapolated fraction drops
+# out instead of appearing as a phantom series.
 add(90, "Faults, Last 24h",
     "Every counted fault in the last day, client and server together. Indicative rather than authoritative: the client half arrives over an unauthenticated endpoint.",
-    [query("sum(increase(sf_events_total%s[24h]))" % J, "Faults")],
+    [query("round(sum(increase(sf_events_total%s[24h])))" % J, "Faults")],
     stat([{"value": 0, "color": "green"}, {"value": 1, "color": "#EAB839"}, {"value": 50, "color": "red"}],
          graph="area"))
 
 add(91, "Server Errors, Last 24h",
     "HTTP 5xx responses. The line that matters most, because a 500 means the server itself failed rather than refusing something.",
-    [query('sum(increase(sf_http_errors_total%s[24h]))' % sel('status=~"5.."'), "5xx")],
+    [query('round(sum(increase(sf_http_errors_total%s[24h])))' % sel('status=~"5.."'), "5xx")],
     stat([{"value": 0, "color": "green"}, {"value": 1, "color": "red"}], graph="area"))
 
 add(92, "Plan Repairs, Last 24h",
     "Loaded plans that had to be corrected before they could be used. Each one is a plan that was saved wrong at some point.",
-    [query('sum(increase(sf_events_total%s[24h]))' % sel('reason=~"plan_repair_.*"'), "Repairs")],
+    [query('round(sum(increase(sf_events_total%s[24h])))' % sel('reason=~"plan_repair_.*"'), "Repairs")],
     stat([{"value": 0, "color": "green"}, {"value": 1, "color": "#EAB839"}], graph="area"))
 
 add(93, "Faults by Reason, Last 24h",
     "Every reason with at least one occurrence in the last day, largest first. A reason at zero is absent from this panel by design; that is the good news.",
-    [query("sort_desc(sum by (reason) (increase(sf_events_total%s[24h])) > 0)" % J, "{{reason}}", instant=True)],
+    [query("sort_desc(round(sum by (reason) (increase(sf_events_total%s[24h]))) > 0)" % J, "{{reason}}", instant=True)],
     bargauge(display_name="${__field.labels.reason}"))
 
 add(94, "Faults Over Time",
-    "Per-minute fault rate by reason. A flat line at zero is what this should normally look like.",
-    [query("sum by (reason) (rate(sf_events_total%s[5m]) * 60) > 0" % J, "{{reason}}")],
+    "A rolling one-hour count per reason. An hour rather than a five-minute rate because faults are rare: at five minutes a single one is a pixel-wide blip on a day-long axis and you would never see it.",
+    [query("round(sum by (reason) (increase(sf_events_total%s[1h]))) > 0" % J, "{{reason}}")],
     timeseries(fill=15))
 
 add(95, "Client and Server",
     "Which half of the app is reporting. A spike on one side only usually says where to look first.",
-    [query("sum by (source) (increase(sf_events_total%s[24h]))" % J, "{{source}}")],
+    [query("round(sum by (source) (increase(sf_events_total%s[24h])))" % J, "{{source}}")],
     timeseries(fill=25, stack="normal"))
 
 add(96, "HTTP Errors by Status",
     "Per-response view. 4xx is dominated by ordinary refusals and is mostly noise; 5xx is not.",
-    [query("sum by (status) (increase(sf_http_errors_total%s[24h])) > 0" % J, "{{status}}")],
+    [query("round(sum by (status) (increase(sf_http_errors_total%s[24h]))) > 0" % J, "{{status}}")],
     timeseries(fill=15))
 
 add(97, "Records Lost After a Commit",
     "Times somebody's change was saved and the record of it was not. Each one is a silent gap in the activity log or the account stamps.",
-    [query('sum(increase(sf_events_total%s[24h]))' % sel('reason=~"post_commit_.*"'), "Lost"),],
+    [query('round(sum(increase(sf_events_total%s[24h])))' % sel('reason=~"post_commit_.*"'), "Lost"),],
     stat([{"value": 0, "color": "green"}, {"value": 1, "color": "#EAB839"}, {"value": 10, "color": "red"}]))
 
 # ------------------------------------------------------------------- growth

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -3182,7 +3182,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(sf_events_total{job=\"satisfactory-factories-preview\"}[24h]))",
+                        "expr": "round(sum(increase(sf_events_total{job=\"satisfactory-factories-preview\"}[24h])))",
                         "legendFormat": "Faults",
                         "range": true
                       }
@@ -3271,7 +3271,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(sf_http_errors_total{job=\"satisfactory-factories-preview\",status=~\"5..\"}[24h]))",
+                        "expr": "round(sum(increase(sf_http_errors_total{job=\"satisfactory-factories-preview\",status=~\"5..\"}[24h])))",
                         "legendFormat": "5xx",
                         "range": true
                       }
@@ -3356,7 +3356,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(sf_events_total{job=\"satisfactory-factories-preview\",reason=~\"plan_repair_.*\"}[24h]))",
+                        "expr": "round(sum(increase(sf_events_total{job=\"satisfactory-factories-preview\",reason=~\"plan_repair_.*\"}[24h])))",
                         "legendFormat": "Repairs",
                         "range": true
                       }
@@ -3441,7 +3441,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sort_desc(sum by (reason) (increase(sf_events_total{job=\"satisfactory-factories-preview\"}[24h])) > 0)",
+                        "expr": "sort_desc(round(sum by (reason) (increase(sf_events_total{job=\"satisfactory-factories-preview\"}[24h]))) > 0)",
                         "legendFormat": "{{reason}}",
                         "instant": true,
                         "range": false
@@ -3513,7 +3513,7 @@
         "spec": {
           "id": 94,
           "title": "Faults Over Time",
-          "description": "Per-minute fault rate by reason. A flat line at zero is what this should normally look like.",
+          "description": "A rolling one-hour count per reason. An hour rather than a five-minute rate because faults are rare: at five minutes a single one is a pixel-wide blip on a day-long axis and you would never see it.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -3531,7 +3531,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (reason) (rate(sf_events_total{job=\"satisfactory-factories-preview\"}[5m]) * 60) > 0",
+                        "expr": "round(sum by (reason) (increase(sf_events_total{job=\"satisfactory-factories-preview\"}[1h]))) > 0",
                         "legendFormat": "{{reason}}",
                         "range": true
                       }
@@ -3646,7 +3646,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (source) (increase(sf_events_total{job=\"satisfactory-factories-preview\"}[24h]))",
+                        "expr": "round(sum by (source) (increase(sf_events_total{job=\"satisfactory-factories-preview\"}[24h])))",
                         "legendFormat": "{{source}}",
                         "range": true
                       }
@@ -3761,7 +3761,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (status) (increase(sf_http_errors_total{job=\"satisfactory-factories-preview\"}[24h])) > 0",
+                        "expr": "round(sum by (status) (increase(sf_http_errors_total{job=\"satisfactory-factories-preview\"}[24h]))) > 0",
                         "legendFormat": "{{status}}",
                         "range": true
                       }
@@ -3876,7 +3876,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(sf_events_total{job=\"satisfactory-factories-preview\",reason=~\"post_commit_.*\"}[24h]))",
+                        "expr": "round(sum(increase(sf_events_total{job=\"satisfactory-factories-preview\",reason=~\"post_commit_.*\"}[24h])))",
                         "legendFormat": "Lost",
                         "range": true
                       }

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -3182,7 +3182,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(sf_events_total{job=\"satisfactory-factories\"}[24h]))",
+                        "expr": "round(sum(increase(sf_events_total{job=\"satisfactory-factories\"}[24h])))",
                         "legendFormat": "Faults",
                         "range": true
                       }
@@ -3271,7 +3271,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(sf_http_errors_total{job=\"satisfactory-factories\",status=~\"5..\"}[24h]))",
+                        "expr": "round(sum(increase(sf_http_errors_total{job=\"satisfactory-factories\",status=~\"5..\"}[24h])))",
                         "legendFormat": "5xx",
                         "range": true
                       }
@@ -3356,7 +3356,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(sf_events_total{job=\"satisfactory-factories\",reason=~\"plan_repair_.*\"}[24h]))",
+                        "expr": "round(sum(increase(sf_events_total{job=\"satisfactory-factories\",reason=~\"plan_repair_.*\"}[24h])))",
                         "legendFormat": "Repairs",
                         "range": true
                       }
@@ -3441,7 +3441,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sort_desc(sum by (reason) (increase(sf_events_total{job=\"satisfactory-factories\"}[24h])) > 0)",
+                        "expr": "sort_desc(round(sum by (reason) (increase(sf_events_total{job=\"satisfactory-factories\"}[24h]))) > 0)",
                         "legendFormat": "{{reason}}",
                         "instant": true,
                         "range": false
@@ -3513,7 +3513,7 @@
         "spec": {
           "id": 94,
           "title": "Faults Over Time",
-          "description": "Per-minute fault rate by reason. A flat line at zero is what this should normally look like.",
+          "description": "A rolling one-hour count per reason. An hour rather than a five-minute rate because faults are rare: at five minutes a single one is a pixel-wide blip on a day-long axis and you would never see it.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -3531,7 +3531,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (reason) (rate(sf_events_total{job=\"satisfactory-factories\"}[5m]) * 60) > 0",
+                        "expr": "round(sum by (reason) (increase(sf_events_total{job=\"satisfactory-factories\"}[1h]))) > 0",
                         "legendFormat": "{{reason}}",
                         "range": true
                       }
@@ -3646,7 +3646,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (source) (increase(sf_events_total{job=\"satisfactory-factories\"}[24h]))",
+                        "expr": "round(sum by (source) (increase(sf_events_total{job=\"satisfactory-factories\"}[24h])))",
                         "legendFormat": "{{source}}",
                         "range": true
                       }
@@ -3761,7 +3761,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (status) (increase(sf_http_errors_total{job=\"satisfactory-factories\"}[24h])) > 0",
+                        "expr": "round(sum by (status) (increase(sf_http_errors_total{job=\"satisfactory-factories\"}[24h]))) > 0",
                         "legendFormat": "{{status}}",
                         "range": true
                       }
@@ -3876,7 +3876,7 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(sf_events_total{job=\"satisfactory-factories\",reason=~\"post_commit_.*\"}[24h]))",
+                        "expr": "round(sum(increase(sf_events_total{job=\"satisfactory-factories\",reason=~\"post_commit_.*\"}[24h])))",
                         "legendFormat": "Lost",
                         "range": true
                       }


### PR DESCRIPTION
**No manual steps.** Dashboard JSON only, no backend change. I'll re-apply both dashboards to Grafana once this merges.

## The bug

The faults panel looked like it was counting something every minute. It wasn't. The counter was sitting at exactly **4** and never moved.

`increase()` extrapolates to the range boundaries, so a counter that jumped once and went flat reports a *drifting non-integer*. Measured live, 20 seconds apart:

```
truth: 4

BEFORE                 AFTER
4.012813675213676      4
4.047006837606837      4
4.081198290598291      4
4.012506666666667      4
4.045843333333333      4
```

On a stat panel that reads as continuous activity when nothing at all is happening.

## The fix

`round()` on the outermost aggregate, then the `> 0` filter, so an extrapolated fraction drops out instead of becoming a phantom series. **All eight** fault panels had this, not the three first spotted.

`round(increase(...))` rather than the offset difference used for the edits panel, and the difference matters: these counters **reset on every deploy**, `increase()` handles a reset natively, and an offset or `min_over_time` would measure from the post-restart low and undercount. Edits come from the database and never reset, so they can afford the other form.

## Also: Faults Over Time was accurate and useless

It used `rate(...[5m]) * 60`. Correct, but it meant a single fault appeared as a **five-minute blip on a 24-hour axis**, about a pixel wide. Now a rolling one-hour count, so a one-off stays visible for an hour.

## Worth saying plainly

The 4 faults currently showing are **mine**, from the smoke test when #634 deployed. No real user has reported anything. They clear on the next preview redeploy, since the counters are in-process.

## Verification

All 73 dashboard expressions re-validated against live Prometheus: **0 syntax errors**. No unrounded `increase(` or `rate(` left in any fault panel. Drift confirmed gone by sampling five times over 100 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)