### PR TITLE
feat: share link metrics, created and opened

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -68,7 +68,7 @@ Every route except `GET /health` and `GET /share/:id` requires an `X-App-Version
 | `GET /share/:id` | Reads a snapshot link and bumps its view counter |
 | `POST /save`, `GET /load` | **410 Gone.** Replaced by synced tabs |
 | `GET /health` | The one to monitor. Pings Mongo and returns **503** if it doesn't answer inside 3s. Rate limited to 10 requests a minute, in its own bucket |
-| `GET /metrics` | Prometheus scrape target. Needs `Authorization: Bearer $METRICS_TOKEN`; **404 when `METRICS_TOKEN` is unset**, so a box that never got the variable exposes nothing. 30 a minute, own bucket. Carries usernames and plan ids in the top-20 gauges, so the token is what keeps it private |
+| `GET /metrics` | Prometheus scrape target. Needs `Authorization: Bearer $METRICS_TOKEN`; **404 when `METRICS_TOKEN` is unset**, so a box that never got the variable exposes nothing. 30 a minute, own bucket. Carries usernames, plan ids and share link ids in the top-20 gauges, so the token is what keeps it private |
 | `POST /events` | Anonymous fault counts, batched. The reason is a closed enum in `common`, so nothing a caller sends can become a new metric label. 120 a minute per address in its own bucket, plus a 30s floor per instance |
 | `POST /telemetry` | The anonymous client heartbeat, unauthenticated by design. 60 a minute per address in its own bucket, plus a 30s floor per instance. See [docs/telemetry.md](../docs/telemetry.md) for exactly what it collects |
 

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -7,6 +7,7 @@ import { MetricsController } from './metrics.controller'
 import { MetricsService } from './metrics.service'
 import { MetricsTokenGuard } from './metrics-token.guard'
 import { RealtimeModule } from '../realtime/realtime.module'
+import { Share, ShareSchema } from '../legacy/share.schema'
 import { RoomsModule } from '../rooms/rooms.module'
 import { TelemetryController } from './telemetry.controller'
 import { TelemetryInstance, TelemetryInstanceSchema } from './telemetry-instance.schema'
@@ -28,8 +29,11 @@ import { UserActivityService } from '../user-activity/user-activity.service'
     AuthModule,
     RealtimeModule,
     UserActivityModule,
+    // The share schema is registered here rather than importing LegacyModule: this module
+    // reads other people's collections and must not depend on the modules that own them.
     MongooseModule.forFeature([
       { name: TelemetryInstance.name, schema: TelemetryInstanceSchema },
+      { name: Share.name, schema: ShareSchema },
     ]),
   ],
   controllers: [MetricsController, TelemetryController, EventsController],

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -17,6 +17,7 @@ import { ConnectionRegistry } from '../realtime/connection-registry'
 import { EventCountersService } from '../event-counters/event-counters.service'
 import { Room } from '../rooms/schemas/room.schema'
 import { RoomMembership } from '../rooms/schemas/room-membership.schema'
+import { Share } from '../legacy/share.schema'
 import { TelemetryService } from './telemetry.service'
 import type { TelemetrySnapshot } from './telemetry.service'
 import { User } from '../auth/user.schema'
@@ -30,10 +31,13 @@ interface CheapCounts {
   roomMembers: number
   users: number
   signIns: number
+  shares: number
+  shareOpens: number
 }
 
 interface OwnedTotal { name: string, value: number }
 interface RoomTotal { roomId: string, owner: string, factories: number }
+interface ShareTotal { shareId: string, opens: number }
 
 /** The slow numbers: five window counts and three top-N aggregations. */
 interface SlowStats {
@@ -43,6 +47,8 @@ interface SlowStats {
   topRooms: RoomTotal[]
   topEditors: OwnedTotal[]
   topOwners: OwnedTotal[]
+  newShares: Array<readonly [string, number]>
+  topShares: ShareTotal[]
 }
 
 /**
@@ -83,6 +89,11 @@ export class MetricsService {
   private readonly userEdits: Gauge<'username'>
   private readonly userFactories: Gauge<'username'>
 
+  private readonly sharesTotal: Gauge<string>
+  private readonly shareOpensTotal: Gauge<string>
+  private readonly newShares: Gauge<'window'>
+  private readonly shareOpens: Gauge<'share_id'>
+
   private readonly census: CachedQuery<TelemetrySnapshot>
   private readonly cheap: CachedQuery<CheapCounts>
   private readonly slow: CachedQuery<SlowStats>
@@ -91,6 +102,7 @@ export class MetricsService {
     @InjectModel(Room.name) private readonly rooms: Model<Room>,
     @InjectModel(RoomMembership.name) private readonly memberships: Model<RoomMembership>,
     @InjectModel(User.name) private readonly users: Model<User>,
+    @InjectModel(Share.name) private readonly shares: Model<Share>,
     private readonly connections: ConnectionRegistry,
     private readonly telemetry: TelemetryService,
     private readonly counters: EventCountersService,
@@ -207,6 +219,29 @@ export class MetricsService {
       registers,
     })
 
+    this.sharesTotal = new Gauge({
+      name: 'sf_shares_total',
+      help: 'Snapshot share links that exist. Complete back to the feature shipping, since nothing purges the collection, and it falls only if a row is removed by hand.',
+      registers,
+    })
+    this.shareOpensTotal = new Gauge({
+      name: 'sf_share_opens_total',
+      help: 'Snapshot link opens, summed across links. Counted when the link is fetched, which is the same moment the planner adds the tab.',
+      registers,
+    })
+    this.newShares = new Gauge({
+      name: 'sf_new_shares',
+      help: 'Snapshot links created inside each rolling window. Retroactive: the creation date has always been stored.',
+      labelNames: ['window'],
+      registers,
+    })
+    this.shareOpens = new Gauge({
+      name: 'sf_share_opens',
+      help: `The ${METRICS_TOP_N} most-opened snapshot links.`,
+      labelNames: ['share_id'],
+      registers,
+    })
+
     // The census is a database read now too, so it gets the same last-good-value
     // treatment: a Mongo outage must not blank the client panels either.
     this.census = new CachedQuery(METRICS_CACHE_MS, () => this.telemetry.snapshot())
@@ -252,6 +287,8 @@ export class MetricsService {
       this.roomMembersTotal.set(cheap.value.roomMembers)
       this.usersTotal.set(cheap.value.users)
       this.signInsTotal.set(cheap.value.signIns)
+      this.sharesTotal.set(cheap.value.shares)
+      this.shareOpensTotal.set(cheap.value.shareOpens)
     }
 
     // Only on a real reload. prom-client remembers every label set it has been given, so a
@@ -304,36 +341,52 @@ export class MetricsService {
     for (const owner of stats.topOwners) {
       this.userFactories.set({ username: owner.name }, owner.value)
     }
+
+    for (const [window, shares] of stats.newShares) {
+      this.newShares.set({ window }, shares)
+    }
+
+    this.shareOpens.reset()
+    for (const share of stats.topShares) {
+      this.shareOpens.set({ share_id: share.shareId }, share.opens)
+    }
   }
 
   private async loadCheap (): Promise<CheapCounts> {
-    const [sharedRooms, privateRooms, totals, roomMembers, users, signIns] = await Promise.all([
-      this.rooms.countDocuments({ deletedAt: null, shared: true }),
-      // `$ne: true` rather than `false`, so a document predating the field still counts
-      // once rather than not at all.
-      this.rooms.countDocuments({ deletedAt: null, shared: { $ne: true } }),
-      this.sumRoomTotals(),
-      this.memberships.countDocuments(),
-      this.users.countDocuments(),
-      this.sumSignIns(),
-    ])
+    const [sharedRooms, privateRooms, totals, roomMembers, users, signIns, shares, shareOpens] =
+      await Promise.all([
+        this.rooms.countDocuments({ deletedAt: null, shared: true }),
+        // `$ne: true` rather than `false`, so a document predating the field still counts
+        // once rather than not at all.
+        this.rooms.countDocuments({ deletedAt: null, shared: { $ne: true } }),
+        this.sumRoomTotals(),
+        this.memberships.countDocuments(),
+        this.users.countDocuments(),
+        this.sumSignIns(),
+        this.shares.countDocuments(),
+        this.sumShareOpens(),
+      ])
 
-    return { sharedRooms, privateRooms, ...totals, roomMembers, users, signIns }
+    return { sharedRooms, privateRooms, ...totals, roomMembers, users, signIns, shares, shareOpens }
   }
 
   private async loadSlow (): Promise<SlowStats> {
     const now = this.clock.now()
-    const [activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners] =
+    const [activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners, newShares, topShares] =
       await Promise.all([
-        this.countByWindow(now, 'lastActiveAt'),
-        this.countByWindow(now, 'registered'),
-        this.countByWindow(now, 'lastSignInAt'),
+        this.countByWindow(now, since => this.users.countDocuments({ lastActiveAt: { $gt: since } })),
+        this.countByWindow(now, since => this.users.countDocuments({ registered: { $gt: since } })),
+        this.countByWindow(now, since => this.users.countDocuments({ lastSignInAt: { $gt: since } })),
         this.findLargestRooms(),
         this.findBusiestEditors(),
         this.findLargestOwners(),
+        this.countByWindow(now, since => this.shares.countDocuments({ created: { $gt: since } })),
+        this.findMostOpenedShares(),
       ])
 
-    return { activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners }
+    return {
+      activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners, newShares, topShares,
+    }
   }
 
   /** Factories and accepted edits in one pass, since both are sums over the same documents. */
@@ -360,17 +413,39 @@ export class MetricsService {
   }
 
   /**
-   * One rolling-window count per configured window, over whichever date field is asked for.
+   * Opens across every link. `views` is bumped by `GET /share/:id`, which the planner calls
+   * immediately before adding the tab, so this counts links actually opened into a plan.
+   */
+  private async sumShareOpens (): Promise<number> {
+    const [row] = await this.shares.aggregate<{ total: number }>([
+      { $group: { _id: null, total: { $sum: { $ifNull: ['$views', 0] } } } },
+    ])
+    return row?.total ?? 0
+  }
+
+  /** Tie-broken on the id, so equally popular links do not swap places between scrapes. */
+  private async findMostOpenedShares (): Promise<ShareTotal[]> {
+    const rows = await this.shares
+      .find({ views: { $gt: 0 } }, { id: 1, views: 1 })
+      .sort({ views: -1, id: 1 })
+      .limit(METRICS_TOP_N)
+      .lean()
+
+    return rows.map(row => ({ shareId: row.id, opens: row.views }))
+  }
+
+  /**
+   * One rolling-window count per configured window, for whatever the caller counts.
    * A timestamp rather than a bucket, so every window is exact with no boundary error, and
-   * `registered` needs no new writes at all: accounts have carried it since the beginning.
+   * most of the fields need no new writes at all: accounts have carried `registered` and
+   * shares their creation date since the beginning, so these windows are true retroactively.
    */
   private async countByWindow (
     now: Date,
-    field: 'lastActiveAt' | 'registered' | 'lastSignInAt',
+    count: (since: Date) => Promise<number>,
   ): Promise<Array<readonly [string, number]>> {
     return Promise.all(ACTIVE_ACCOUNT_WINDOWS.map(async ([label, ms]) => {
-      const since = new Date(now.getTime() - ms)
-      const matched = await this.users.countDocuments({ [field]: { $gt: since } })
+      const matched = await count(new Date(now.getTime() - ms))
       return [label, matched] as const
     }))
   }

--- a/backend/test/metrics-usage.spec.ts
+++ b/backend/test/metrics-usage.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/metrics/metrics.constants'
 import { ANONYMOUS_ACTOR, UserActivityService } from '../src/user-activity/user-activity.service'
 import { Room } from '../src/rooms/schemas/room.schema'
+import { Share } from '../src/legacy/share.schema'
 import { RoomActivity } from '../src/rooms/schemas/room-activity.schema'
 import { RoomOpService } from '../src/realtime/room-op.service'
 import { TestContext, awaitConnection, createTestApp, destroyTestApp } from './utils/test-app'
@@ -256,6 +257,128 @@ describe('the database-backed usage metrics', () => {
       const second = labelValues(await scrape(), 'sf_room_factories', 'room_id')
 
       expect(first).toEqual(second)
+    })
+  })
+
+  describe('the share link metrics', () => {
+    const shares = () => context.app.get<Model<Share>>(getModelToken(Share.name))
+
+    let minted = 0
+    const seedShare = async (overrides: Partial<Share> = {}) =>
+      shares().create({
+        id: `link-${minted++}`,
+        data: '[]',
+        createdBy: 'Anonymous',
+        ...overrides,
+      })
+
+    // resetRooms leaves the shares collection alone, since every other suite owns its own.
+    beforeEach(async () => {
+      await shares().deleteMany({})
+    })
+
+    it('counts the links that exist, and the opens summed across them', async () => {
+      await seedShare({ views: 3 })
+      await seedShare({ views: 11 })
+      await seedShare()
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_shares_total')).toBe(3)
+      expect(sample(body, 'sf_share_opens_total')).toBe(14)
+    })
+
+    it('reads a row predating the view counter as zero rather than failing', async () => {
+      await shares().collection.insertOne({ id: 'ancient', data: '[]', createdBy: 'Anonymous' })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_shares_total')).toBe(1)
+      expect(sample(body, 'sf_share_opens_total')).toBe(0)
+    })
+
+    it('reports zero for both when no link has ever been made', async () => {
+      const body = await scrape()
+
+      expect(sample(body, 'sf_shares_total')).toBe(0)
+      expect(sample(body, 'sf_share_opens_total')).toBe(0)
+    })
+
+    // Retroactive, like sf_new_accounts: the creation date has always been stored, so these
+    // windows are correct for every link made before the metric existed.
+    it('counts links created in each rolling window', async () => {
+      const now = clock.now().getTime()
+      await seedShare({ created: new Date(now - 2 * HOUR) })
+      await seedShare({ created: new Date(now - 4 * DAY) })
+      await seedShare({ created: new Date(now - 20 * DAY) })
+      await seedShare({ created: new Date(now - 300 * DAY) })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_new_shares', 'window="24h"')).toBe(1)
+      expect(sample(body, 'sf_new_shares', 'window="7d"')).toBe(2)
+      expect(sample(body, 'sf_new_shares', 'window="30d"')).toBe(3)
+    })
+
+    it('exports every window even with no links at all', async () => {
+      const body = await scrape()
+
+      for (const [label] of ACTIVE_ACCOUNT_WINDOWS) {
+        expect(sample(body, 'sf_new_shares', `window="${label}"`)).toBe(0)
+      }
+    })
+
+    it('names the most-opened links', async () => {
+      await seedShare({ id: 'popular-copper-belt', views: 42 })
+      await seedShare({ id: 'quiet-iron-rod', views: 1 })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_share_opens', 'share_id="popular-copper-belt"')).toBe(42)
+      expect(sample(body, 'sf_share_opens', 'share_id="quiet-iron-rod"')).toBe(1)
+    })
+
+    it('leaves a never-opened link out of the top N rather than listing it at zero', async () => {
+      await seedShare({ id: 'never-opened', views: 0 })
+
+      expect(sample(await scrape(), 'sf_share_opens', 'share_id="never-opened"')).toBeUndefined()
+    })
+
+    it(`exports at most ${METRICS_TOP_N} links however many exist`, async () => {
+      for (let index = 0; index < METRICS_TOP_N + 8; index++) await seedShare({ views: index + 1 })
+
+      expect(labelValues(await scrape(), 'sf_share_opens', 'share_id').length).toBe(METRICS_TOP_N)
+    })
+
+    it('drops a link that has fallen out of the top N', async () => {
+      await seedShare({ id: 'one-open', views: 1 })
+      expect(sample(await scrape(), 'sf_share_opens', 'share_id="one-open"')).toBe(1)
+
+      for (let index = 0; index < METRICS_TOP_N; index++) await seedShare({ views: 50 + index })
+
+      expect(sample(await scrape(), 'sf_share_opens', 'share_id="one-open"')).toBeUndefined()
+    })
+
+    it('breaks ties on the link id, so equal links keep their order between scrapes', async () => {
+      for (let index = 0; index < METRICS_TOP_N + 5; index++) await seedShare({ views: 7 })
+
+      expect(labelValues(await scrape(), 'sf_share_opens', 'share_id'))
+        .toEqual(labelValues(await scrape(), 'sf_share_opens', 'share_id'))
+    })
+
+    /**
+     * The whole chain, since the count is a side effect of a route nothing else asserts
+     * against the metrics: opening the link is what moves the number.
+     */
+    it('rises when a link is actually opened', async () => {
+      await seedShare({ id: 'opened-for-real', views: 0 })
+
+      await call(context.app, 'get', '/share/opened-for-real')
+      await call(context.app, 'get', '/share/opened-for-real')
+
+      const body = await scrape()
+      expect(sample(body, 'sf_share_opens', 'share_id="opened-for-real"')).toBe(2)
+      expect(sample(body, 'sf_share_opens_total')).toBe(2)
     })
   })
 

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -10,7 +10,7 @@ The two dashboards that read `GET /metrics`, and the script that generates them.
 
 ## Why a generator rather than hand-edited JSON
 
-The dashboards are 41 panels each and identical apart from one label matcher. Keeping two
+The dashboards are 63 panels each and identical apart from one label matcher. Keeping two
 hand-written copies in step would not survive contact with a single edit.
 
 More importantly, **production and preview export the same metric names**. An unfiltered query

--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -485,6 +485,42 @@ add(87, "Of Those Who Signed In, How Many Edited",
     stat([{"value": 0, "color": "red"}, {"value": 0.3, "color": "#EAB839"}, {"value": 0.6, "color": "green"}],
          unit="percentunit", minmax=(0, 1)))
 
+# ----------------------------------------------------------------- share links
+# Snapshot links, the "copy a link to this plan" feature. Every number here comes from the
+# shares collection, which nothing purges, so all of it is complete back to the feature
+# shipping rather than starting at whenever these panels did.
+add(100, "Share Links Created",
+    "Snapshot links that exist, all time. Counted from the rows themselves, so it is exact and complete, and falls only if a row is deleted by hand.",
+    [query("sum(sf_shares_total%s)" % J, "Links")],
+    stat(BLUE, graph="area", color_mode="background_solid"))
+
+add(101, "Share Links Opened",
+    "Opens summed across every link. Counted when the link is fetched, which is the same moment the planner adds the plan as a tab.",
+    [query("sum(sf_share_opens_total%s)" % J, "Opens")],
+    stat(GREEN, graph="area", color_mode="background_solid"))
+
+add(102, "Opens per Link",
+    "Average opens per link. Around 1 means links are made and read once; well above means they are being passed around.",
+    [query("sum(sf_share_opens_total%s) / sum(sf_shares_total%s)" % (J, J), "Opens")],
+    stat([{"value": 0, "color": "#6a6a6a"}, {"value": 1, "color": "green"}], decimals=1))
+
+add(103, "New Share Links",
+    "Links created inside each rolling window. Read from the creation date the rows have always carried, so it is correct all the way back, not just since this metric shipped.",
+    [query('sum(sf_new_shares%s)' % sel('window="24h"'), "24 hours", "A"),
+     query('sum(sf_new_shares%s)' % sel('window="7d"'), "7 days", "B"),
+     query('sum(sf_new_shares%s)' % sel('window="30d"'), "30 days", "C")],
+    stat(GREEN, color_mode="value", text_mode="value_and_name"))
+
+add(104, "Share Links Created Over Time",
+    "Each rolling window plotted. A step up in the 24h line is somebody making a link.",
+    [query("sum by (window) (sf_new_shares%s)" % J, "{{window}}")],
+    timeseries(fill=8))
+
+add(105, "Most Opened Share Links",
+    "The links people actually pass around. Top 20 only, and a link that has never been opened is left out rather than shown at zero.",
+    [query("sort_desc(sf_share_opens%s)" % J, "{{share_id}}", instant=True)],
+    bargauge(display_name="${__field.labels.share_id}"))
+
 # ------------------------------------------------------------- biggest and busiest
 add(70, "Biggest Plans",
     "The largest synced plans by factory count, with the account that owns each. Top 20 only.",
@@ -579,6 +615,11 @@ rows = [
         item(14, 0, 10, 4, 80),
         item(0, 4, 12, 8, 83), item(12, 4, 12, 8, 86),
         item(0, 12, 5, 4, 85), item(5, 12, 19, 4, 84),
+    ]),
+    row("🔗 Share Links · from the database", [
+        item(0, 0, 5, 4, 100), item(5, 0, 5, 4, 101), item(10, 0, 4, 4, 102),
+        item(14, 0, 10, 4, 103),
+        item(0, 4, 12, 8, 104), item(12, 4, 12, 8, 105),
     ]),
     row("🏆 Biggest and Busiest · from the database", [
         item(0, 0, 4, 4, 73),

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -4760,6 +4760,582 @@
           }
         }
       },
+      "panel-100": {
+        "kind": "Panel",
+        "spec": {
+          "id": 100,
+          "title": "Share Links Created",
+          "description": "Snapshot links that exist, all time. Counted from the rows themselves, so it is exact and complete, and falls only if a row is deleted by hand.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_shares_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Links",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-101": {
+        "kind": "Panel",
+        "spec": {
+          "id": 101,
+          "title": "Share Links Opened",
+          "description": "Opens summed across every link. Counted when the link is fetched, which is the same moment the planner adds the plan as a tab.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_share_opens_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Opens",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-102": {
+        "kind": "Panel",
+        "spec": {
+          "id": 102,
+          "title": "Opens per Link",
+          "description": "Average opens per link. Around 1 means links are made and read once; well above means they are being passed around.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_share_opens_total{job=\"satisfactory-factories-preview\"}) / sum(sf_shares_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Opens",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-103": {
+        "kind": "Panel",
+        "spec": {
+          "id": 103,
+          "title": "New Share Links",
+          "description": "Links created inside each rolling window. Read from the creation date the rows have always carried, so it is correct all the way back, not just since this metric shipped.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories-preview\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-104": {
+        "kind": "Panel",
+        "spec": {
+          "id": 104,
+          "title": "Share Links Created Over Time",
+          "description": "Each rolling window plotted. A step up in the 24h line is somebody making a link.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (window) (sf_new_shares{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{window}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-105": {
+        "kind": "Panel",
+        "spec": {
+          "id": 105,
+          "title": "Most Opened Share Links",
+          "description": "The links people actually pass around. Top 20 only, and a link that has never been opened is left out rather than shown at zero.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sf_share_opens{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{share_id}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.share_id}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
       "panel-70": {
         "kind": "Panel",
         "spec": {
@@ -6112,6 +6688,98 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-84"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🔗 Share Links · from the database",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-100"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 5,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-101"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 10,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-102"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 14,
+                        "y": 0,
+                        "width": 10,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-103"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-104"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-105"
                         }
                       }
                     }

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -4760,6 +4760,582 @@
           }
         }
       },
+      "panel-100": {
+        "kind": "Panel",
+        "spec": {
+          "id": 100,
+          "title": "Share Links Created",
+          "description": "Snapshot links that exist, all time. Counted from the rows themselves, so it is exact and complete, and falls only if a row is deleted by hand.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_shares_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Links",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-101": {
+        "kind": "Panel",
+        "spec": {
+          "id": 101,
+          "title": "Share Links Opened",
+          "description": "Opens summed across every link. Counted when the link is fetched, which is the same moment the planner adds the plan as a tab.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_share_opens_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Opens",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-102": {
+        "kind": "Panel",
+        "spec": {
+          "id": 102,
+          "title": "Opens per Link",
+          "description": "Average opens per link. Around 1 means links are made and read once; well above means they are being passed around.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_share_opens_total{job=\"satisfactory-factories\"}) / sum(sf_shares_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Opens",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-103": {
+        "kind": "Panel",
+        "spec": {
+          "id": 103,
+          "title": "New Share Links",
+          "description": "Links created inside each rolling window. Read from the creation date the rows have always carried, so it is correct all the way back, not just since this metric shipped.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-104": {
+        "kind": "Panel",
+        "spec": {
+          "id": 104,
+          "title": "Share Links Created Over Time",
+          "description": "Each rolling window plotted. A step up in the 24h line is somebody making a link.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (window) (sf_new_shares{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{window}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-105": {
+        "kind": "Panel",
+        "spec": {
+          "id": 105,
+          "title": "Most Opened Share Links",
+          "description": "The links people actually pass around. Top 20 only, and a link that has never been opened is left out rather than shown at zero.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sf_share_opens{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{share_id}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "displayName": "${__field.labels.share_id}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
       "panel-70": {
         "kind": "Panel",
         "spec": {
@@ -6112,6 +6688,98 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-84"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🔗 Share Links · from the database",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-100"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 5,
+                        "y": 0,
+                        "width": 5,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-101"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 10,
+                        "y": 0,
+                        "width": 4,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-102"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 14,
+                        "y": 0,
+                        "width": 10,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-103"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-104"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 4,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-105"
                         }
                       }
                     }


### PR DESCRIPTION
## Manual steps

No manual steps or intervention required.

## What this adds

Four gauges over the `shares` collection, and a **🔗 Share Links** row on both dashboards.

| Metric | What it is |
| --- | --- |
| `sf_shares_total` | Snapshot links that exist, all time |
| `sf_share_opens_total` | Opens summed across every link |
| `sf_new_shares{window}` | Links created in each rolling window, same windows as accounts |
| `sf_share_opens{share_id}` | The 20 most-opened links |

Six panels: the two totals, opens-per-link, the rolling windows as a stat and as a graph, and a top-20 bar gauge.

## No new writes

Everything here reads fields the documents already carried. `Share.created` and `Share.views` have been on the schema from the beginning, and `GET /share/:id` has always bumped the view count in one atomic `findOneAndUpdate`.

The practical effect is that all four numbers are **exact and complete back to when share links shipped**, rather than starting at zero on deploy. That is the same property `sf_new_accounts` has, for the same reason.

## Where the open is counted

The count moves when the link is fetched, not when the tab lands in the planner. Those are the same moment in practice: `web/src/pages/share/[id].vue` fetches and calls `appStore.addTab()` back to back inside one function, with no user step between them. The pair only diverges when the payload comes back unusable, in which case no tab appears but the fetch was still counted. Moving the count would need a second endpoint and a second write to close a gap that only opens on a corrupt row.

## Cardinality

`sf_share_opens` is capped at the top 20, like the room and account gauges, and a link that has never been opened is left out rather than exported at zero. Share ids are three-word slugs. The same caveat as the other top-20 gauges applies: the cap bounds what leaves the database per scrape, not the series Prometheus keeps over the retention period.

Share ids now appear in `/metrics` alongside usernames and plan ids, so the `METRICS_TOKEN` note in the backend README has been updated to say so.

## Wiring

`MetricsModule` registers the share schema itself rather than importing `LegacyModule`, keeping this module dependent on none of the modules whose collections it reads.

## Validation

- `pnpm exec vitest run` in `backend/` — 453 passed, 30 files
- 13 new cases: the totals, a pre-`views` row reading zero, empty-collection zeros, the rolling windows, top-N capping, drop-out, tie-break stability, and one end-to-end case that opens a link through `GET /share/:id` twice and asserts the gauge moved
- `pnpm exec tsc --noEmit` and `pnpm lint` clean
- Both dashboards regenerated and checked: 63 panels, 10 rows, every laid-out panel resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)
