### PR TITLE
feat: collaboration metrics, rooms made and invites accepted

### DIFF
--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -8,6 +8,7 @@ import { MetricsService } from './metrics.service'
 import { MetricsTokenGuard } from './metrics-token.guard'
 import { RealtimeModule } from '../realtime/realtime.module'
 import { Share, ShareSchema } from '../legacy/share.schema'
+import { RoomTotalsModule } from '../room-totals/room-totals.module'
 import { RoomsModule } from '../rooms/rooms.module'
 import { TelemetryController } from './telemetry.controller'
 import { TelemetryInstance, TelemetryInstanceSchema } from './telemetry-instance.schema'
@@ -29,6 +30,7 @@ import { UserActivityService } from '../user-activity/user-activity.service'
     AuthModule,
     RealtimeModule,
     UserActivityModule,
+    RoomTotalsModule,
     // The share schema is registered here rather than importing LegacyModule: this module
     // reads other people's collections and must not depend on the modules that own them.
     MongooseModule.forFeature([

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -17,6 +17,7 @@ import { ConnectionRegistry } from '../realtime/connection-registry'
 import { EventCountersService } from '../event-counters/event-counters.service'
 import { Room } from '../rooms/schemas/room.schema'
 import { RoomMembership } from '../rooms/schemas/room-membership.schema'
+import { RoomTotalsService } from '../room-totals/room-totals.service'
 import { Share } from '../legacy/share.schema'
 import { TelemetryService } from './telemetry.service'
 import type { TelemetrySnapshot } from './telemetry.service'
@@ -33,6 +34,7 @@ interface CheapCounts {
   signIns: number
   shares: number
   shareOpens: number
+  roomActions: Map<string, number>
 }
 
 interface OwnedTotal { name: string, value: number }
@@ -49,6 +51,8 @@ interface SlowStats {
   topOwners: OwnedTotal[]
   newShares: Array<readonly [string, number]>
   topShares: ShareTotal[]
+  newRooms: Array<readonly [string, number]>
+  newMemberships: Array<readonly [string, number]>
 }
 
 /**
@@ -94,6 +98,10 @@ export class MetricsService {
   private readonly newShares: Gauge<'window'>
   private readonly shareOpens: Gauge<'share_id'>
 
+  private readonly roomActions: Gauge<'action'>
+  private readonly newRooms: Gauge<'window'>
+  private readonly newMemberships: Gauge<'window'>
+
   private readonly census: CachedQuery<TelemetrySnapshot>
   private readonly cheap: CachedQuery<CheapCounts>
   private readonly slow: CachedQuery<SlowStats>
@@ -105,6 +113,7 @@ export class MetricsService {
     @InjectModel(Share.name) private readonly shares: Model<Share>,
     private readonly connections: ConnectionRegistry,
     private readonly telemetry: TelemetryService,
+    private readonly roomTotals: RoomTotalsService,
     private readonly counters: EventCountersService,
     @Inject(CLOCK) private readonly clock: Clock,
   ) {
@@ -242,6 +251,25 @@ export class MetricsService {
       registers,
     })
 
+    this.roomActions = new Gauge({
+      name: 'sf_room_actions_total',
+      help: 'Room lifecycle events that have ever happened, by kind: rooms created, rooms shared, invites accepted, and the rest. Only ever rises, and survives the room being deleted. Counts from this metric shipping rather than being backfilled, because the activity log it would have been read from is trimmed and purged. Excludes `op`, which sf_room_revisions already sums.',
+      labelNames: ['action'],
+      registers,
+    })
+    this.newRooms = new Gauge({
+      name: 'sf_new_rooms',
+      help: 'Rooms created inside each rolling window, counted from the room documents. Retroactive, so it is answerable immediately, but it sees only rooms that still exist: a room deleted inside the window is not in it.',
+      labelNames: ['window'],
+      registers,
+    })
+    this.newMemberships = new Gauge({
+      name: 'sf_new_memberships',
+      help: 'Invites accepted inside each rolling window, counted from the membership rows. Retroactive like sf_new_rooms, and with the same caveat: someone who joined and then left, or was dropped by an unshare, is not in it.',
+      labelNames: ['window'],
+      registers,
+    })
+
     // The census is a database read now too, so it gets the same last-good-value
     // treatment: a Mongo outage must not blank the client panels either.
     this.census = new CachedQuery(METRICS_CACHE_MS, () => this.telemetry.snapshot())
@@ -289,6 +317,12 @@ export class MetricsService {
       this.signInsTotal.set(cheap.value.signIns)
       this.sharesTotal.set(cheap.value.shares)
       this.shareOpensTotal.set(cheap.value.shareOpens)
+
+      // Not reset first: the tally only ever grows and a kind never leaves it, so there is
+      // no stale label set to clear the way the top-N gauges have.
+      for (const [action, count] of cheap.value.roomActions) {
+        this.roomActions.set({ action }, count)
+      }
     }
 
     // Only on a real reload. prom-client remembers every label set it has been given, so a
@@ -350,10 +384,17 @@ export class MetricsService {
     for (const share of stats.topShares) {
       this.shareOpens.set({ share_id: share.shareId }, share.opens)
     }
+
+    for (const [window, rooms] of stats.newRooms) {
+      this.newRooms.set({ window }, rooms)
+    }
+    for (const [window, memberships] of stats.newMemberships) {
+      this.newMemberships.set({ window }, memberships)
+    }
   }
 
   private async loadCheap (): Promise<CheapCounts> {
-    const [sharedRooms, privateRooms, totals, roomMembers, users, signIns, shares, shareOpens] =
+    const [sharedRooms, privateRooms, totals, roomMembers, users, signIns, shares, shareOpens, roomActions] =
       await Promise.all([
         this.rooms.countDocuments({ deletedAt: null, shared: true }),
         // `$ne: true` rather than `false`, so a document predating the field still counts
@@ -365,14 +406,20 @@ export class MetricsService {
         this.sumSignIns(),
         this.shares.countDocuments(),
         this.sumShareOpens(),
+        this.roomTotals.all(),
       ])
 
-    return { sharedRooms, privateRooms, ...totals, roomMembers, users, signIns, shares, shareOpens }
+    return {
+      sharedRooms, privateRooms, ...totals, roomMembers, users, signIns, shares, shareOpens, roomActions,
+    }
   }
 
   private async loadSlow (): Promise<SlowStats> {
     const now = this.clock.now()
-    const [activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners, newShares, topShares] =
+    const [
+      activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners, newShares, topShares,
+      newRooms, newMemberships,
+    ] =
       await Promise.all([
         this.countByWindow(now, since => this.users.countDocuments({ lastActiveAt: { $gt: since } })),
         this.countByWindow(now, since => this.users.countDocuments({ registered: { $gt: since } })),
@@ -382,10 +429,16 @@ export class MetricsService {
         this.findLargestOwners(),
         this.countByWindow(now, since => this.shares.countDocuments({ created: { $gt: since } })),
         this.findMostOpenedShares(),
+        this.countByWindow(now, since => this.rooms.countDocuments({ createdAt: { $gt: since } })),
+        // Owners are excluded: the owner's row is written by the create, so counting it
+        // would report every new room as an invite somebody accepted.
+        this.countByWindow(now, since =>
+          this.memberships.countDocuments({ role: 'member', joinedAt: { $gt: since } })),
       ])
 
     return {
       activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners, newShares, topShares,
+      newRooms, newMemberships,
     }
   }
 

--- a/backend/src/room-totals/room-total.schema.ts
+++ b/backend/src/room-totals/room-total.schema.ts
@@ -1,0 +1,23 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
+import type { HydratedDocument } from 'mongoose'
+
+/**
+ * One row per room activity kind, holding how many have ever happened.
+ *
+ * This exists because `room_activity` cannot answer that question, despite recording every
+ * one of these events. The sweeper trims it to 200 rows per room and deletes a room's rows
+ * outright when the room is purged, so counting rows there undercounts, and does so more
+ * the longer the service runs. A tally that is only ever incremented has neither problem.
+ */
+@Schema({ collection: 'room_totals' })
+export class RoomTotal {
+  /** A `RoomActivityKind`. Not typed as the enum: an old row must survive a kind being renamed. */
+  @Prop({ type: String, required: true, unique: true })
+  kind!: string
+
+  @Prop({ type: Number, default: 0 })
+  value!: number
+}
+
+export type RoomTotalDocument = HydratedDocument<RoomTotal>
+export const RoomTotalSchema = SchemaFactory.createForClass(RoomTotal)

--- a/backend/src/room-totals/room-totals.module.ts
+++ b/backend/src/room-totals/room-totals.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common'
+import { MongooseModule } from '@nestjs/mongoose'
+
+import { RoomTotal, RoomTotalSchema } from './room-total.schema'
+import { RoomTotalsService } from './room-totals.service'
+
+/**
+ * Written by RoomsModule and read by MetricsModule, so it belongs to neither. Registers its
+ * own model; `forFeature` is idempotent, so declaring a schema twice is fine.
+ */
+@Module({
+  imports: [MongooseModule.forFeature([{ name: RoomTotal.name, schema: RoomTotalSchema }])],
+  providers: [RoomTotalsService],
+  exports: [RoomTotalsService],
+})
+export class RoomTotalsModule {}

--- a/backend/src/room-totals/room-totals.service.ts
+++ b/backend/src/room-totals/room-totals.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
+import type { Model } from 'mongoose'
+
+import { EventCountersService } from '../event-counters/event-counters.service'
+import { RoomTotal } from './room-total.schema'
+import type { RoomActivityKind } from '../rooms/schemas/room-activity.schema'
+
+/**
+ * The permanent count of room lifecycle events: how many rooms have ever been made, how
+ * many invites have ever been accepted. See `room-total.schema.ts` for why the activity
+ * log itself cannot answer this.
+ *
+ * In a module of its own for the same reason as UserActivityService: the writer lives in
+ * RoomsModule and the reader in MetricsModule, and hanging it off either would put a cycle
+ * in the graph.
+ */
+@Injectable()
+export class RoomTotalsService {
+  private readonly logger = new Logger(RoomTotalsService.name)
+
+  constructor (
+    @InjectModel(RoomTotal.name) private readonly totals: Model<RoomTotal>,
+    private readonly counters: EventCountersService,
+  ) {}
+
+  /**
+   * Never throws. By the time this is called the event it counts has already committed, so
+   * failing the request would report a room that was made as one that was not. A lost bump
+   * is a metric that reads one low forever, which is worth strictly less than the request.
+   */
+  async bump (kind: RoomActivityKind): Promise<void> {
+    try {
+      await this.totals.updateOne({ kind }, { $inc: { value: 1 } }, { upsert: true })
+    } catch (cause) {
+      this.logger.error(`Failed to count a "${kind}" room event`, cause)
+      this.counters.record('server', 'post_commit_room_total_lost')
+    }
+  }
+
+  async all (): Promise<Map<string, number>> {
+    const rows = await this.totals.find({}, { kind: 1, value: 1 }).lean()
+    return new Map(rows.map(row => [row.kind, row.value]))
+  }
+}

--- a/backend/src/rooms/room-activity.service.ts
+++ b/backend/src/rooms/room-activity.service.ts
@@ -4,6 +4,7 @@ import { Model } from 'mongoose'
 
 import { CLOCK, Clock } from './clock'
 import { RoomActivity, RoomActivityKind } from './schemas/room-activity.schema'
+import { RoomTotalsService } from '../room-totals/room-totals.service'
 
 /** The actor recorded for an anonymous visitor's write. */
 export const ANONYMOUS_ACTOR = 'anon'
@@ -13,7 +14,16 @@ export class RoomActivityService {
   constructor (
     @InjectModel(RoomActivity.name) private readonly activity: Model<RoomActivity>,
     @Inject(CLOCK) private readonly clock: Clock,
+    private readonly totals: RoomTotalsService,
   ) {}
+
+  /**
+   * Ops are excluded. One fires per accepted edit, which is the hottest write path in the
+   * service, and `sf_room_revisions` already sums them from the room documents for free.
+   */
+  private async tally (kind: RoomActivityKind): Promise<void> {
+    if (kind !== 'op') await this.totals.bump(kind)
+  }
 
   // Append-only, so it is the last step of every chain: a resumed mutation then
   // writes exactly one row rather than a duplicate.
@@ -22,8 +32,10 @@ export class RoomActivityService {
     actor: string,
     kind: RoomActivityKind,
     summary?: string,
+    options: { tally?: boolean } = {},
   ): Promise<void> {
     await this.activity.create({ roomId, actor, kind, summary, at: this.clock.now() })
+    if (options.tally !== false) await this.tally(kind)
   }
 
   /**
@@ -31,10 +43,14 @@ export class RoomActivityService {
    * An upsert keeps a resumed chain from logging the same event twice.
    */
   async recordOnce (roomId: string, actor: string, kind: RoomActivityKind): Promise<void> {
-    await this.activity.updateOne(
+    const { upsertedCount } = await this.activity.updateOne(
       { roomId, kind },
       { $setOnInsert: { roomId, kind, actor, at: this.clock.now() } },
       { upsert: true },
     )
+
+    // Only when the row was actually inserted. A resumed chain calls this again and the
+    // upsert matches instead, which must not count the same creation a second time.
+    if (upsertedCount > 0) await this.tally(kind)
   }
 }

--- a/backend/src/rooms/rooms.module.ts
+++ b/backend/src/rooms/rooms.module.ts
@@ -12,6 +12,7 @@ import { RoomActivityService } from './room-activity.service'
 import { RoomEventsService } from './room-events.service'
 import { RoomMembership, RoomMembershipSchema } from './schemas/room-membership.schema'
 import { RoomSweeperService } from './room-sweeper.service'
+import { RoomTotalsModule } from '../room-totals/room-totals.module'
 import { RoomsController } from './rooms.controller'
 import { RoomsService } from './rooms.service'
 import { UserActivityModule } from '../user-activity/user-activity.module'
@@ -26,6 +27,7 @@ import { UserActivityModule } from '../user-activity/user-activity.module'
     AuthModule, // The User model, for roomsRevision and the legacy import stamp.
     UserActivityModule, // Re-exported so the WS gateway can stamp an editor.
     LegacyModule, // The read-only FactoryData blob.
+    RoomTotalsModule, // The permanent lifecycle tally RoomActivityService bumps.
   ],
   controllers: [RoomsController],
   providers: [

--- a/backend/src/rooms/rooms.service.ts
+++ b/backend/src/rooms/rooms.service.ts
@@ -329,7 +329,12 @@ export class RoomsService {
       role: 'visitor',
     }
 
-    await this.activity.record(roomId, ANONYMOUS_ACTOR, 'joined', 'visitor token issued')
+    // Logged in the history but deliberately not tallied. Clearing the password is an
+    // authentication step, not an acceptance: the joiner calls /join straight after with
+    // the token, and counting both would report one collaborator as two.
+    await this.activity.record(
+      roomId, ANONYMOUS_ACTOR, 'joined', 'visitor token issued', { tally: false },
+    )
 
     return this.jwt.signAsync(payload, { expiresIn: VISITOR_TOKEN_TTL })
   }

--- a/backend/test/metrics-usage.spec.ts
+++ b/backend/test/metrics-usage.spec.ts
@@ -12,12 +12,13 @@ import {
 } from '../src/metrics/metrics.constants'
 import { ANONYMOUS_ACTOR, UserActivityService } from '../src/user-activity/user-activity.service'
 import { Room } from '../src/rooms/schemas/room.schema'
+import { RoomMembership } from '../src/rooms/schemas/room-membership.schema'
 import { Share } from '../src/legacy/share.schema'
 import { RoomActivity } from '../src/rooms/schemas/room-activity.schema'
 import { RoomOpService } from '../src/realtime/room-op.service'
 import { TestContext, awaitConnection, createTestApp, destroyTestApp } from './utils/test-app'
 import { User } from '../src/auth/user.schema'
-import { FakeClock, call, registerAndLogin, resetRooms } from './utils/rooms'
+import { FakeClock, TestUser, call, registerAndLogin, resetRooms } from './utils/rooms'
 import { clearMetricsToken, labelValues, sample, scrapeMetrics, useMetricsToken } from './utils/metrics'
 
 const HOUR = 60 * 60 * 1000
@@ -257,6 +258,149 @@ describe('the database-backed usage metrics', () => {
       const second = labelValues(await scrape(), 'sf_room_factories', 'room_id')
 
       expect(first).toEqual(second)
+    })
+  })
+
+  describe('the room lifecycle metrics', () => {
+    const memberships = () => context.app.get<Model<RoomMembership>>(getModelToken(RoomMembership.name))
+
+    const createRoom = async (as: TestUser, name = 'Iron Line') => {
+      const roomId = randomUUID()
+      await call(context.app, 'post', '/rooms', as).send({ roomId, name })
+      return roomId
+    }
+
+    const action = (body: string, name: string) =>
+      sample(body, 'sf_room_actions_total', `action="${name}"`)
+
+    /**
+     * The whole reason this metric is a stored tally rather than a count over room_activity:
+     * that log is trimmed to 200 rows a room and deleted outright with the room, so the
+     * numbers here have to survive both. These cases go through the real API so the counting
+     * hook is exercised where it actually sits.
+     */
+    it('counts a room being created', async () => {
+      const mael = await registerAndLogin(context.app, 'maker')
+      await createRoom(mael)
+      await createRoom(mael)
+
+      expect(action(await scrape(), 'created')).toBe(2)
+    })
+
+    it('counts a room being shared, separately from it being created', async () => {
+      const mael = await registerAndLogin(context.app, 'sharer')
+      const roomId = await createRoom(mael)
+      await createRoom(mael)
+      await call(context.app, 'post', `/rooms/${roomId}/share`, mael).send({})
+
+      const body = await scrape()
+      expect(action(body, 'created')).toBe(2)
+      expect(action(body, 'shared')).toBe(1)
+    })
+
+    it('counts an invite being accepted', async () => {
+      const host = await registerAndLogin(context.app, 'host')
+      const guest = await registerAndLogin(context.app, 'guest')
+      const roomId = await createRoom(host)
+      await call(context.app, 'post', `/rooms/${roomId}/share`, host).send({})
+      await call(context.app, 'post', `/rooms/${roomId}/join`, guest).send({})
+
+      expect(action(await scrape(), 'joined')).toBe(1)
+    })
+
+    /**
+     * A logged-in joiner clears a password-protected room with /auth and then calls /join,
+     * and both write a "joined" activity row. Tallying both would report one collaborator
+     * as two, so the visitor-token step is logged and not counted.
+     */
+    it('counts a password-protected join once, not once per step', async () => {
+      const host = await registerAndLogin(context.app, 'pwhost')
+      const guest = await registerAndLogin(context.app, 'pwguest')
+      const roomId = await createRoom(host)
+      await call(context.app, 'post', `/rooms/${roomId}/share`, host).send({})
+      await call(context.app, 'put', `/rooms/${roomId}/password`, host).send({ password: 'ficsit-forever' })
+
+      const auth = await call(context.app, 'post', `/rooms/${roomId}/auth`)
+        .send({ password: 'ficsit-forever' })
+      expect(auth.status).toBe(200)
+      const joined = await call(context.app, 'post', `/rooms/${roomId}/join`, guest)
+        .send({ visitorToken: auth.body.visitorToken })
+      expect(joined.status).toBe(200)
+
+      expect(action(await scrape(), 'joined')).toBe(1)
+    })
+
+    // The point of the tally. Deleting the room purges its activity rows, and counting
+    // those would make the number fall back down.
+    it('keeps counting a room that has since been deleted', async () => {
+      const mael = await registerAndLogin(context.app, 'deleter')
+      const roomId = await createRoom(mael)
+      await call(context.app, 'delete', `/rooms/${roomId}`, mael)
+
+      const body = await scrape()
+      expect(action(body, 'created')).toBe(1)
+      expect(action(body, 'deleted')).toBe(1)
+      // The room itself is gone from the live count, which is the contrast being drawn.
+      expect(sample(body, 'sf_rooms_total', 'shared="false"')).toBe(0)
+    })
+
+    // recordOnce upserts, so a resumed ensure-chain calls it again on a row that already
+    // exists. Counting that would report one creation as two.
+    it('does not count a creation twice when the chain is resumed', async () => {
+      const mael = await registerAndLogin(context.app, 'resumer')
+      const roomId = randomUUID()
+      await call(context.app, 'post', '/rooms', mael).send({ roomId, name: 'Iron Line' })
+      await call(context.app, 'post', '/rooms', mael).send({ roomId, name: 'Iron Line' })
+
+      expect(action(await scrape(), 'created')).toBe(1)
+    })
+
+    // One per accepted edit would be the hottest write in the service, and sf_room_revisions
+    // already sums them off the room documents for nothing.
+    it('leaves ops out of the tally', async () => {
+      const mael = await registerAndLogin(context.app, 'editor')
+      await createRoom(mael)
+
+      expect(action(await scrape(), 'op')).toBeUndefined()
+    })
+
+    describe('the rolling windows', () => {
+      it('counts rooms created in each window from the room documents', async () => {
+        const now = clock.now().getTime()
+        await seedRoom(1, { createdAt: new Date(now - 2 * HOUR) })
+        await seedRoom(1, { createdAt: new Date(now - 4 * DAY) })
+        await seedRoom(1, { createdAt: new Date(now - 300 * DAY) })
+
+        const body = await scrape()
+
+        expect(sample(body, 'sf_new_rooms', 'window="24h"')).toBe(1)
+        expect(sample(body, 'sf_new_rooms', 'window="7d"')).toBe(2)
+        expect(sample(body, 'sf_new_rooms', 'window="30d"')).toBe(2)
+      })
+
+      it('counts accepted invites in each window, and never the owner', async () => {
+        const now = clock.now().getTime()
+        const roomId = randomUUID()
+        await memberships().create({ userId: 'a', roomId, role: 'owner', joinedAt: new Date(now - 1 * HOUR) })
+        await memberships().create({ userId: 'b', roomId, role: 'member', joinedAt: new Date(now - 2 * HOUR) })
+        await memberships().create({ userId: 'c', roomId, role: 'member', joinedAt: new Date(now - 4 * DAY) })
+
+        const body = await scrape()
+
+        // The owner's row is written by the create, so counting it would report every new
+        // room as an invite somebody accepted.
+        expect(sample(body, 'sf_new_memberships', 'window="24h"')).toBe(1)
+        expect(sample(body, 'sf_new_memberships', 'window="7d"')).toBe(2)
+      })
+
+      it('exports every window for both even with nothing at all', async () => {
+        const body = await scrape()
+
+        for (const [label] of ACTIVE_ACCOUNT_WINDOWS) {
+          expect(sample(body, 'sf_new_rooms', `window="${label}"`)).toBe(0)
+          expect(sample(body, 'sf_new_memberships', `window="${label}"`)).toBe(0)
+        }
+      })
     })
   })
 

--- a/backend/test/utils/rooms.ts
+++ b/backend/test/utils/rooms.ts
@@ -18,7 +18,7 @@ export interface TestUser {
   token: string
 }
 
-const ROOM_COLLECTIONS = ['rooms', 'room_memberships', 'room_activity', 'user_preferences']
+const ROOM_COLLECTIONS = ['rooms', 'room_memberships', 'room_activity', 'room_totals', 'user_preferences']
 
 type Method = 'get' | 'post' | 'put' | 'delete'
 

--- a/common/src/schemas/events.ts
+++ b/common/src/schemas/events.ts
@@ -70,6 +70,7 @@ export const EVENT_REASONS = [
   'post_commit_editor_stamp_lost',
   'post_commit_signin_stamp_lost',
   'post_commit_room_activity_lost',
+  'post_commit_room_total_lost',
 ] as const
 
 export type EventReason = typeof EVENT_REASONS[number]

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -10,7 +10,7 @@ The two dashboards that read `GET /metrics`, and the script that generates them.
 
 ## Why a generator rather than hand-edited JSON
 
-The dashboards are 63 panels each and identical apart from one label matcher. Keeping two
+The dashboards are 70 panels each and identical apart from one label matcher. Keeping two
 hand-written copies in step would not survive contact with a single edit.
 
 More importantly, **production and preview export the same metric names**. An unfiltered query

--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -485,6 +485,51 @@ add(87, "Of Those Who Signed In, How Many Edited",
     stat([{"value": 0, "color": "red"}, {"value": 0.3, "color": "#EAB839"}, {"value": 0.6, "color": "green"}],
          unit="percentunit", minmax=(0, 1)))
 
+# ---------------------------------------------------------------- collaboration
+# Everything above about rooms is a live count: it falls when a plan is deleted. This row
+# is the opposite — a stored tally that only ever rises, so a plan made and then deleted
+# still counts. It starts at zero when this shipped, because the activity log it would
+# otherwise be read from is trimmed to 200 rows a plan and deleted with the plan.
+add(110, "Plans Ever Created",
+    "Synced plans made, all time. Unlike Synced Plans above, deleting a plan does not take it back off this number. Counts from when this metric shipped.",
+    [query('sum(sf_room_actions_total%s)' % sel('action="created"'), "Created")],
+    stat(BLUE, graph="area", color_mode="background_solid"))
+
+add(111, "Plans Ever Shared",
+    "Times somebody turned a plan into a collaborative one by allocating an invite link. A plan shared, unshared and shared again counts twice, because that is two decisions to share.",
+    [query('sum(sf_room_actions_total%s)' % sel('action="shared"'), "Shared")],
+    stat(GREEN, graph="area", color_mode="background_solid"))
+
+add(112, "Invites Accepted",
+    "Times somebody joined a plan they did not create. The number that says collaboration is actually happening rather than merely being switched on.",
+    [query('sum(sf_room_actions_total%s)' % sel('action="joined"'), "Accepted")],
+    stat([{"value": 0, "color": "#6a6a6a"}, {"value": 1, "color": "green"}],
+         graph="area", color_mode="background_solid"))
+
+add(113, "Plans Ever Deleted",
+    "Deletions, all time. Read against Plans Ever Created: the gap is roughly what is still live.",
+    [query('sum(sf_room_actions_total%s)' % sel('action="deleted"'), "Deleted")],
+    stat(GREY, graph="area", color_mode="background_solid"))
+
+add(114, "New Plans",
+    "Synced plans created inside each rolling window, counted off the plan documents rather than the tally, so it was answerable the day it shipped. It sees only plans that still exist, so a plan created and deleted inside the window is missing from it.",
+    [query('sum(sf_new_rooms%s)' % sel('window="24h"'), "24 hours", "A"),
+     query('sum(sf_new_rooms%s)' % sel('window="7d"'), "7 days", "B"),
+     query('sum(sf_new_rooms%s)' % sel('window="30d"'), "30 days", "C")],
+    stat(BLUE, color_mode="value", text_mode="value_and_name"))
+
+add(115, "Invites Accepted Recently",
+    "Invites accepted inside each rolling window, counted off the membership rows. Same caveat as New Plans: somebody who joined and then left, or who was dropped when the owner unshared, is not in it.",
+    [query('sum(sf_new_memberships%s)' % sel('window="24h"'), "24 hours", "A"),
+     query('sum(sf_new_memberships%s)' % sel('window="7d"'), "7 days", "B"),
+     query('sum(sf_new_memberships%s)' % sel('window="30d"'), "30 days", "C")],
+    stat(GREEN, color_mode="value", text_mode="value_and_name"))
+
+add(116, "Plan Lifecycle Over Time",
+    "Every tallied action. Flat lines are the normal state; a step is somebody doing that thing. Ops are deliberately absent, since Edits and Activity already covers them.",
+    [query("sum by (action) (sf_room_actions_total%s)" % J, "{{action}}")],
+    timeseries(fill=8))
+
 # ----------------------------------------------------------------- share links
 # Snapshot links, the "copy a link to this plan" feature. Every number here comes from the
 # shares collection, which nothing purges, so all of it is complete back to the feature
@@ -615,6 +660,12 @@ rows = [
         item(14, 0, 10, 4, 80),
         item(0, 4, 12, 8, 83), item(12, 4, 12, 8, 86),
         item(0, 12, 5, 4, 85), item(5, 12, 19, 4, 84),
+    ]),
+    row("🤝 Collaboration · from the database, all time", [
+        item(0, 0, 6, 4, 110), item(6, 0, 6, 4, 111),
+        item(12, 0, 6, 4, 112), item(18, 0, 6, 4, 113),
+        item(0, 4, 12, 4, 114), item(12, 4, 12, 4, 115),
+        item(0, 8, 24, 8, 116),
     ]),
     row("🔗 Share Links · from the database", [
         item(0, 0, 5, 4, 100), item(5, 0, 5, 4, 101), item(10, 0, 4, 4, 102),

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -4760,6 +4760,695 @@
           }
         }
       },
+      "panel-110": {
+        "kind": "Panel",
+        "spec": {
+          "id": 110,
+          "title": "Plans Ever Created",
+          "description": "Synced plans made, all time. Unlike Synced Plans above, deleting a plan does not take it back off this number. Counts from when this metric shipped.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories-preview\",action=\"created\"})",
+                        "legendFormat": "Created",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-111": {
+        "kind": "Panel",
+        "spec": {
+          "id": 111,
+          "title": "Plans Ever Shared",
+          "description": "Times somebody turned a plan into a collaborative one by allocating an invite link. A plan shared, unshared and shared again counts twice, because that is two decisions to share.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories-preview\",action=\"shared\"})",
+                        "legendFormat": "Shared",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-112": {
+        "kind": "Panel",
+        "spec": {
+          "id": 112,
+          "title": "Invites Accepted",
+          "description": "Times somebody joined a plan they did not create. The number that says collaboration is actually happening rather than merely being switched on.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories-preview\",action=\"joined\"})",
+                        "legendFormat": "Accepted",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-113": {
+        "kind": "Panel",
+        "spec": {
+          "id": 113,
+          "title": "Plans Ever Deleted",
+          "description": "Deletions, all time. Read against Plans Ever Created: the gap is roughly what is still live.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories-preview\",action=\"deleted\"})",
+                        "legendFormat": "Deleted",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-114": {
+        "kind": "Panel",
+        "spec": {
+          "id": 114,
+          "title": "New Plans",
+          "description": "Synced plans created inside each rolling window, counted off the plan documents rather than the tally, so it was answerable the day it shipped. It sees only plans that still exist, so a plan created and deleted inside the window is missing from it.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_rooms{job=\"satisfactory-factories-preview\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_rooms{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_rooms{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-115": {
+        "kind": "Panel",
+        "spec": {
+          "id": 115,
+          "title": "Invites Accepted Recently",
+          "description": "Invites accepted inside each rolling window, counted off the membership rows. Same caveat as New Plans: somebody who joined and then left, or who was dropped when the owner unshared, is not in it.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_memberships{job=\"satisfactory-factories-preview\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_memberships{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_memberships{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-116": {
+        "kind": "Panel",
+        "spec": {
+          "id": 116,
+          "title": "Plan Lifecycle Over Time",
+          "description": "Every tallied action. Flat lines are the normal state; a step is somebody doing that thing. Ops are deliberately absent, since Edits and Activity already covers them.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (action) (sf_room_actions_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "{{action}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
       "panel-100": {
         "kind": "Panel",
         "spec": {
@@ -6688,6 +7377,111 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-84"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🤝 Collaboration · from the database, all time",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-110"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 6,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-111"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-112"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 18,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-113"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-114"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 4,
+                        "width": 12,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-115"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 8,
+                        "width": 24,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-116"
                         }
                       }
                     }

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -4760,6 +4760,695 @@
           }
         }
       },
+      "panel-110": {
+        "kind": "Panel",
+        "spec": {
+          "id": 110,
+          "title": "Plans Ever Created",
+          "description": "Synced plans made, all time. Unlike Synced Plans above, deleting a plan does not take it back off this number. Counts from when this metric shipped.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories\",action=\"created\"})",
+                        "legendFormat": "Created",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-111": {
+        "kind": "Panel",
+        "spec": {
+          "id": 111,
+          "title": "Plans Ever Shared",
+          "description": "Times somebody turned a plan into a collaborative one by allocating an invite link. A plan shared, unshared and shared again counts twice, because that is two decisions to share.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories\",action=\"shared\"})",
+                        "legendFormat": "Shared",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-112": {
+        "kind": "Panel",
+        "spec": {
+          "id": 112,
+          "title": "Invites Accepted",
+          "description": "Times somebody joined a plan they did not create. The number that says collaboration is actually happening rather than merely being switched on.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories\",action=\"joined\"})",
+                        "legendFormat": "Accepted",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      },
+                      {
+                        "value": 1,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-113": {
+        "kind": "Panel",
+        "spec": {
+          "id": 113,
+          "title": "Plans Ever Deleted",
+          "description": "Deletions, all time. Read against Plans Ever Created: the gap is roughly what is still live.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories\",action=\"deleted\"})",
+                        "legendFormat": "Deleted",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "background_solid",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "#6a6a6a"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-114": {
+        "kind": "Panel",
+        "spec": {
+          "id": 114,
+          "title": "New Plans",
+          "description": "Synced plans created inside each rolling window, counted off the plan documents rather than the tally, so it was answerable the day it shipped. It sees only plans that still exist, so a plan created and deleted inside the window is missing from it.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_rooms{job=\"satisfactory-factories\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_rooms{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_rooms{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-115": {
+        "kind": "Panel",
+        "spec": {
+          "id": 115,
+          "title": "Invites Accepted Recently",
+          "description": "Invites accepted inside each rolling window, counted off the membership rows. Same caveat as New Plans: somebody who joined and then left, or who was dropped when the owner unshared, is not in it.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_memberships{job=\"satisfactory-factories\",window=\"24h\"})",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_memberships{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_memberships{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "30 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-116": {
+        "kind": "Panel",
+        "spec": {
+          "id": 116,
+          "title": "Plan Lifecycle Over Time",
+          "description": "Every tallied action. Flat lines are the normal state; a step is somebody doing that thing. Ops are deliberately absent, since Edits and Activity already covers them.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (action) (sf_room_actions_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "{{action}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
       "panel-100": {
         "kind": "Panel",
         "spec": {
@@ -6688,6 +7377,111 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-84"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🤝 Collaboration · from the database, all time",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-110"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 6,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-111"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-112"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 18,
+                        "y": 0,
+                        "width": 6,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-113"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 4,
+                        "width": 12,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-114"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 4,
+                        "width": 12,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-115"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 8,
+                        "width": 24,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-116"
                         }
                       }
                     }


### PR DESCRIPTION
## Manual steps

No manual steps or intervention required. A new collection, `room_totals`, is created on first write.

## What this adds

| Metric | What it is |
| --- | --- |
| `sf_room_actions_total{action}` | Room lifecycle events that have **ever** happened: created, shared, joined, deleted, renamed, left, password set/removed, adopted, imported |
| `sf_new_rooms{window}` | Plans created in each rolling window |
| `sf_new_memberships{window}` | Invites accepted in each rolling window |

A new **🤝 Collaboration** dashboard row of seven panels: Plans Ever Created, Plans Ever Shared, Invites Accepted, Plans Ever Deleted, the two rolling-window stats, and a lifecycle graph.

Everything else about rooms on the dashboard is a live count that falls when a plan is deleted. This row is the opposite.

## Why a stored tally and not a count over `room_activity`

`room_activity` records every one of these events and still cannot answer "how many times". `RoomSweeperService` trims it to `ACTIVITY_PER_ROOM` (200) rows per room, and `purge()` deletes a room's rows outright when the room is tombstoned or orphaned. Counting rows there undercounts, and by more the longer the service runs — a busy plan passes 200 rows on ops alone and loses its own `created` row.

`UserActivityService` already carries this exact reasoning for the same collection, so this follows it: a small collection, `$inc` only, in a module of its own because the writer is in `RoomsModule` and the reader in `MetricsModule`.

## Where it counts, and the two carve-outs

Bumped inside `RoomActivityService`, so one hook covers every kind and no call site changed.

- **`op` is excluded.** One fires per accepted edit, the hottest write path in the service, and `sf_room_revisions` already sums them off the room documents for free.
- **The visitor-token step is logged and not tallied.** A logged-in joiner clears a password-protected room with `POST /rooms/:id/auth` and then calls `/join`, and both write a `joined` activity row. Counting both would report one collaborator as two. There is a test for this specifically.

`recordOnce` upserts, so a resumed ensure-chain calls it again on a row that already exists. The tally only fires on `upsertedCount > 0`, so one creation cannot be counted twice.

A lost bump never fails the request — by then the event has committed, and reporting a plan that was made as one that was not is the worse error. It records `post_commit_room_total_lost`, matching `post_commit_room_activity_lost` beside it.

## The rolling windows are free and retroactive

`Room.createdAt` exists (`timestamps: true`) and `RoomMembership.joinedAt` has always been stored, so both windows needed no new writes and are **answerable immediately** rather than in a week's time. Owners are excluded from `sf_new_memberships`: the owner's row is written by the create, so counting it would report every new plan as an invite somebody accepted.

Their one caveat, stated in both the help strings and the panel descriptions: they see only rows that still exist. A plan created and deleted inside the window is missing from it, as is somebody who joined and then left. The tally is the number without that caveat, at the cost of starting from zero now.

## Validation

- `pnpm exec vitest run` in `backend/` — 463 passed, 30 files
- 10 new cases, driven through the real API rather than seeded: creation, sharing, joining, the password-protected double-count, deletion still counting after the room is gone, the resumed chain not double counting, ops staying out, and the three window cases
- `common` 143 passed; `web` events store 19 passed (the reason enum gained `post_commit_room_total_lost`)
- `pnpm exec tsc --noEmit` and `pnpm lint` clean across `backend` and `common`
- Both dashboards regenerated and checked: 70 panels, 11 rows, every laid-out panel resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)
