### PR TITLE
docs(backend): say what lastViewed actually does

### DIFF
--- a/backend/src/legacy/share.schema.ts
+++ b/backend/src/legacy/share.schema.ts
@@ -22,7 +22,10 @@ export class Share {
   @Prop({ type: Number, default: 0 })
   views!: number
 
-  /** Feeds the purge of old shares, so the collection cannot grow forever. */
+  /**
+   * When the link was last opened. No purge of old shares is implemented,
+   * so this is written on every view and never read back.
+   */
   @Prop({ type: Date, default: Date.now })
   lastViewed!: Date
 }


### PR DESCRIPTION
No manual steps or intervention required.

## What was wrong

`lastViewed` on the share schema carried this comment:

> Feeds the purge of old shares, so the collection cannot grow forever.

There is no purge. The field is written by the view counter in `backend/src/legacy/legacy.controller.ts` and read nowhere else. Grepping `backend/src` for `shareModel`, `Share.name` and `ShareSchema` turns up only the schema, its registration in `legacy.module.ts` and `metrics.module.ts`, and the two controller uses (create, and the view-counting `findOneAndUpdate`). The room sweeper does not touch shares. So the collection does grow without bound.

## Why it is worth a commit

The share link metrics from #637 say `sf_shares_total` and `sf_new_shares` are complete back to when the feature shipped, and that claim rests on nothing purging the collection. The comment asserted the opposite, so a reader who trusted it would wrongly doubt the metric.

## The change

One comment, corrected to say what the field records and that no purge is implemented. The metric help strings and the Grafana panel descriptions stay as they are, because they are accurate.

I chose to fix the comment rather than build the purge. Nothing currently needs shares to expire, and adding one would invalidate the completeness the metrics rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)