### PR TITLE
fix: window legends out of order, and room actions reading No data

### DIFF
--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -16,6 +16,7 @@ import { CachedQuery } from './cached-query'
 import { ConnectionRegistry } from '../realtime/connection-registry'
 import { EventCountersService } from '../event-counters/event-counters.service'
 import { Room } from '../rooms/schemas/room.schema'
+import { ROOM_ACTIVITY_KINDS } from '../rooms/schemas/room-activity.schema'
 import { RoomMembership } from '../rooms/schemas/room-membership.schema'
 import { RoomTotalsService } from '../room-totals/room-totals.service'
 import { Share } from '../legacy/share.schema'
@@ -318,11 +319,7 @@ export class MetricsService {
       this.sharesTotal.set(cheap.value.shares)
       this.shareOpensTotal.set(cheap.value.shareOpens)
 
-      // Not reset first: the tally only ever grows and a kind never leaves it, so there is
-      // no stale label set to clear the way the top-N gauges have.
-      for (const [action, count] of cheap.value.roomActions) {
-        this.roomActions.set({ action }, count)
-      }
+      this.setRoomActionGauges(cheap.value.roomActions)
     }
 
     // Only on a real reload. prom-client remembers every label set it has been given, so a
@@ -330,6 +327,26 @@ export class MetricsService {
     // forever unless the gauge is cleared first. Equally, a failed reload must leave the
     // previous set intact rather than blanking the panel.
     if (slow.refreshed && slow.value) this.setSlowGauges(slow.value)
+  }
+
+  /**
+   * Every kind is exported, whether or not it has ever happened. prom-client emits a series
+   * only once it has been set, so a kind nobody has done yet would be absent entirely and
+   * its panel would read "No data" rather than a green zero — which is what the tally said
+   * on release, when nothing had been counted at all.
+   *
+   * Not reset first: the tally only rises and a kind never leaves it, so unlike the top-N
+   * gauges there is no stale label set to clear.
+   */
+  private setRoomActionGauges (stored: Map<string, number>): void {
+    // Seeded first, then overlaid, so a kind held in the database but no longer in the enum
+    // still reports rather than being silently dropped.
+    const actions = new Map<string, number>(
+      ROOM_ACTIVITY_KINDS.filter(kind => kind !== 'op').map(kind => [kind, 0]),
+    )
+    for (const [action, count] of stored) actions.set(action, count)
+
+    for (const [action, count] of actions) this.roomActions.set({ action }, count)
   }
 
   private setClientGauges (census: TelemetrySnapshot): void {

--- a/backend/test/metrics-usage.spec.ts
+++ b/backend/test/metrics-usage.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/metrics/metrics.constants'
 import { ANONYMOUS_ACTOR, UserActivityService } from '../src/user-activity/user-activity.service'
 import { Room } from '../src/rooms/schemas/room.schema'
+import { ROOM_ACTIVITY_KINDS } from '../src/rooms/schemas/room-activity.schema'
 import { RoomMembership } from '../src/rooms/schemas/room-membership.schema'
 import { Share } from '../src/legacy/share.schema'
 import { RoomActivity } from '../src/rooms/schemas/room-activity.schema'
@@ -279,6 +280,20 @@ describe('the database-backed usage metrics', () => {
      * numbers here have to survive both. These cases go through the real API so the counting
      * hook is exercised where it actually sits.
      */
+    /**
+     * prom-client emits a series only once it has been set, so without seeding, a kind that
+     * has not happened yet is absent from the scrape entirely and its panel reads "No data".
+     * That is what the whole metric did on release, when the tally was empty.
+     */
+    it('exports every kind at zero before anything has happened', async () => {
+      const body = await scrape()
+
+      for (const kind of ROOM_ACTIVITY_KINDS) {
+        if (kind === 'op') continue
+        expect(action(body, kind)).toBe(0)
+      }
+    })
+
     it('counts a room being created', async () => {
       const mael = await registerAndLogin(context.app, 'maker')
       await createRoom(mael)

--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -49,6 +49,24 @@ def query(expr, legend, ref="A", instant=False):
     }
 
 
+# Ascending, matching ACTIVE_ACCOUNT_WINDOWS in the backend.
+WINDOWS = ["1h", "24h", "7d", "14d", "30d"]
+
+
+def window_queries(metric):
+    """One query per window, ascending.
+
+    Not `sum by (window) (metric)`. Grafana renders series in query order, but a single
+    grouped query returns one frame whose series are ordered as *text* — which puts 14d
+    first, then 1h, 24h, 30d, and 7d last. Splitting it is what fixes the legend order,
+    and it is what the matching stat panels already do.
+    """
+    return [
+        query("sum(%s%s)" % (metric, sel('window="%s"' % window)), window, "ABCDE"[index])
+        for index, window in enumerate(WINDOWS)
+    ]
+
+
 def panel(pid, title, description, queries, viz):
     return {
         "kind": "Panel",
@@ -369,7 +387,7 @@ add(64, "Active Accounts",
 
 add(65, "Active Accounts Over Time",
     "The windows plotted together. The 30-day line is thin for the first month after release: it is seeded from an activity log that is trimmed per plan, so early history is partial.",
-    [query("sum by (window) (sf_active_accounts%s)" % J, "{{window}}")],
+    window_queries("sf_active_accounts"),
     timeseries(fill=8))
 
 add(66, "Stickiness",
@@ -458,7 +476,7 @@ add(82, "New Accounts This Month",
 
 add(83, "New Accounts Over Time",
     "Each rolling window plotted. A step up in the 24h line is a signup; the wider lines are the trend.",
-    [query("sum by (window) (sf_new_accounts%s)" % J, "{{window}}")],
+    window_queries("sf_new_accounts"),
     timeseries(fill=8))
 
 add(84, "Sign-ins",
@@ -475,7 +493,7 @@ add(85, "Sign-ins, All Time",
 
 add(86, "Sign-ins Over Time",
     "Rolling sign-in windows. Compare against Active Accounts: a gap means people are signing in and not building.",
-    [query("sum by (window) (sf_signed_in_accounts%s)" % J, "{{window}}")],
+    window_queries("sf_signed_in_accounts"),
     timeseries(fill=8))
 
 add(87, "Of Those Who Signed In, How Many Edited",
@@ -558,7 +576,7 @@ add(103, "New Share Links",
 
 add(104, "Share Links Created Over Time",
     "Each rolling window plotted. A step up in the 24h line is somebody making a link.",
-    [query("sum by (window) (sf_new_shares%s)" % J, "{{window}}")],
+    window_queries("sf_new_shares"),
     timeseries(fill=8))
 
 add(105, "Most Opened Share Links",

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -2976,12 +2976,96 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (window) (sf_active_accounts{job=\"satisfactory-factories-preview\"})",
-                        "legendFormat": "{{window}}",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"1h\"})",
+                        "legendFormat": "1h",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"24h\"})",
+                        "legendFormat": "24h",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "7d",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"14d\"})",
+                        "legendFormat": "14d",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "30d",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
                     "hidden": false
                   }
                 }
@@ -4258,12 +4342,96 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (window) (sf_new_accounts{job=\"satisfactory-factories-preview\"})",
-                        "legendFormat": "{{window}}",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories-preview\",window=\"1h\"})",
+                        "legendFormat": "1h",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories-preview\",window=\"24h\"})",
+                        "legendFormat": "24h",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "7d",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories-preview\",window=\"14d\"})",
+                        "legendFormat": "14d",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "30d",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
                     "hidden": false
                   }
                 }
@@ -4577,12 +4745,96 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (window) (sf_signed_in_accounts{job=\"satisfactory-factories-preview\"})",
-                        "legendFormat": "{{window}}",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories-preview\",window=\"1h\"})",
+                        "legendFormat": "1h",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories-preview\",window=\"24h\"})",
+                        "legendFormat": "24h",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "7d",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories-preview\",window=\"14d\"})",
+                        "legendFormat": "14d",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "30d",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
                     "hidden": false
                   }
                 }
@@ -5843,12 +6095,96 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (window) (sf_new_shares{job=\"satisfactory-factories-preview\"})",
-                        "legendFormat": "{{window}}",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories-preview\",window=\"1h\"})",
+                        "legendFormat": "1h",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories-preview\",window=\"24h\"})",
+                        "legendFormat": "24h",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories-preview\",window=\"7d\"})",
+                        "legendFormat": "7d",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories-preview\",window=\"14d\"})",
+                        "legendFormat": "14d",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories-preview\",window=\"30d\"})",
+                        "legendFormat": "30d",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
                     "hidden": false
                   }
                 }

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -2976,12 +2976,96 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (window) (sf_active_accounts{job=\"satisfactory-factories\"})",
-                        "legendFormat": "{{window}}",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"1h\"})",
+                        "legendFormat": "1h",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"24h\"})",
+                        "legendFormat": "24h",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "7d",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"14d\"})",
+                        "legendFormat": "14d",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_active_accounts{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "30d",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
                     "hidden": false
                   }
                 }
@@ -4258,12 +4342,96 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (window) (sf_new_accounts{job=\"satisfactory-factories\"})",
-                        "legendFormat": "{{window}}",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories\",window=\"1h\"})",
+                        "legendFormat": "1h",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories\",window=\"24h\"})",
+                        "legendFormat": "24h",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "7d",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories\",window=\"14d\"})",
+                        "legendFormat": "14d",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_accounts{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "30d",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
                     "hidden": false
                   }
                 }
@@ -4577,12 +4745,96 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (window) (sf_signed_in_accounts{job=\"satisfactory-factories\"})",
-                        "legendFormat": "{{window}}",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories\",window=\"1h\"})",
+                        "legendFormat": "1h",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories\",window=\"24h\"})",
+                        "legendFormat": "24h",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "7d",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories\",window=\"14d\"})",
+                        "legendFormat": "14d",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_signed_in_accounts{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "30d",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
                     "hidden": false
                   }
                 }
@@ -5843,12 +6095,96 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (window) (sf_new_shares{job=\"satisfactory-factories\"})",
-                        "legendFormat": "{{window}}",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories\",window=\"1h\"})",
+                        "legendFormat": "1h",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories\",window=\"24h\"})",
+                        "legendFormat": "24h",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories\",window=\"7d\"})",
+                        "legendFormat": "7d",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories\",window=\"14d\"})",
+                        "legendFormat": "14d",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_new_shares{job=\"satisfactory-factories\",window=\"30d\"})",
+                        "legendFormat": "30d",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
                     "hidden": false
                   }
                 }


### PR DESCRIPTION
## Manual steps

**Re-apply both dashboards after this merges.** The panel change is in the generated JSON, so the copy in Grafana stays wrong until it is pushed again. Nothing does that automatically.

## Two faults

### 1. Window legends sorted as text

The four "over time" panels grouped with `sum by (window)`. That returns one frame whose series are ordered as strings, so the legend read **14d, 1h, 24h, 30d, 7d**.

Fixed by splitting into one query per window in ascending order. This is exactly what the matching stat panels already did, which is why "Active Accounts" read correctly while "Active Accounts Over Time" beside it did not.

Affects: Active Accounts Over Time, New Accounts Over Time, Sign-ins Over Time, Share Links Created Over Time.

Every other grouped label was checked:

| Label | Verdict |
| --- | --- |
| `status` | Three-digit HTTP codes, so text order is correct order |
| `action`, `kind`, `source`, `shared`, `signed_in` | Not ordinal, order carries no meaning |
| `version` | **Genuinely sorts wrong** (`0.10.0` before `0.7.0`), and left alone: the label set is whatever clients report, so it cannot be enumerated in the generator the way windows can |

### 2. `sf_room_actions_total` exported nothing

prom-client emits a series only once it has been set, and the tally starts empty. So on release, before anyone had created a room, the metric had no series at all and every panel in the Collaboration row read "No data" instead of a green zero.

Confirmed rather than assumed: querying the preview instance returned no result for `sf_room_actions_total`, while `sf_new_rooms` beside it returned all five windows.

Every kind is now seeded at zero with the stored values overlaid, which is what `EventCountersService` already does for fault reasons. The overlay is deliberate: a kind held in the database but no longer in the enum still reports, rather than being silently dropped.

## Validation

- `pnpm exec vitest run` in `backend/` — 464 passed, 30 files
- One new case asserting every kind reads zero on a scrape before anything has happened
- `pnpm exec tsc --noEmit` and `pnpm lint` clean
- Both dashboards regenerated; every window panel's legend order asserted ascending (`1h, 24h, 7d, 14d, 30d`) across all four panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
