### PR TITLE
docs(repo): record the prom-client label lifecycle trap

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -45,3 +45,4 @@
 - [Overlay z-index bands](overlay-z-index-bands.md) — banners sit at 1900 below Vuetify menus (2000+), toasts at 2600 above dialogs; a banner above the overlay stack steals menu clicks
 - [prom-client is deprecated](prom-client-deprecated-successor.md) — the successor was days old and 0.x, so the metrics endpoint stayed put; what would change that, and the third package name context7 hands out
 - [Verify: hidden-pane menu freeze](verify-hidden-pane-menu-freeze.md) — a hidden browser pane leaves Vuetify menus stuck invisible with inline pointer-events:none; clear the inline props before hit-testing
+- [prom-client label lifecycle](prom-client-label-lifecycle.md) — seed bounded label sets at zero or panels read "No data"; reset ranked ones or dropped labels report forever

--- a/.claude/memory/prom-client-label-lifecycle.md
+++ b/.claude/memory/prom-client-label-lifecycle.md
@@ -1,0 +1,36 @@
+---
+name: prom-client-label-lifecycle
+description: A prom-client gauge publishes a label set only after it is set, and remembers it forever once it has been; bounded labels must be seeded at zero and top-N labels must be reset
+metadata:
+  type: project
+  volatility: durable
+  lastVerified: 2026-09-02
+---
+
+`prom-client` emits a series for a label combination only once `.set()` has been called with
+it, and once called it remembers that combination for the life of the process. Both halves
+cause a different bug, and the fix for one is the opposite of the fix for the other.
+
+**Never set means absent, and Grafana renders absent as "No data", not as zero.** A gauge whose
+labels come from a database table is missing entirely while that table is empty, which is
+exactly release day. `sf_room_actions_total` shipped this way and every panel in the
+Collaboration row read "No data" until the metric was seeded. `EventCountersService` had
+already solved it for fault reasons and the lesson did not carry across.
+
+**Set once means set forever, so a label that drops out keeps reporting its last value.** The
+top-N gauges (`sf_room_factories`, `sf_user_edits`, `sf_share_opens`) would otherwise show a
+plan its final size long after it left the top twenty.
+
+So:
+
+- **Bounded, known label set** — enumerate it and seed every value at zero before overlaying
+  what is stored. Overlay rather than replace, so a value held in the database but no longer
+  in the enum still reports instead of being silently dropped.
+- **Unbounded or ranked label set** — `reset()` the gauge before writing the new rows, and
+  only when the underlying query actually refreshed. Resetting on a failed refresh blanks the
+  panel; see the `refreshed` flag on [[calc-engine-gotchas]]-style cached queries in
+  `metrics/cached-query.ts`.
+
+A related trap on the query side: `increase()` and `delta()` extrapolate to the range
+boundaries, so a flat counter reports drifting non-integers. Wrap them in `round()`, and for a
+monotonic value held in a gauge use `x - (x offset 7d)` rather than `delta()`, which is exact.


### PR DESCRIPTION
## Manual steps

No manual steps or intervention required.

## What this is

One memory file and its index line. No code.

Both halves of the prom-client label lifecycle have now cost a fix in this branch, and the fix for one is the opposite of the fix for the other:

- **A label set is absent until it is set**, and Grafana renders absent as "No data" rather than zero. `sf_room_actions_total` shipped this way and every Collaboration panel was blank until it was seeded ([#641](https://github.com/satisfactory-factories/application/pull/641)). `EventCountersService` had already solved it for fault reasons and the lesson did not carry across, which is the reason for writing it down.
- **A label set is never forgotten once set**, which is why the top-N gauges have to `reset()` first, and only when the underlying query actually refreshed.

It also carries the `increase()` extrapolation note from [#636](https://github.com/satisfactory-factories/application/pull/636), since it is the same class of trap one layer up in the query.

Belongs with #641, which was already merged by the time this was written, so it goes in on its own rather than being left uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
