### PR TITLE
fix(web): accept a task edit on enter instead of adding a newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,12 @@ Dimensional Depot Uploaders you have put on that item's surplus.
 
 ### Fixes
 
+- **Enter accepts a task you are editing** instead of dropping a newline into it. Task titles are
+  edited in an auto-growing textarea, so pressing enter grew the row and left the edit sitting
+  there uncommitted, while the new-task field right above it has always taken enter as "add this".
+  Enter now commits the edit and leaves the field, the same as clicking away; shift+enter still
+  types a second line for anyone who wants one.
+
 - **Checklist mode: ticks on the Products, Imports and export-chip checkboxes are reliable again**
   (#592, #593). The export tick sat inside the chip's own clickable area, so the chip's click
   handler and ripple layer could win the click before it ever reached the checkbox; it's now a

--- a/web/src/components/planner/PlannerFactoryTasks.spec.ts
+++ b/web/src/components/planner/PlannerFactoryTasks.spec.ts
@@ -10,10 +10,11 @@ import { newFactory } from '@/utils/factory-management/factory'
 describe('Component: PlannerFactoryTasks', () => {
   let factory: Factory
 
-  const mountSubject = () =>
+  const mountSubject = (options: Record<string, unknown> = {}) =>
     mount(PlannerFactoryTasks, {
       propsData: { factory },
       global: { plugins: [vuetify] },
+      ...options,
     })
 
   // Sortable has already moved the DOM by the time it reports; the component's job is to
@@ -73,6 +74,48 @@ describe('Component: PlannerFactoryTasks', () => {
     await subject.findAll('tbody tr')[1].find('textarea').setValue('Bravo edited')
 
     expect(factory.tasks.map(task => task.title)).toEqual(['Alpha', 'Bravo edited', 'Charlie'])
+  })
+
+  describe('editing a task title', () => {
+    const titleField = (subject: VueWrapper, index: number) =>
+      subject.findAll('tbody tr')[index].find('textarea')
+
+    // A task is a one-liner: enter accepts it, the way it does in the new-task field above.
+    it('accepts the edit on enter rather than adding a newline', async () => {
+      const subject = mountSubject()
+      const field = titleField(subject, 1)
+      await field.setValue('Bravo edited')
+
+      const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+      field.element.dispatchEvent(event)
+      await subject.vm.$nextTick()
+
+      expect(event.defaultPrevented).toBe(true)
+      expect(factory.tasks[1].title).toBe('Bravo edited')
+    })
+
+    it('blurs the field on enter so the edit is committed', async () => {
+      const subject = mountSubject({ attachTo: document.body })
+      const field = titleField(subject, 1)
+      field.element.focus()
+      expect(document.activeElement).toBe(field.element)
+
+      await field.trigger('keydown', { key: 'Enter' })
+
+      expect(document.activeElement).not.toBe(field.element)
+      subject.unmount()
+    })
+
+    it('leaves shift+enter alone so a second line is still possible', async () => {
+      const subject = mountSubject()
+      const field = titleField(subject, 1)
+
+      const event = new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true, bubbles: true, cancelable: true })
+      field.element.dispatchEvent(event)
+      await subject.vm.$nextTick()
+
+      expect(event.defaultPrevented).toBe(false)
+    })
   })
 
   it('ticking a task only touches that task', async () => {

--- a/web/src/components/planner/PlannerFactoryTasks.vue
+++ b/web/src/components/planner/PlannerFactoryTasks.vue
@@ -54,6 +54,7 @@
                   rows="1"
                   variant="plain"
                   @change="validateTaskLength(task)"
+                  @keydown.enter.exact.prevent="commitTaskEdit"
                 />
                 <p v-if="task.completed" class="text-done">{{ task.title }}</p>
               </td>
@@ -146,6 +147,13 @@
 
   const removeTask = (index: number) => {
     props.factory.tasks.splice(index, 1)
+  }
+
+  // Tasks are one-liners, so enter accepts the edit instead of dropping a newline into the
+  // title. Blurring is the accept: it commits through the field's own change handler, which is
+  // what clicking away already did. Shift+enter is left alone for a deliberate second line.
+  const commitTaskEdit = (event: KeyboardEvent) => {
+    (event.target as HTMLTextAreaElement).blur()
   }
 
   const validateTaskLength = (task: { title: string }) => {


### PR DESCRIPTION
## The bug

Pressing Enter while editing an existing task inserted a newline rather than accepting the task.

Task titles are edited in an auto-growing `v-textarea`, so Enter grew the row and left the edit sitting there uncommitted — while the **New Task** field directly above it has always treated Enter as "add this". Two fields in the same card, one key, two different answers.

## The fix

`web/src/components/planner/PlannerFactoryTasks.vue`

- The title textarea now handles `@keydown.enter.exact.prevent`, which blurs the field.
- Blurring is the accept: it commits through the field's existing `@change` handler, exactly as clicking away already did, so the length validation path is unchanged.
- `.exact` leaves Shift+Enter alone, so a deliberate second line is still possible.

## Tests

`web/src/components/planner/PlannerFactoryTasks.spec.ts` gains an `editing a task title` block:

- Enter prevents the default (no newline) and keeps the edited title.
- Enter blurs the field, so the edit is committed.
- Shift+Enter is not prevented.

`pnpm exec vitest run src/components/planner/PlannerFactoryTasks.spec.ts` — 17 passed. `pnpm lint` and `vue-tsc --noEmit` clean.

`CHANGELOG.md` gets an entry under Beta v0.7 → Fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7g3dGEfukw1DF6Vk79G3w

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7g3dGEfukw1DF6Vk79G3w)_