### PR TITLE
chore(repo): commit the Claude Code dev server launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "full",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev", "--port", "3100,3101"],
+      "port": 3100
+    },
+    {
+      "name": "web",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev:web", "--port", "3100,3101"],
+      "port": 3100
+    },
+    {
+      "name": "backend",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev:backend", "--port", "3100,3101"],
+      "port": 3101
+    }
+  ]
+}


### PR DESCRIPTION
## Manual steps

No manual steps or intervention required.

## What this is

One file, `.claude/launch.json`. It tells Claude Code's Browser pane how to start the dev servers, so `preview_start` works without being told the command each time.

Three configurations, matching the three existing scripts: `full`, `web`, `backend`.

## Why explicit ports rather than the defaults

All three pass `--port 3100,3101`, the flag added in #635, instead of taking 3000/3001. Both reasons are about the pane pointing at the right place:

- **3000 is the port most likely to already be taken**, by an editor or another project. That was the reason #635 existed.
- **Without an explicit port, Vite drifts.** `strictPort` is only set when `--port` is passed, so a bare `pnpm dev` on an occupied 3000 quietly serves 3001 instead, and the pane opens a port nothing is serving. With the flag, a clash fails loudly and says so.

The deployed ports are untouched. This is local dev only.

## Validation

Brought the `full` stack up through `preview_start` and watched it end to end:

- Mongo container healthy, web on 3100, API on 3101
- `OPTIONS /health` → 204, so the CORS wiring #635 added for a moved dev origin does the job
- `GET /health` → 200, `POST /telemetry` → 204
- No backend warning rendered in the app

Worth recording from that run: the backend first failed to compile with nine type errors, all of them stale `common/dist` against newer sources. `pnpm --filter common build` cleared it. Nothing to do with this config, but it is what a stale `dist` looks like from the outside, and the symptom is the API simply never answering while the web app comes up fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
