### PR TITLE
feat(web): checklist desyncs say what changed, and flag the factory that has one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,8 +135,8 @@ A ticked checklist item whose number the plan has since moved was flagged only a
 which said something had changed but not what, so the only way to find out was to remember what the
 number used to be.
 
-- **Every desynced row now carries an amber chip with both numbers** — `560 → 720/min` for a
-  product, import or export, `4 → 6 buildings` for a power generator. Hovering it spells out the
+- **Every desynced row now carries an amber chip with both numbers** — `560/min → 720/min` for a
+  product, import or export, `4 buildings → 6 buildings` for a power generator. Hovering it spells out the
   two ways forward: build the difference and confirm it, or change the plan back to match what you
   have already built.
 - **Clicking that chip confirms the new number**, exactly as re-ticking the row's checkbox does.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,13 @@ number used to be.
 - **The factory's Checklist chip counts them** — `Checklist: 12/14 · 2 to reconfirm` — instead of
   saying `(desynced)`, so a collapsed factory card tells you whether it is one stale row or nine.
   The sidebar's checklist tooltip counts them the same way.
+- **A desynced checklist is now a factory status of its own**, so it wears an amber **Checklist
+  desync** chip everywhere the other statuses appear — the card header, the sidebar entry, the
+  Factories Summary and the plan- and group-level tallies — carrying the icons of the items that
+  moved, and turning the factory amber like any other warning. Previously the only clue in the
+  sidebar was a counter quietly changing colour, which said a factory was amber without saying why.
+- **The sidebar's checklist counter takes a chip's outline when it is amber**, rather than only
+  changing colour, so it reads as a state to act on rather than a recoloured icon.
 - **The checkboxes on the Products, Imports, Power and Satisfaction rows** carry the same two
   numbers in their hover text, where there is no room for a chip.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,26 @@ Dimensional Depot Uploaders you have put on that item's surplus.
 - Three tooltips that promised sinking was "coming in a future update" now point at the control that
   does it, and the **End product** chip no longer claims the planner assumes you sink it — you say so.
 
+### Checklist: a desynced item now says what changed
+
+A ticked checklist item whose number the plan has since moved was flagged only as "desynced",
+which said something had changed but not what, so the only way to find out was to remember what the
+number used to be.
+
+- **Every desynced row now carries an amber chip with both numbers** — `560 → 720/min` for a
+  product, import or export, `4 → 6 buildings` for a power generator. Hovering it spells out the
+  two ways forward: build the difference and confirm it, or change the plan back to match what you
+  have already built.
+- **Clicking that chip confirms the new number**, exactly as re-ticking the row's checkbox does.
+- **The Checklist panel opens with an amber summary** when anything has drifted, saying how many
+  items are affected, with a **Reconfirm all** button for when you have already rebuilt the lot.
+  Reconfirming only touches rows that actually moved — an item you never ticked stays unticked.
+- **The factory's Checklist chip counts them** — `Checklist: 12/14 · 2 to reconfirm` — instead of
+  saying `(desynced)`, so a collapsed factory card tells you whether it is one stale row or nine.
+  The sidebar's checklist tooltip counts them the same way.
+- **The checkboxes on the Products, Imports, Power and Satisfaction rows** carry the same two
+  numbers in their hover text, where there is no room for a chip.
+
 ### Interface
 
 - **Every dialog in the planner now has the same header and spacing.** Vuetify's stock card title sat the heading flush in the top-left corner with no breathing room, and each dialog had drifted its own way from there: some closed from a button at the bottom of the actions row, some had no way out but the scrim, and body text came in three different sizes. They now share one shell — a padded title row with the icon beside the heading, the close button in the top-right corner where a dialog's way out belongs, and body text at a single size. Dialogs that ask for a decision before they will go away (the out-of-sync prompt, the update-required notice) still have no corner close, deliberately.

--- a/web/src/components.d.ts
+++ b/web/src/components.d.ts
@@ -22,6 +22,7 @@ declare module 'vue' {
     BuildingGroups: typeof import('./components/planner/products/BuildingGroups.vue')['default']
     BuildingGroupsSection: typeof import('./components/planner/products/BuildingGroupsSection.vue')['default']
     BuildingGroupTutorial: typeof import('./components/planner/products/BuildingGroupTutorial.vue')['default']
+    ChecklistDesyncChip: typeof import('./components/planner/ChecklistDesyncChip.vue')['default']
     ChecklistTutorial: typeof import('./components/planner/ChecklistTutorial.vue')['default']
     Copyright: typeof import('./components/Copyright.vue')['default']
     CustomBuilding: typeof import('./components/planner/products/CustomBuilding.vue')['default']

--- a/web/src/components/planner/ChecklistDesyncChip.vue
+++ b/web/src/components/planner/ChecklistDesyncChip.vue
@@ -1,0 +1,36 @@
+<!--
+  The amber flag on a ticked checklist row whose number has since moved.
+
+  It carries the two numbers rather than the bare word "Desynced": knowing that something changed
+  is not actionable, knowing it went from 560/min to 720/min is — the player can tell at a glance
+  whether that is a belt upgrade or a whole new mine, without opening anything. Clicking it is the
+  acknowledgement ("yes, I have built that"), the same action as re-ticking the row's checkbox;
+  the tooltip states the other option, which is to change the plan back instead.
+-->
+<template>
+  <tooltip :text="checklistDesyncReason(desync)">
+    <v-chip
+      class="sf-chip sf-chip-clickable x-small status-warning no-margin"
+      @click="emit('acknowledge')"
+    >
+      <i class="fas fa-exclamation-triangle" />
+      <span class="ml-2">{{ checklistDesyncChange(desync) }}</span>
+    </v-chip>
+  </tooltip>
+</template>
+
+<script setup lang="ts">
+  import {
+    ChecklistDesync,
+    checklistDesyncChange,
+    checklistDesyncReason,
+  } from '@/utils/factory-management/checklist'
+
+  defineProps<{
+    desync: ChecklistDesync
+  }>()
+
+  const emit = defineEmits<{
+    (e: 'acknowledge'): void
+  }>()
+</script>

--- a/web/src/components/planner/PlannerFactory.vue
+++ b/web/src/components/planner/PlannerFactory.vue
@@ -91,11 +91,17 @@
                 <v-chip
                   class="sf-chip sf-chip-clickable small no-margin"
                   :class="checklistChipClass(factory)"
+                  :title="checklistChipTitle"
                   @click="navigateToFactory(factory.id, `${factory.id}-checklist`)"
                 >
                   <i class="fas fa-check" />
                   <span class="ml-2">Checklist: {{ countChecklistCompleted(factory) }}/{{ countChecklistTotal(factory) }}</span>
-                  <span v-if="hasChecklistDesync(factory)" class="ml-2">(desynced)</span>
+                  <!-- The count, not the bare word "desynced": a collapsed card is often all the
+                       player sees of a factory, and one stale row is a very different afternoon
+                       from nine. What each one actually changed is on the rows themselves. -->
+                  <span v-if="checklistDesyncCount > 0" class="ml-2">
+                    &middot; {{ checklistDesyncCount }} to reconfirm
+                  </span>
                 </v-chip>
               </div>
               <!-- power difference chip -->
@@ -470,8 +476,8 @@
   import {
     checklistChipClass,
     countChecklistCompleted,
+    countChecklistDesynced,
     countChecklistTotal,
-    hasChecklistDesync,
     setChecklistEnabled,
   } from '@/utils/factory-management/checklist'
   import { useAppStore } from '@/stores/app-store'
@@ -559,6 +565,17 @@
 
   // Header chips: net power and total somersloops / power shards across the whole
   // factory (products + power producers).
+  const checklistDesyncCount = computed(() => countChecklistDesynced(props.factory))
+
+  // The card's chip is often read collapsed, with the checklist panel out of sight, so the hover
+  // has to carry both the problem and where to go for the detail.
+  const checklistChipTitle = computed(() => {
+    const count = checklistDesyncCount.value
+    if (count === 0) return 'Open this factory\'s checklist'
+    return `${count} ticked ${count === 1 ? 'item was' : 'items were'} built to a number the plan ` +
+      'has since changed. Open the checklist to see what changed on each.'
+  })
+
   const factoryPowerDifference = computed(() =>
     (props.factory.power?.produced ?? 0) - (props.factory.power?.consumed ?? 0),
   )

--- a/web/src/components/planner/PlannerFactoryChecklist.vue
+++ b/web/src/components/planner/PlannerFactoryChecklist.vue
@@ -6,7 +6,8 @@
           <i class="fas fa-check-square" /><span class="ml-3">Checklist</span>
         </div>
         <v-chip class="sf-chip small no-margin" :class="checklistChipClass(factory)">
-          {{ completedCount }}/{{ totalCount }} {{ hasChecklistDesync(factory) ? 'ticked, needs reconfirming' : 'complete' }}
+          {{ completedCount }}/{{ totalCount }}
+          {{ desyncs.length > 0 ? `ticked, ${desyncs.length} to reconfirm` : 'complete' }}
         </v-chip>
       </v-col>
       <v-col class="text-right" cols="4">
@@ -29,6 +30,34 @@
       </v-col>
     </v-row>
     <v-card-text v-if="!factory.checklistPanelHidden" class="text-body-1">
+      <!-- The one place that says what to DO about a desync. The per-row chips below say what
+           changed on each row; this says why the factory is amber at all, and offers the bulk
+           acknowledgement for the common case of "I already rebuilt the lot". -->
+      <div v-if="desyncs.length > 0" class="desync-banner mb-4">
+        <div class="d-flex align-center flex-wrap ga-2">
+          <i class="fas fa-exclamation-triangle" />
+          <span>
+            <b>{{ desyncs.length }}</b>
+            {{ desyncs.length === 1 ? 'ticked item has' : 'ticked items have' }}
+            changed since you marked
+            {{ desyncs.length === 1 ? 'it' : 'them' }} as built.
+          </span>
+          <v-btn
+            class="ml-auto"
+            color="primary"
+            prepend-icon="fas fa-check-double"
+            size="small"
+            variant="flat"
+            @click="acknowledgeChecklistDesyncs(factory)"
+          >Reconfirm all
+          </v-btn>
+        </div>
+        <p class="text-body-2 mt-2 mb-0">
+          Each one is flagged below with the number it was ticked at and the number the plan asks
+          for now. Build the difference and reconfirm it, or change the plan back to match what you
+          have already built.
+        </p>
+      </div>
       <p v-if="totalCount === 0" class="text-body-2">
         Nothing to check off yet: add products, power producers, imports or exports to this factory.
       </p>
@@ -54,7 +83,11 @@
               width="24"
             />
             <span class="ml-2">{{ getPartDisplayName(product.id) }}</span>
-            <v-chip v-if="isProductChecklistDesynced(product)" class="sf-chip x-small status-warning no-margin">Desynced</v-chip>
+            <checklist-desync-chip
+              v-if="productChecklistDesync(product)"
+              :desync="productChecklistDesync(product)!"
+              @acknowledge="toggleChecklistProduct(factory, product)"
+            />
           </div>
         </div>
         <div v-if="factory.powerProducers.length > 0" class="checklist-group">
@@ -78,7 +111,11 @@
               width="24"
             />
             <span class="ml-2">{{ getPowerProducerDisplayName(producer) }}</span>
-            <v-chip v-if="isPowerProducerChecklistDesynced(producer)" class="sf-chip x-small status-warning no-margin">Desynced</v-chip>
+            <checklist-desync-chip
+              v-if="powerProducerChecklistDesync(producer)"
+              :desync="powerProducerChecklistDesync(producer)!"
+              @acknowledge="toggleChecklistPowerProducer(factory, producer)"
+            />
           </div>
         </div>
         <div v-if="factory.inputs.length > 0" class="checklist-group">
@@ -119,7 +156,11 @@
                 @click.stop="navigateToFactory(input.factoryId)"
               />
             </v-chip>
-            <v-chip v-if="isInputChecklistDesynced(input)" class="sf-chip x-small status-warning no-margin">Desynced</v-chip>
+            <checklist-desync-chip
+              v-if="inputChecklistDesync(input)"
+              :desync="inputChecklistDesync(input)!"
+              @acknowledge="toggleChecklistInput(factory, input)"
+            />
           </div>
         </div>
         <div v-if="exportRequests.length > 0" class="checklist-group">
@@ -162,10 +203,11 @@
                 @click.stop="navigateToFactory(request.requestingFactoryId)"
               />
             </v-chip>
-            <v-chip
-              v-if="isChecklistExportDesynced(factory, request.requestingFactoryId, request.part, request.amount)"
-              class="sf-chip x-small status-warning no-margin"
-            >Desynced</v-chip>
+            <checklist-desync-chip
+              v-if="checklistExportDesync(factory, request.requestingFactoryId, request.part, request.amount)"
+              :desync="checklistExportDesync(factory, request.requestingFactoryId, request.part, request.amount)!"
+              @acknowledge="toggleChecklistExport(factory, request.requestingFactoryId, request.part, request.amount)"
+            />
           </div>
         </div>
       </template>
@@ -180,15 +222,20 @@
   import { getPowerProducerDisplayName } from '@/utils/factory-management/common'
   import { getRequestsForFactory } from '@/utils/factory-management/exports'
   import {
+    acknowledgeChecklistDesyncs,
     checklistChipClass,
+    checklistExportDesync,
     countChecklistCompleted,
     countChecklistTotal,
-    hasChecklistDesync,
+    inputChecklistDesync,
     isChecklistExportComplete,
     isChecklistExportDesynced,
     isInputChecklistDesynced,
     isPowerProducerChecklistDesynced,
     isProductChecklistDesynced,
+    listChecklistDesyncs,
+    powerProducerChecklistDesync,
+    productChecklistDesync,
     setChecklistPanelHidden,
     toggleChecklistExport,
     toggleChecklistInput,
@@ -210,9 +257,23 @@
   const totalCount = computed(() => countChecklistTotal(props.factory))
   const completedCount = computed(() => countChecklistCompleted(props.factory))
   const exportRequests = computed(() => getRequestsForFactory(props.factory))
+  const desyncs = computed(() => listChecklistDesyncs(props.factory))
 </script>
 
 <style lang="scss" scoped>
+// Amber card rather than a chip: it holds a sentence, a paragraph and a button, and reads as the
+// panel's own state instead of one more label in the row of them above.
+.desync-banner {
+  background-color: var(--sf-status-warning-bg);
+  border: 1px solid var(--sf-status-warning-border);
+  border-radius: 4px;
+  padding: 12px;
+
+  > div > i {
+    color: var(--sf-status-warning);
+  }
+}
+
 .checklist-group {
   margin-bottom: 16px;
 

--- a/web/src/components/planner/PlannerFactorySatisfactionItems.vue
+++ b/web/src/components/planner/PlannerFactorySatisfactionItems.vue
@@ -503,7 +503,7 @@
                     :checked="isChecklistExportComplete(factory, request.requestingFactoryId, partId.toString())"
                     class="checklist-tick"
                     :class="{ desynced: isChecklistExportDesynced(factory, request.requestingFactoryId, partId.toString(), request.amount) }"
-                    :title="isChecklistExportDesynced(factory, request.requestingFactoryId, partId.toString(), request.amount) ? 'Built amount no longer matches the plan — click to re-confirm' : 'Mark this export as built'"
+                    :title="checklistTickTitle(checklistExportDesync(factory, request.requestingFactoryId, partId.toString(), request.amount), 'Mark this export as built')"
                     type="checkbox"
                     @click.prevent="toggleChecklistExport(factory, request.requestingFactoryId, partId.toString(), request.amount)"
                   >
@@ -606,7 +606,13 @@
     isUnhandledByproduct,
     showBacklogAdvisory,
   } from '@/utils/factory-management/status'
-  import { isChecklistExportComplete, isChecklistExportDesynced, toggleChecklistExport } from '@/utils/factory-management/checklist'
+  import {
+    checklistExportDesync,
+    checklistTickTitle,
+    isChecklistExportComplete,
+    isChecklistExportDesynced,
+    toggleChecklistExport,
+  } from '@/utils/factory-management/checklist'
   import { formatNumber } from '@/utils/numberFormatter'
   import { useAppStore } from '@/stores/app-store'
   import {

--- a/web/src/components/planner/groups/PlannerSidebarFactoryRow.vue
+++ b/web/src/components/planner/groups/PlannerSidebarFactoryRow.vue
@@ -69,7 +69,9 @@
           </template>
           <span>
             Checklist: {{ countChecklistCompleted(factory) }}/{{ countChecklistTotal(factory) }}
-            {{ hasChecklistDesync(factory) ? 'ticked, but some numbers have changed since' : 'complete' }}
+            {{ checklistDesyncCount > 0
+              ? `ticked, ${checklistDesyncCount} of them at a number that has since changed`
+              : 'complete' }}
           </span>
         </v-tooltip>
         <v-tooltip right>
@@ -134,8 +136,8 @@
   import {
     checklistTextClass,
     countChecklistCompleted,
+    countChecklistDesynced,
     countChecklistTotal,
-    hasChecklistDesync,
   } from '@/utils/factory-management/checklist'
   import { useFactoryDrag } from '@/composables/useFactoryDrag'
   import FactoryStatusChips from '@/components/planner/FactoryStatusChips.vue'
@@ -164,6 +166,8 @@
   const { dragEnabled } = useFactoryDrag()
 
   const iconDialogOpen = ref(false)
+
+  const checklistDesyncCount = computed(() => countChecklistDesynced(props.factory))
 
   const rowClass = computed(() => ({
     'factory-card': true,

--- a/web/src/components/planner/groups/PlannerSidebarFactoryRow.vue
+++ b/web/src/components/planner/groups/PlannerSidebarFactoryRow.vue
@@ -54,10 +54,14 @@
         </v-tooltip>
         <v-tooltip right>
           <template #activator="{ props: activatorProps }">
+            <!-- Desynced, this stops being a plain grey counter and takes a chip's outline. Amber
+                 text alone left the row's only explanation of its amber border sitting in a
+                 tooltip; an outlined pill reads as a state the reader is meant to act on, and
+                 matches the amber Checklist chip on the card the row points at. -->
             <v-col
               v-if="factory.checklistEnabled"
               class="context-icon align-content-center text-center py-0 px-1"
-              :class="checklistTextClass(factory)"
+              :class="[checklistTextClass(factory), { 'checklist-desynced': checklistDesyncCount > 0 }]"
               cols="auto"
               v-bind="activatorProps"
               @click="navigateToFactory(factory.id, `${factory.id}-checklist`)"
@@ -230,6 +234,22 @@
 
   &:hover {
     color: white;
+  }
+
+  // The chip look, borrowed from .sf-chip.status-warning rather than reaching for a v-chip: this
+  // sits in a fixed-width icon strip beside the tasks and notes glyphs, and a real chip's own
+  // padding and height would push that row out of line.
+  &.checklist-desynced {
+    align-self: center;
+    background-color: var(--sf-status-warning-bg);
+    border: 1px solid var(--sf-status-warning-border);
+    border-radius: 4px;
+    padding: 1px 6px !important;
+    white-space: nowrap;
+
+    &:hover {
+      color: var(--sf-status-warning);
+    }
   }
 }
 </style>

--- a/web/src/components/planner/imports/Imports.vue
+++ b/web/src/components/planner/imports/Imports.vue
@@ -35,7 +35,7 @@
             :checked="!!input.completed"
             class="checklist-tick"
             :class="{ desynced: isInputChecklistDesynced(input) }"
-            :title="isInputChecklistDesynced(input) ? 'Built amount no longer matches the plan — click to re-confirm' : 'Mark this import as built'"
+            :title="checklistTickTitle(inputChecklistDesync(input), 'Mark this import as built')"
             type="checkbox"
             @click.prevent="toggleChecklistInput(factory, input)"
           >
@@ -237,7 +237,12 @@
   import { useAppStore } from '@/stores/app-store'
   import { useGameDataStore } from '@/stores/game-data-store'
   import { getExportableFactories } from '@/utils/factory-management/exports'
-  import { isInputChecklistDesynced, toggleChecklistInput } from '@/utils/factory-management/checklist'
+  import {
+    checklistTickTitle,
+    inputChecklistDesync,
+    isInputChecklistDesynced,
+    toggleChecklistInput,
+  } from '@/utils/factory-management/checklist'
   import { productRowId } from '@/utils/factory-management/products'
   import { useDebouncedAction } from '@/composables/useDebouncedAction'
 

--- a/web/src/components/planner/products/PowerProducer.vue
+++ b/web/src/components/planner/products/PowerProducer.vue
@@ -44,7 +44,7 @@
           :checked="!!producer.completed"
           class="checklist-tick"
           :class="{ desynced: isPowerProducerChecklistDesynced(producer) }"
-          :title="isPowerProducerChecklistDesynced(producer) ? 'Built amount no longer matches the plan — click to re-confirm' : 'Mark this generator as built'"
+          :title="checklistTickTitle(powerProducerChecklistDesync(producer), 'Mark this generator as built')"
           type="checkbox"
           @click.prevent="toggleChecklistPowerProducer(factory, producer)"
         >
@@ -304,7 +304,12 @@
   import { inject } from 'vue'
   import { deleteItem, getBuildingDisplayName } from '@/utils/factory-management/common'
   import { isPotentialBlockage, isUnhandledByproduct } from '@/utils/factory-management/status'
-  import { isPowerProducerChecklistDesynced, toggleChecklistPowerProducer } from '@/utils/factory-management/checklist'
+  import {
+    checklistTickTitle,
+    isPowerProducerChecklistDesynced,
+    powerProducerChecklistDesync,
+    toggleChecklistPowerProducer,
+  } from '@/utils/factory-management/checklist'
   import { addPowerProducerBuildingGroup } from '@/utils/factory-management/building-groups/power'
   import { productRowId } from '@/utils/factory-management/products'
   import { useDebouncedAction } from '@/composables/useDebouncedAction'

--- a/web/src/components/planner/products/Product.vue
+++ b/web/src/components/planner/products/Product.vue
@@ -53,7 +53,7 @@
           :checked="!!product.completed"
           class="checklist-tick"
           :class="{ desynced: isProductChecklistDesynced(product) }"
-          :title="isProductChecklistDesynced(product) ? 'Built amount no longer matches the plan — click to re-confirm' : 'Mark this product as built'"
+          :title="checklistTickTitle(productChecklistDesync(product), 'Mark this product as built')"
           type="checkbox"
           @click.prevent="toggleChecklistProduct(factory, product)"
         >
@@ -320,7 +320,12 @@
     updateProductAmountViaRequirement,
   } from '@/utils/factory-management/products'
   import { isEndProduct, isPotentialBlockage, isUnhandledByproduct } from '@/utils/factory-management/status'
-  import { isProductChecklistDesynced, toggleChecklistProduct } from '@/utils/factory-management/checklist'
+  import {
+    checklistTickTitle,
+    isProductChecklistDesynced,
+    productChecklistDesync,
+    toggleChecklistProduct,
+  } from '@/utils/factory-management/checklist'
   import { getPartDisplayName } from '@/utils/helpers'
   import { fixTargetSuffix, formatMw, formatNumberFully } from '@/utils/numberFormatter'
   import { Factory, FactoryItem, ItemType } from '@/interfaces/planner/FactoryInterface'

--- a/web/src/utils/factory-management/checklist.spec.ts
+++ b/web/src/utils/factory-management/checklist.spec.ts
@@ -225,9 +225,10 @@ describe('checklist', () => {
     })
 
     it('phrases the change for a chip and the reason for a tooltip', () => {
-      expect(checklistDesyncChange({ from: 560, to: 720, unit: 'perMin' })).toBe('560 → 720/min')
-      expect(checklistDesyncChange({ from: 4, to: 6, unit: 'buildings' })).toBe('4 → 6 buildings')
-      expect(checklistDesyncChange({ from: 2, to: 1, unit: 'buildings' })).toBe('2 → 1 building')
+      // Both sides carry the unit: "560 → 720/min" reads as though only the second were a rate.
+      expect(checklistDesyncChange({ from: 560, to: 720, unit: 'perMin' })).toBe('560/min → 720/min')
+      expect(checklistDesyncChange({ from: 4, to: 6, unit: 'buildings' })).toBe('4 buildings → 6 buildings')
+      expect(checklistDesyncChange({ from: 2, to: 1, unit: 'buildings' })).toBe('2 buildings → 1 building')
 
       const reason = checklistDesyncReason({ from: 560, to: 720, unit: 'perMin' })
       expect(reason).toContain('560/min')

--- a/web/src/utils/factory-management/checklist.spec.ts
+++ b/web/src/utils/factory-management/checklist.spec.ts
@@ -6,17 +6,27 @@ import { setSyncState } from '@/utils/factory-management/syncState'
 import { mockPowerProducer } from '@/utils/factory-management/status-fixtures'
 import eventBus from '@/utils/eventBus'
 import {
+  acknowledgeChecklistDesyncs,
+  checklistDesyncChange,
+  checklistDesyncReason,
+  checklistExportDesync,
   checklistExportKey,
   checklistSummaryState,
+  checklistTickTitle,
   countChecklistCompleted,
+  countChecklistDesynced,
   countChecklistTotal,
   hasChecklistDesync,
+  inputChecklistDesync,
   isChecklistComplete,
   isChecklistExportComplete,
   isChecklistExportDesynced,
   isInputChecklistDesynced,
   isPowerProducerChecklistDesynced,
   isProductChecklistDesynced,
+  listChecklistDesyncs,
+  powerProducerChecklistDesync,
+  productChecklistDesync,
   resetChecklistState,
   setChecklistEnabled,
   setChecklistPanelHidden,
@@ -183,6 +193,118 @@ describe('checklist', () => {
       expect(isChecklistExportComplete(provider, consumer.id, 'IronPlate')).toBe(true)
     })
   })
+  // The point of keeping the baseline is being able to say WHAT moved, not just that something
+  // did: "Coal export 560 -> 720/min" is actionable, "desynced" is not.
+  describe('desync reasons', () => {
+    it('reports the pair of numbers behind each kind of desync, with the right unit', () => {
+      const factory = newFactory('Provider', 0, 1)
+
+      const product: FactoryItem = { id: 'IronPlate', recipe: 'IronPlate', amount: 100, displayOrder: 0, requirements: {}, buildingRequirements: { name: 'assemblermk1', amount: 1 }, buildingGroups: [], buildingGroupsTrayOpen: false, buildingGroupsHaveProblem: false, buildingGroupItemSync: true }
+      toggleChecklistProduct(factory, product)
+      expect(productChecklistDesync(product)).toBeNull()
+      product.amount = 150
+      expect(productChecklistDesync(product)).toEqual({ from: 100, to: 150, unit: 'perMin' })
+
+      const input = { factoryId: 99, outputPart: 'IronIngot', amount: 400 }
+      toggleChecklistInput(factory, input)
+      input.amount = 380
+      expect(inputChecklistDesync(input)).toEqual({ from: 400, to: 380, unit: 'perMin' })
+
+      // A generator's baseline is a building count, not a rate. The unit travels with the numbers
+      // so a chip cannot label four generators as 4/min.
+      const producer = mockPowerProducer('generatorcoal', { buildingAmount: 4 })
+      toggleChecklistPowerProducer(factory, producer)
+      producer.buildingAmount = 6
+      expect(powerProducerChecklistDesync(producer)).toEqual({ from: 4, to: 6, unit: 'buildings' })
+
+      toggleChecklistExport(factory, 2, 'Coal', 560)
+      expect(checklistExportDesync(factory, 2, 'Coal', 560)).toBeNull()
+      expect(checklistExportDesync(factory, 2, 'Coal', 720)).toEqual({ from: 560, to: 720, unit: 'perMin' })
+      // Never ticked: no reason to report, whatever the amount does.
+      expect(checklistExportDesync(factory, 3, 'Coal', 720)).toBeNull()
+    })
+
+    it('phrases the change for a chip and the reason for a tooltip', () => {
+      expect(checklistDesyncChange({ from: 560, to: 720, unit: 'perMin' })).toBe('560 → 720/min')
+      expect(checklistDesyncChange({ from: 4, to: 6, unit: 'buildings' })).toBe('4 → 6 buildings')
+      expect(checklistDesyncChange({ from: 2, to: 1, unit: 'buildings' })).toBe('2 → 1 building')
+
+      const reason = checklistDesyncReason({ from: 560, to: 720, unit: 'perMin' })
+      expect(reason).toContain('560/min')
+      expect(reason).toContain('720/min')
+
+      // The inline ticks have no room for a chip, so they carry the same sentence — and their
+      // ordinary label when there is nothing to say.
+      expect(checklistTickTitle(null, 'Mark this product as built')).toBe('Mark this product as built')
+      expect(checklistTickTitle({ from: 560, to: 720, unit: 'perMin' }, 'Mark this product as built')).toBe(reason)
+    })
+
+    it('lists every desynced row in the factory, tagged with what it is and what it points at', () => {
+      const provider = newFactory('Provider', 0, 1)
+      const consumer = newFactory('Consumer', 1, 2)
+
+      provider.products.push({ id: 'IronPlate', recipe: 'IronPlate', amount: 100, displayOrder: 0, requirements: {}, buildingRequirements: { name: 'assemblermk1', amount: 1 }, buildingGroups: [], buildingGroupsTrayOpen: false, buildingGroupsHaveProblem: false, buildingGroupItemSync: true })
+      provider.inputs.push({ factoryId: 99, outputPart: 'IronIngot', amount: 200 })
+      provider.powerProducers.push(mockPowerProducer('generatorcoal', { buildingAmount: 4 }))
+      updateDependency(consumer, provider, { factoryId: consumer.id, outputPart: 'IronPlate', amount: 60 })
+
+      toggleChecklistProduct(provider, provider.products[0])
+      toggleChecklistInput(provider, provider.inputs[0])
+      toggleChecklistPowerProducer(provider, provider.powerProducers[0])
+      toggleChecklistExport(provider, consumer.id, 'IronPlate', 60)
+
+      expect(listChecklistDesyncs(provider)).toEqual([])
+      expect(countChecklistDesynced(provider)).toBe(0)
+
+      provider.products[0].amount = 120
+      provider.inputs[0].amount = 240
+      provider.powerProducers[0].buildingAmount = 5
+      provider.dependencies.requests[consumer.id][0].amount = 45
+
+      expect(listChecklistDesyncs(provider)).toEqual([
+        { kind: 'product', part: 'IronPlate', desync: { from: 100, to: 120, unit: 'perMin' } },
+        { kind: 'power', building: 'generatorcoal', desync: { from: 4, to: 5, unit: 'buildings' } },
+        { kind: 'import', part: 'IronIngot', factoryId: 99, desync: { from: 200, to: 240, unit: 'perMin' } },
+        { kind: 'export', part: 'IronPlate', factoryId: consumer.id, desync: { from: 60, to: 45, unit: 'perMin' } },
+      ])
+      expect(countChecklistDesynced(provider)).toBe(4)
+    })
+
+    it('acknowledgeChecklistDesyncs re-baselines every moved row and leaves untouched ones alone', () => {
+      const provider = newFactory('Provider', 0, 1)
+      const consumer = newFactory('Consumer', 1, 2)
+
+      provider.products.push(
+        { id: 'IronPlate', recipe: 'IronPlate', amount: 100, displayOrder: 0, requirements: {}, buildingRequirements: { name: 'assemblermk1', amount: 1 }, buildingGroups: [], buildingGroupsTrayOpen: false, buildingGroupsHaveProblem: false, buildingGroupItemSync: true },
+        { id: 'IronRod', recipe: 'IronRod', amount: 50, displayOrder: 1, requirements: {}, buildingRequirements: { name: 'constructormk1', amount: 1 }, buildingGroups: [], buildingGroupsTrayOpen: false, buildingGroupsHaveProblem: false, buildingGroupItemSync: true },
+      )
+      provider.inputs.push({ factoryId: 99, outputPart: 'IronIngot', amount: 200 })
+      provider.powerProducers.push(mockPowerProducer('generatorcoal', { buildingAmount: 4 }))
+      updateDependency(consumer, provider, { factoryId: consumer.id, outputPart: 'IronPlate', amount: 60 })
+
+      toggleChecklistProduct(provider, provider.products[0])
+      toggleChecklistInput(provider, provider.inputs[0])
+      toggleChecklistPowerProducer(provider, provider.powerProducers[0])
+      toggleChecklistExport(provider, consumer.id, 'IronPlate', 60)
+
+      provider.products[0].amount = 120
+      provider.inputs[0].amount = 240
+      provider.powerProducers[0].buildingAmount = 5
+      provider.dependencies.requests[consumer.id][0].amount = 45
+
+      acknowledgeChecklistDesyncs(provider)
+
+      expect(hasChecklistDesync(provider)).toBe(false)
+      // Acknowledging is not ticking: the never-ticked product stays unticked and unbaselined, so
+      // it cannot start reading as desynced later off a baseline it never asked for.
+      expect(provider.products[1].completed).toBeFalsy()
+      expect(provider.products[1].checklistSyncedAmount).toBeUndefined()
+      // And the ticks that were already there stay ticked.
+      expect(provider.products[0].completed).toBe(true)
+      expect(isChecklistExportComplete(provider, consumer.id, 'IronPlate')).toBe(true)
+    })
+  })
+
   // Every checklist mutation has to dirty the plan. Nothing else does it for them: the cloud
   // dirty flag and the local persist both hang off `factoryUpdated`, and checklist mode is the
   // one feature where a whole session can be nothing but ticks. Without this a build session

--- a/web/src/utils/factory-management/checklist.ts
+++ b/web/src/utils/factory-management/checklist.ts
@@ -9,9 +9,12 @@
 // Desync tracking: every checked item also stamps a `checklistSyncedAmount` baseline (the export
 // equivalent lives in factory.checklistExportSyncedAmounts, same keying as checklistExports). If
 // the plan's own number for that item later drifts away from the baseline, the item is "desynced"
-// — ticked as built, but the plan has since asked for something different. Toggling an item back
-// to checked re-stamps the baseline, which is how a player acknowledges the new number. Marking
-// the whole factory in sync with the game (setSyncState) re-stamps every baseline at once.
+// — ticked as built, but the plan has since asked for something different. Because the baseline is
+// kept, the flag can say what actually changed rather than only that something did: the pair of
+// numbers is the primitive (ChecklistDesync), and "is it desynced" derives from it. Toggling an
+// item back to checked re-stamps the baseline, which is how a player acknowledges the new number;
+// acknowledgeChecklistDesyncs does the same for every moved row at once. Marking the whole factory
+// in sync with the game (setSyncState) re-stamps every baseline, moved or not.
 //
 // Every mutation here emits `factoryUpdated`. That is the only thing that sets the cloud-sync
 // dirty flag and schedules a local persist, and checklist mode is the one feature where a whole
@@ -21,6 +24,7 @@
 import { Factory, FactoryInput, FactoryItem, FactoryPowerProducer } from '@/interfaces/planner/FactoryInterface'
 import { getRequestsForFactory } from '@/utils/factory-management/exports'
 import { setSyncState } from '@/utils/factory-management/syncState'
+import { formatNumber } from '@/utils/numberFormatter'
 import eventBus from '@/utils/eventBus'
 
 export const checklistExportKey = (requestingFactoryId: number | string, part: string): string =>
@@ -120,30 +124,171 @@ export const setChecklistPanelHidden = (factory: Factory, hidden: boolean): void
   eventBus.emit('factoryUpdated', factory)
 }
 
-// Desynced: ticked as built, but the number it was ticked against has since moved. An absent
-// baseline (never ticked since this existed) must read as "not desynced" rather than firing on
-// every old save the first time it loads.
+// Desynced: ticked as built, but the number it was ticked against has since moved. What the
+// player needs is not that something moved but WHAT moved and by how much, so the primitive here
+// is the pair of numbers, and "is it desynced" is derived from it. An absent baseline (never
+// ticked since this existed) must read as "not desynced" rather than firing on every old save the
+// first time it loads.
+//
+// Products, imports and exports are rates; a power producer's baseline is a building count. The
+// unit rides along so a chip 200 lines away cannot mislabel 40 generators as 40/min.
+export type ChecklistDesyncUnit = 'perMin' | 'buildings'
+
+export interface ChecklistDesync {
+  // The number this item was ticked against.
+  from: number
+  // What the plan asks for now.
+  to: number
+  unit: ChecklistDesyncUnit
+}
+
+const desyncBetween = (
+  completed: boolean,
+  baseline: number | undefined,
+  current: number,
+  unit: ChecklistDesyncUnit
+): ChecklistDesync | null =>
+  completed && baseline !== undefined && baseline !== current
+    ? { from: baseline, to: current, unit }
+    : null
+
+export const productChecklistDesync = (product: FactoryItem): ChecklistDesync | null =>
+  desyncBetween(!!product.completed, product.checklistSyncedAmount, product.amount, 'perMin')
+
+export const inputChecklistDesync = (input: FactoryInput): ChecklistDesync | null =>
+  desyncBetween(!!input.completed, input.checklistSyncedAmount, input.amount, 'perMin')
+
+export const powerProducerChecklistDesync = (producer: FactoryPowerProducer): ChecklistDesync | null =>
+  desyncBetween(
+    !!producer.completed,
+    producer.checklistSyncedAmount,
+    producer.buildingAmount,
+    'buildings'
+  )
+
+export const checklistExportDesync = (
+  factory: Factory,
+  requestingFactoryId: number | string,
+  part: string,
+  amount: number
+): ChecklistDesync | null =>
+  desyncBetween(
+    isChecklistExportComplete(factory, requestingFactoryId, part),
+    factory.checklistExportSyncedAmounts[checklistExportKey(requestingFactoryId, part)],
+    amount,
+    'perMin'
+  )
+
 export const isProductChecklistDesynced = (product: FactoryItem): boolean =>
-  !!product.completed && product.checklistSyncedAmount !== undefined &&
-  product.checklistSyncedAmount !== product.amount
+  productChecklistDesync(product) !== null
 
 export const isInputChecklistDesynced = (input: FactoryInput): boolean =>
-  !!input.completed && input.checklistSyncedAmount !== undefined &&
-  input.checklistSyncedAmount !== input.amount
+  inputChecklistDesync(input) !== null
 
 export const isPowerProducerChecklistDesynced = (producer: FactoryPowerProducer): boolean =>
-  !!producer.completed && producer.checklistSyncedAmount !== undefined &&
-  producer.checklistSyncedAmount !== producer.buildingAmount
+  powerProducerChecklistDesync(producer) !== null
 
 export const isChecklistExportDesynced = (
   factory: Factory,
   requestingFactoryId: number | string,
   part: string,
   amount: number
-): boolean => {
-  if (!isChecklistExportComplete(factory, requestingFactoryId, part)) return false
-  const synced = factory.checklistExportSyncedAmounts[checklistExportKey(requestingFactoryId, part)]
-  return synced !== undefined && synced !== amount
+): boolean => checklistExportDesync(factory, requestingFactoryId, part, amount) !== null
+
+const desyncValue = (value: number, unit: ChecklistDesyncUnit): string =>
+  unit === 'buildings'
+    ? `${formatNumber(value)} ${value === 1 ? 'building' : 'buildings'}`
+    : `${formatNumber(value)}/min`
+
+// "560 → 720/min". Short enough to sit on the chip beside the row it belongs to, and specific
+// enough that the player can tell at a glance whether the change is worth walking to the factory
+// for. The unit is stated once, on the number that is now true.
+export const checklistDesyncChange = (desync: ChecklistDesync): string =>
+  `${formatNumber(desync.from)} → ${desyncValue(desync.to, desync.unit)}`
+
+// The long form, for tooltips: what changed, and the two things the player can do about it. Both
+// are legitimate — the plan may have moved because they changed their mind, in which case the
+// build is what is wrong, not the tick.
+export const checklistDesyncReason = (desync: ChecklistDesync): string =>
+  `Ticked as built at ${desyncValue(desync.from, desync.unit)}, but the plan now says ` +
+  `${desyncValue(desync.to, desync.unit)}. Build the difference and click to confirm, or change ` +
+  'the plan back.'
+
+// The checklist ticks scattered through the product, import, power and satisfaction rows have no
+// room for a chip beside them, so their native `title` carries the same two numbers the chip in
+// the checklist panel would have shown.
+export const checklistTickTitle = (desync: ChecklistDesync | null, fallback: string): string =>
+  desync ? checklistDesyncReason(desync) : fallback
+
+// One desynced row, named well enough for a summary to list it without re-deriving which of the
+// four lists it came from. Part / building / factory ids stay raw: turning them into display
+// names needs the game data, which is a component's job rather than this module's.
+export type ChecklistDesyncKind = 'product' | 'power' | 'import' | 'export'
+
+export interface ChecklistDesyncEntry {
+  kind: ChecklistDesyncKind
+  desync: ChecklistDesync
+  part?: string
+  building?: string
+  // Imports: the factory supplying it. Exports: the factory asking for it.
+  factoryId?: number | string | null
+}
+
+// Every desynced row in the factory, in the order the checklist panel lists them. Separate from
+// hasChecklistDesync, which stays a short-circuiting `.some()` because it runs for every factory
+// card and sidebar row on every recalculation, whether or not anything is desynced at all.
+export const listChecklistDesyncs = (factory: Factory): ChecklistDesyncEntry[] => {
+  const entries: ChecklistDesyncEntry[] = []
+
+  factory.products.forEach(product => {
+    const desync = productChecklistDesync(product)
+    if (desync) entries.push({ kind: 'product', desync, part: product.id })
+  })
+  factory.powerProducers.forEach(producer => {
+    const desync = powerProducerChecklistDesync(producer)
+    if (desync) entries.push({ kind: 'power', desync, building: producer.building })
+  })
+  factory.inputs.forEach(input => {
+    const desync = inputChecklistDesync(input)
+    if (desync) {
+      entries.push({ kind: 'import', desync, part: input.outputPart ?? undefined, factoryId: input.factoryId })
+    }
+  })
+  getRequestsForFactory(factory).forEach(request => {
+    const desync = checklistExportDesync(factory, request.requestingFactoryId, request.part, request.amount)
+    if (desync) {
+      entries.push({ kind: 'export', desync, part: request.part, factoryId: request.requestingFactoryId })
+    }
+  })
+
+  return entries
+}
+
+export const countChecklistDesynced = (factory: Factory): number => listChecklistDesyncs(factory).length
+
+// Acknowledge every desynced row at once: the same "yes, I have built that change" a re-tick
+// makes, applied to all of them. Only rows that have actually moved are re-stamped, so this can
+// never quietly baseline something the player has not ticked. Deliberately lighter than
+// setSyncState, which also claims the whole factory matches the game.
+export const acknowledgeChecklistDesyncs = (factory: Factory): void => {
+  factory.products.forEach(product => {
+    if (productChecklistDesync(product)) product.checklistSyncedAmount = product.amount
+  })
+  factory.powerProducers.forEach(producer => {
+    if (powerProducerChecklistDesync(producer)) producer.checklistSyncedAmount = producer.buildingAmount
+  })
+  factory.inputs.forEach(input => {
+    if (inputChecklistDesync(input)) input.checklistSyncedAmount = input.amount
+  })
+  getRequestsForFactory(factory).forEach(request => {
+    if (checklistExportDesync(factory, request.requestingFactoryId, request.part, request.amount)) {
+      factory.checklistExportSyncedAmounts[checklistExportKey(request.requestingFactoryId, request.part)] =
+        request.amount
+    }
+  })
+
+  reconcileFactoryInSyncWithGame(factory)
+  eventBus.emit('factoryUpdated', factory)
 }
 
 // Does anything in this factory read as ticked-but-moved? The per-row "Desynced" chips only

--- a/web/src/utils/factory-management/checklist.ts
+++ b/web/src/utils/factory-management/checklist.ts
@@ -200,11 +200,12 @@ const desyncValue = (value: number, unit: ChecklistDesyncUnit): string =>
     ? `${formatNumber(value)} ${value === 1 ? 'building' : 'buildings'}`
     : `${formatNumber(value)}/min`
 
-// "560 → 720/min". Short enough to sit on the chip beside the row it belongs to, and specific
+// "560/min → 720/min". Short enough to sit on the chip beside the row it belongs to, and specific
 // enough that the player can tell at a glance whether the change is worth walking to the factory
-// for. The unit is stated once, on the number that is now true.
+// for. Both numbers carry the unit: stated only on the second, "560 → 720/min" reads as though
+// the first were something else.
 export const checklistDesyncChange = (desync: ChecklistDesync): string =>
-  `${formatNumber(desync.from)} → ${desyncValue(desync.to, desync.unit)}`
+  `${desyncValue(desync.from, desync.unit)} → ${desyncValue(desync.to, desync.unit)}`
 
 // The long form, for tooltips: what changed, and the two things the player can do about it. Both
 // are legitimate — the plan may have moved because they changed their mind, in which case the

--- a/web/src/utils/factory-management/status.spec.ts
+++ b/web/src/utils/factory-management/status.spec.ts
@@ -237,6 +237,60 @@ describe('status', () => {
     })
   })
 
+  describe('checklistDesync', () => {
+    // The product `mockProduct` gives the baseline factory, ticked and then moved.
+    const withDesyncedProduct = (target: Factory) => {
+      target.checklistEnabled = true
+      target.products[0].completed = true
+      target.products[0].checklistSyncedAmount = target.products[0].amount + 50
+    }
+
+    test('does not fire on a factory whose ticked items still match the plan', () => {
+      factory.checklistEnabled = true
+      factory.products[0].completed = true
+      factory.products[0].checklistSyncedAmount = factory.products[0].amount
+
+      expect(typesOf(factory)).not.toContain('checklistDesync')
+    })
+
+    test('does not fire while checklist mode is off, however stale the ticks are', () => {
+      withDesyncedProduct(factory)
+      factory.checklistEnabled = false
+
+      expect(typesOf(factory)).not.toContain('checklistDesync')
+    })
+
+    test('fires as an amber status pointing at the checklist, carrying the moved items', () => {
+      withDesyncedProduct(factory)
+
+      expect(statusOf(factory, 'checklistDesync')).toMatchObject({
+        severity: 'warning',
+        section: 'checklist',
+        label: 'Checklist desync',
+        subjects: [{ id: factory.products[0].id, type: 'item' }],
+      })
+    })
+
+    test('counts the moved rows in its label, and a generator by its building', () => {
+      withDesyncedProduct(factory)
+      factory.powerProducers = [mockPowerProducer('GeneratorCoal', { buildingAmount: 4 })]
+      factory.powerProducers[0].completed = true
+      factory.powerProducers[0].checklistSyncedAmount = 6
+
+      const status = statusOf(factory, 'checklistDesync')
+      expect(status?.label).toBe('2 checklist desyncs')
+      expect(status?.detailLabel).toBe('2 desynced checklist items')
+      expect(status?.subjects).toContainEqual({ id: 'GeneratorCoal', type: 'building' })
+    })
+
+    test('colours the factory amber and jumps at the checklist panel', () => {
+      withDesyncedProduct(factory)
+
+      expect(factoryStatusClass(getFactoryStatuses(factory))).toMatchObject({ problem: false, warning: true })
+      expect(statusJumpTargets(7, { section: 'checklist' }).fallback).toBe('7-checklist')
+    })
+  })
+
   describe('redundantImport', () => {
     test('does not fire for an import the factory actually needs', () => {
       withRequiredImport(factory, 'IronOre')

--- a/web/src/utils/factory-management/status.ts
+++ b/web/src/utils/factory-management/status.ts
@@ -21,9 +21,12 @@
  *
  * This module must stay a LEAF. `problems.ts` imports it and is itself imported by `factory.ts`, so
  * importing anything that reaches `factory.ts` closes a cycle. That is why the import predicates
- * live in `inputs-analysis.ts`.
+ * live in `inputs-analysis.ts`. `checklist.ts` is safe to reach for: its own subtree is
+ * `exports.ts`, `syncState.ts`, `numberFormatter.ts` and the event bus, none of which climb back up
+ * to `factory.ts`.
  */
 import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { listChecklistDesyncs } from '@/utils/factory-management/checklist'
 import { isDuplicateImport, isImportRedundant } from '@/utils/factory-management/inputs-analysis'
 import { isSurplusSignificant } from '@/utils/factory-management/parts'
 import { usePlannerOptions } from '@/composables/usePlannerOptions'
@@ -31,13 +34,14 @@ import { usePlannerOptions } from '@/composables/usePlannerOptions'
 export type FactoryStatusSeverity = 'problem' | 'warning' | 'note'
 
 // Element-id suffix of the card section a status points at, for navigateToFactory().
-export type FactoryStatusSection = 'satisfaction' | 'imports' | 'products'
+export type FactoryStatusSection = 'satisfaction' | 'imports' | 'products' | 'checklist'
 
 export type FactoryStatusType =
   | 'partShortage' |
   'exportShortage' |
   'buildingGroupMismatch' |
   'outOfSync' |
+  'checklistDesync' |
   'unhandledByproduct' |
   'redundantImport' |
   'duplicateImport' |
@@ -304,6 +308,33 @@ export const factoryStatusDefinitions: FactoryStatusDefinition[] = [
     label: () => 'Out of sync',
   },
   {
+    // Amber by the tier rule's second clause: the numbers say the plan moved, but only the player
+    // knows whether the thing standing in the world was rebuilt to match. Its own status rather
+    // than a shade of outOfSync — that one is about the factory's recipes against the game, this
+    // is about individual rows the player ticked, and the two go stale independently.
+    type: 'checklistDesync',
+    severity: 'warning',
+    // The checklist's own glyph, not a warning triangle: the whole point of the chip is that the
+    // reader can tell at a glance which of a card's amber signals this one is.
+    icon: 'fas fa-check-square',
+    chip: true,
+    section: 'checklist',
+    detail: 'Items ticked off as built at a number the plan has since changed. Reconfirm each one, or change the plan back.',
+    // Gated on checklist mode being on: with the panel hidden there is nothing on the card to act
+    // on, and the ticks survive the toggle, so an old plan would otherwise light up amber for a
+    // mode its owner has switched off.
+    detect: factory => {
+      if (!factory.checklistEnabled) return null
+      const desyncs = listChecklistDesyncs(factory)
+      return nonEmpty([
+        ...subjects(desyncs.map(entry => entry.part)),
+        ...subjects(desyncs.map(entry => entry.building), 'building'),
+      ])
+    },
+    label: list => count(list, 'Checklist desync', 'checklist desyncs'),
+    detailLabel: list => count(list, 'Checklist desync', 'desynced checklist items'),
+  },
+  {
     type: 'redundantImport',
     severity: 'warning',
     icon: 'fas fa-arrow-to-right',
@@ -526,6 +557,14 @@ const tallyChipDefinitions: TallyChipDefinition[] = [
     class: 'status-warning',
     label: ['out of sync', 'out of sync'],
     sentence: ['factory is out of sync with the game', 'factories are out of sync with the game'],
+  },
+  {
+    key: 'checklistDesync',
+    types: ['checklistDesync'],
+    icon: 'fas fa-check-square',
+    class: 'status-warning',
+    label: ['checklist desync', 'checklist desyncs'],
+    sentence: ['factory has checklist items ticked at a number that has since changed', 'factories have checklist items ticked at a number that has since changed'],
   },
   {
     key: 'redundantImport',


### PR DESCRIPTION
## What

A ticked checklist item whose plan number has since moved was flagged only as **"Desynced"**. That says something changed but not what, so the only way to find out was to remember the old number. And the only trace of it outside the panel was the sidebar's checklist counter quietly changing colour — a factory going amber with nothing to say why.

This makes the flag state what actually moved, gives the player something to click, and promotes the condition to a proper factory status so it shows up like every other one.

Example from Mael's own plan: *Steel MF Coal Mine #2* had its Coal export to the Steel MegaFac ticked at 560/min, and the plan later asked for 720/min. Before, that read as "Desynced". Now it reads `560/min → 720/min`.

## Changes

### Core — `web/src/utils/factory-management/checklist.ts`

The baseline needed to answer "what changed" was already stored in `checklistSyncedAmount` and `checklistExportSyncedAmounts`. It was just being collapsed into a boolean and thrown away. The primitive is now the pair of numbers:

```ts
interface ChecklistDesync { from: number, to: number, unit: 'perMin' | 'buildings' }
```

`productChecklistDesync` / `inputChecklistDesync` / `powerProducerChecklistDesync` / `checklistExportDesync` each return one or `null`; the existing `is*Desynced` booleans are now thin wrappers over them, so every caller is unchanged. Products, imports and exports carry a rate; a power producer's baseline is a building count, so the unit rides along with the numbers and a chip two hundred lines away cannot mislabel 4 generators as 4/min.

Added alongside: `checklistDesyncChange` (chip text), `checklistDesyncReason` (tooltip sentence), `checklistTickTitle`, `listChecklistDesyncs` / `countChecklistDesynced`, and `acknowledgeChecklistDesyncs`.

### A desynced checklist is now a factory status — `status.ts`

One entry in `factoryStatusDefinitions` plus one tally chip, exactly as that module's own docs prescribe, and every display site picks it up: the card header, the sidebar entry, the Factories Summary, and the plan- and group-level tallies. The chip carries the game icons of the items that moved and jumps to the checklist panel, and the factory colours amber like any other warning.

- **Amber, not red**, by the module's tier rule: the numbers say the plan moved, but only the player knows whether what stands in the world was rebuilt to match.
- **Its own status rather than a shade of `outOfSync`** — that one is about the factory's recipes against the game, this is about individual rows the player ticked, and the two go stale independently.
- **Gated on checklist mode being on.** Ticks and baselines survive the toggle, so without the gate an old plan would light up amber for a mode its owner had switched off, with no panel on the card to act on it.
- `status.ts` reaching for `checklist.ts` keeps the leaf rule it documents: `checklist.ts`'s own subtree is `exports.ts`, `syncState.ts`, `numberFormatter.ts` and the event bus, none of which climb back to `factory.ts`.

### UI

- **Every desynced row wears an amber chip with both numbers** — `560/min → 720/min`, or `4 buildings → 6 buildings`. Both halves carry the unit: stated only on the second, `560 → 720/min` reads as though the first were something else. The tooltip names both ways out — build the difference and confirm, or change the plan back — and clicking the chip confirms, exactly as re-ticking the row's checkbox does.
- **The Checklist panel opens with an amber summary** counting the affected rows, with a **Reconfirm all** button for when the lot has already been rebuilt. It re-baselines only rows that actually moved, so an item that was never ticked stays unticked and unbaselined.
- **The factory's Checklist chip counts them** — `Checklist: 6/6 · 1 to reconfirm` — rather than `(desynced)`, so a collapsed card distinguishes one stale row from nine.
- **The sidebar's checklist counter takes a chip's outline when amber**, rather than only changing colour, so it reads as a state to act on instead of a recoloured icon. Styled from the chip tokens rather than dropping in a `v-chip`: that strip is a fixed-height icon row, and a chip's own padding would push it out of line with the tasks and notes glyphs.
- **The checkboxes on the Products, Imports, Power and Satisfaction rows** carry the same two numbers in their hover text, where there is no room for a chip.

## Testing

- `pnpm test` in `web/`: **2258 passed, 1 skipped** across 116 files. Nine new cases — four in `checklist.spec.ts` covering the reason model per item type, the chip and tooltip phrasing (including the `1 building` singular), `listChecklistDesyncs` ordering and tagging, and that `acknowledgeChecklistDesyncs` leaves never-ticked rows alone; five in `status.spec.ts` covering the new status's gating, subjects, counted labels, amber tier and jump target.
- `pnpm lint-check` clean; `vue-tsc --noEmit` clean.
- Driven end to end in Chromium against the demo plan: enabled Checklist on *Copper Basics*, ticked all six items, changed Wire from 400 to 222/min, and confirmed the row chip reads `400/min → 222/min`, the banner reads "1 ticked item has changed since you marked it as built", the card header gains the amber `Checklist desync` chip beside `Checklist: 6/6 · 1 to reconfirm`, the sidebar row gains the same chip with the Wire icon and an outlined amber counter, the tooltip reads "Ticked as built at 400/min, but the plan now says 222/min…", and **Reconfirm all** returns the panel to `6/6 complete`.

`CHANGELOG.md` updated under Beta v0.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AACaB4MJEFKTomoPftrf3j