### PR TITLE
feat(web): match a power generator's fuel draw to what the factory supplies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,14 @@ number used to be.
 - **The checkboxes on the Products, Imports, Power and Satisfaction rows** carry the same two
   numbers in their hover text, where there is no room for a chip.
 
+### Power generators: match the fuel to what the factory can supply
+
+- **A generator burning fuel its own factory makes now offers to match its draw to the supply**, with the same green **Expand to supply** and yellow **Trim to supply** pair the product rows carry, and the figure it would land on named on the button. A Fuel-Powered Generator set to 1,280 Liquid Fuel a minute in a factory that only has 1,120 spare offers **Trim to supply (1120)**; give the same factory more fuel than the generators are burning and it offers **Expand to supply** instead.
+- **The figure accounts for everything else that wants the fuel**, not just the generators. An oil plant that sends 120 Liquid Fuel a minute to Recycled Rubber and 40 to a Packager has 160 less to burn than it makes, which is exactly the sum this saves you doing by hand. Exports to other factories count too, and so does another generator burning the same fuel.
+- **A surplus the AWESOME Sink is currently mopping up still counts as spare**, because burning fuel beats sinking it — take it, and the sinks drop out of the plan by themselves.
+- The buttons appear only where there is something to match against: a generator whose fuel is entirely imported from elsewhere is left alone, as are Geothermal Generators, which have no fuel, and Alien Power Augmenters, whose matrix demand is decided by their building groups rather than by a rate you can set.
+- **The generator's row now wraps** rather than running off the edge of the card. It is the widest row in the planner, and on a 1440px screen with the sidebar open the new button had nowhere left to go.
+
 ### Interface
 
 - **Every dialog in the planner now has the same header and spacing.** Vuetify's stock card title sat the heading flush in the top-left corner with no breathing room, and each dialog had drifted its own way from there: some closed from a button at the bottom of the actions row, some had no way out but the scrim, and body text came in three different sizes. They now share one shell — a padded title row with the icon beside the heading, the close button in the top-right corner where a dialog's way out belongs, and body text at a single size. Dialogs that ask for a decision before they will go away (the out-of-sync prompt, the update-required notice) still have no corner close, deliberately.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,7 +163,7 @@ number used to be.
 - **A surplus the AWESOME Sink is currently mopping up still counts as spare**, because burning fuel beats sinking it — take it, and the sinks drop out of the plan by themselves.
 - The buttons appear only where there is something to match against: a generator whose fuel is entirely imported from elsewhere is left alone, as are Geothermal Generators, which have no fuel, and Alien Power Augmenters, whose matrix demand is decided by their building groups rather than by a rate you can set.
 - **The generator's row now wraps** rather than running off the edge of the card. It is the widest row in the planner, and on a 1440px screen with the sidebar open the new button had nowhere left to go.
-- **A "Generator fuel draw" template** shows it working, for anyone wanting to see the case before meeting it in their own plan. Two self-contained factories, each making 640/min Liquid Fuel from its own crude with Recycled Plastic taking 240 of it: one has its generators on 640 and offers the Trim, the other on 240 and offers the Expand, and both land on the same 400.
+- **A debug template, "#656: Generator fuel draw"**, shows it working: two self-contained factories, each making 640/min Liquid Fuel from its own crude with Recycled Plastic taking 240 of it. One has its generators on 640 and offers the Trim, the other on 240 and offers the Expand, and both land on the same 400. The debug rows in the Templates dialog are the app's primary blue now rather than Vuetify's stock secondary, which belonged to no palette in particular.
 
 ### Interface
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ number used to be.
 - **A surplus the AWESOME Sink is currently mopping up still counts as spare**, because burning fuel beats sinking it — take it, and the sinks drop out of the plan by themselves.
 - The buttons appear only where there is something to match against: a generator whose fuel is entirely imported from elsewhere is left alone, as are Geothermal Generators, which have no fuel, and Alien Power Augmenters, whose matrix demand is decided by their building groups rather than by a rate you can set.
 - **The generator's row now wraps** rather than running off the edge of the card. It is the widest row in the planner, and on a 1440px screen with the sidebar open the new button had nowhere left to go.
+- **A "Generator fuel draw" template** shows it working, for anyone wanting to see the case before meeting it in their own plan. Two self-contained factories, each making 640/min Liquid Fuel from its own crude with Recycled Plastic taking 240 of it: one has its generators on 640 and offers the Trim, the other on 240 and offers the Expand, and both land on the same 400.
 
 ### Interface
 

--- a/web/src/components/Templates.vue
+++ b/web/src/components/Templates.vue
@@ -50,6 +50,7 @@
   import { create503PreMiningPlan } from '@/utils/factory-setups/503-pre-mining-plan'
   import { createMiningDemoPlan } from '@/utils/factory-setups/mining-demo-plan'
   import { create268Scenraio } from '@/utils/factory-setups/268-power-gen-only-import'
+  import { createFuelSupplyMatchingScenario } from '@/utils/factory-setups/fuel-supply-matching'
   import { useAppStore } from '@/stores/app-store'
   import { config } from '@/config/config'
   import { Factory } from '@/interfaces/planner/FactoryInterface'
@@ -133,6 +134,13 @@
       show: isDebugMode,
       isDebug: true,
       rearmNotice: true,
+    },
+    {
+      name: 'Generator fuel draw',
+      description: 'The Oil MegaFac\'s fuel problem, shrunk to two self-contained factories. Each makes 640/min Liquid Fuel from its own crude, and Recycled Plastic takes 240 of it, so 400 is what the generators may burn. They differ only in what the generators are set to: "over-drawing" is on 640 and should offer Trim to supply (400), taking it 8,000 → 5,000 MW; "spare fuel" is on 240 and should offer Expand to supply (400), taking it 3,000 → 5,000 MW. Nothing is imported and every part but the Plastic the factory exists to make balances exactly, so the fuel is the only thing either has left to settle. The over-drawing one also offers Satisfy (880) on its Liquid Fuel product — deliberately: making more fuel and burning less are both real answers to the same shortage, and the two buttons are the two ends of it.',
+      data: scenarioData(createFuelSupplyMatchingScenario().getFactories()),
+      show: isDebugMode,
+      isDebug: true,
     },
     {
       name: 'PowerOnlyImport',

--- a/web/src/components/Templates.vue
+++ b/web/src/components/Templates.vue
@@ -31,7 +31,7 @@
             <td class="text-center">
               <v-btn
                 class="mr-2"
-                :color="template.isDebug ? 'secondary' : 'green'"
+                :color="template.isDebug ? 'primary' : 'green'"
                 :prepend-icon="template.isDebug ? 'fas fa-bug' : 'fas fa-file'"
                 @click="loadTemplate(template)"
               >
@@ -136,13 +136,6 @@
       rearmNotice: true,
     },
     {
-      name: 'Generator fuel draw',
-      description: 'The Oil MegaFac\'s fuel problem, shrunk to two self-contained factories. Each makes 640/min Liquid Fuel from its own crude, and Recycled Plastic takes 240 of it, so 400 is what the generators may burn. They differ only in what the generators are set to: "over-drawing" is on 640 and should offer Trim to supply (400), taking it 8,000 → 5,000 MW; "spare fuel" is on 240 and should offer Expand to supply (400), taking it 3,000 → 5,000 MW. Nothing is imported and every part but the Plastic the factory exists to make balances exactly, so the fuel is the only thing either has left to settle. The over-drawing one also offers Satisfy (880) on its Liquid Fuel product — deliberately: making more fuel and burning less are both real answers to the same shortage, and the two buttons are the two ends of it.',
-      data: scenarioData(createFuelSupplyMatchingScenario().getFactories()),
-      show: isDebugMode,
-      isDebug: true,
-    },
-    {
       name: 'PowerOnlyImport',
       description: '2 factory setup where on factory is producing the a fuel and another is consuming the fuel (via import) for power generation. Related to issue #268',
       data: scenarioData(create268Scenraio().getFactories()),
@@ -230,6 +223,13 @@
       name: '#485 + #499: Rounding & broken chain repair',
       description: 'A plan damaged in both of the ways a saved plan can be, to exercise the "Plan data repaired" dialog. It should open on load listing BOTH kinds of correction, grouped by factory. Micro-rounding: quantities a hair off the numbers they mean, left on whole numbers afterwards — the Refinery on 14,400 Rocket Fuel/min, FG TEST on 2,400 plus 3,000 Compacted Coal, the Mega Plant on 12,000 (its 0.01 and the Refinery\'s 0.012 are past the flat snap tolerance, so they prove the scaling one). Broken chain: the Refinery copy inherits the original\'s exports and should be reported as exporting to two factories that are not importing from it (its own quantities drift too, so that factory\'s heading carries both kinds at once); the Refinery\'s export to FG TEST reads 3,200 against an import of 2,400; the Mega Plant\'s import has no matching export; an export entry points at a factory that no longer exists; and Spare Ingots A and B share an internal ID, so one is reassigned. Afterwards no factory should list an export nobody imports.',
       data: scenarioData(create485DemoPlan().getFactories()),
+      show: isDebugMode,
+      isDebug: true,
+    },
+    {
+      name: '#656: Generator fuel draw',
+      description: 'The Oil MegaFac\'s fuel problem, shrunk to two self-contained factories. Each makes 640/min Liquid Fuel from its own crude, and Recycled Plastic takes 240 of it, so 400 is what the generators may burn. They differ only in what the generators are set to: "over-drawing" is on 640 and should offer Trim to supply (400), taking it 8,000 → 5,000 MW; "spare fuel" is on 240 and should offer Expand to supply (400), taking it 3,000 → 5,000 MW. Nothing is imported and every part but the Plastic the factory exists to make balances exactly, so the fuel is the only thing either has left to settle. The over-drawing one also offers Satisfy (880) on its Liquid Fuel product — deliberately: making more fuel and burning less are both real answers to the same shortage, and the two buttons are the two ends of it.',
+      data: scenarioData(createFuelSupplyMatchingScenario().getFactories()),
       show: isDebugMode,
       isDebug: true,
     },

--- a/web/src/components/planner/products/PowerProducer.spec.ts
+++ b/web/src/components/planner/products/PowerProducer.spec.ts
@@ -14,6 +14,7 @@ import {
   ItemType,
 } from '@/interfaces/planner/FactoryInterface'
 import { addPowerProducerToFactory } from '@/utils/factory-management/power'
+import { addProductToFactory } from '@/utils/factory-management/products'
 import { addBuildingGroup } from '@/utils/factory-management/building-groups/common'
 import { getBuildingDisplayName } from '@/utils/factory-management/common'
 
@@ -331,5 +332,78 @@ describe('Component: PowerProducer (augmenter building count)', () => {
     it('should not claim anything about the power grid', () => {
       expect(augmenterSubject.text()).not.toContain('one power grid')
     })
+  })
+})
+
+// The generator burns fuel this factory makes, so the planner can say what rate it may carry.
+describe('Component: PowerProducer (fuel supply buttons)', () => {
+  const fuelButton = (wrapper: VueWrapper<any>) =>
+    wrapper.findAll('button').find(button => button.text().includes('to supply'))
+
+  // 1280/min Liquid Fuel on site, all of it fed to Fuel Generators.
+  const fuelPlant = () => {
+    const plant = newFactory('Oil MegaFac')
+    addProductToFactory(plant, { id: 'LiquidFuel', amount: 1280, recipe: 'LiquidFuel' })
+    addPowerProducerToFactory(plant, {
+      building: 'generatorfuel',
+      fuelAmount: 1280,
+      recipe: 'GeneratorFuel_LiquidFuel',
+      updated: FactoryPowerChangeType.Fuel,
+    })
+    calculateFactory(plant, [plant], gameData)
+    return plant
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('should offer nothing while the fuel matches the supply', () => {
+    expect(fuelButton(mountSubject(fuelPlant()))).toBeUndefined()
+  })
+
+  it('should offer a trim naming the figure when another recipe takes a share of the fuel', () => {
+    const plant = fuelPlant()
+    // Recycled Rubber eats 120/min of the same Liquid Fuel, leaving the generators short.
+    addProductToFactory(plant, { id: 'Rubber', amount: 240, recipe: 'Alternate_RecycledRubber' })
+    calculateFactory(plant, [plant], gameData)
+
+    expect(fuelButton(mountSubject(plant))?.text()).toBe('Trim to supply (1160)')
+  })
+
+  it('should offer an expand naming the figure when there is spare fuel', () => {
+    const plant = fuelPlant()
+    plant.products[0].amount = 1500
+    calculateFactory(plant, [plant], gameData)
+
+    expect(fuelButton(mountSubject(plant))?.text()).toBe('Expand to supply (1500)')
+  })
+
+  it('should set the fuel rate and recalculate when pressed', async () => {
+    const plant = fuelPlant()
+    addProductToFactory(plant, { id: 'Rubber', amount: 240, recipe: 'Alternate_RecycledRubber' })
+    calculateFactory(plant, [plant], gameData)
+
+    const wrapper = mountSubject(plant)
+    await fuelButton(wrapper)?.trigger('click')
+    await nextTick()
+
+    expect(plant.powerProducers[0].fuelAmount).toBe(1160)
+    expect(plant.parts.LiquidFuel.satisfied).toBe(true)
+    // With the part balanced there is nothing left to offer.
+    expect(fuelButton(mountSubject(plant))).toBeUndefined()
+  })
+
+  it('should offer nothing when the factory supplies none of the fuel', () => {
+    const plant = newFactory('Generators only')
+    addPowerProducerToFactory(plant, {
+      building: 'generatorfuel',
+      fuelAmount: 1280,
+      recipe: 'GeneratorFuel_LiquidFuel',
+      updated: FactoryPowerChangeType.Fuel,
+    })
+    calculateFactory(plant, [plant], gameData)
+
+    expect(fuelButton(mountSubject(plant))).toBeUndefined()
   })
 })

--- a/web/src/components/planner/products/PowerProducer.vue
+++ b/web/src/components/planner/products/PowerProducer.vue
@@ -38,7 +38,11 @@
         @click="deletePowerProducer(producerIndex, factory)"
       />
     </div>
-    <div class="selectors mt-3 mb-2 d-flex flex-column flex-md-row ga-3">
+    <!-- flex-wrap, unlike the product and custom-building rows: this row is the widest in the
+         app (two autocompletes, two number fields and the output chip) and already runs a hair
+         past the card at 1440px. A supply button on the end tips it well over, and a control the
+         user cannot reach is worse than one on a second line. -->
+    <div class="selectors mt-3 mb-2 d-flex flex-column flex-md-row flex-wrap ga-3">
       <div v-if="factory.checklistEnabled" class="input-row d-flex align-center">
         <input
           :checked="!!producer.completed"
@@ -137,6 +141,35 @@
         />
         <debounce-spinner :active="pendingRecalc === `${producer.id}-${FactoryPowerChangeType.Power}`" />
       </div>
+      <!-- The factory makes (or imports) this generator's fuel, and the two do not agree. These
+           set the fuel rate to whatever the rest of the factory leaves over, which is the sum the
+           user would otherwise be doing by hand. -->
+      <tooltip
+        v-if="fuelFixDirection(producer) === 'expand'"
+        classes="align-self-center"
+        :text="`This factory has spare ${fuelFixPartName(producer)} once everything else that wants it has been served.<br>Expanding burns the lot, raising this generator's output.`"
+      >
+        <v-btn
+          class="rounded"
+          color="green"
+          prepend-icon="fas fa-arrow-up"
+          size="default"
+          @click="doFixProducerFuel(producer)"
+        >Expand to supply{{ fuelFixLabel(producer) }}</v-btn>
+      </tooltip>
+      <tooltip
+        v-if="fuelFixDirection(producer) === 'trim'"
+        classes="align-self-center"
+        :text="`This generator burns more ${fuelFixPartName(producer)} than the factory has left after everything else that wants it.<br>Trimming drops it to what is actually spare, lowering this generator's output.`"
+      >
+        <v-btn
+          class="rounded"
+          color="yellow"
+          prepend-icon="fas fa-arrow-down"
+          size="default"
+          @click="doFixProducerFuel(producer)"
+        >Trim to supply{{ fuelFixLabel(producer) }}</v-btn>
+      </tooltip>
       <v-chip
         class="align-self-center sf-chip green"
         variant="tonal"
@@ -311,6 +344,8 @@
     toggleChecklistPowerProducer,
   } from '@/utils/factory-management/checklist'
   import { addPowerProducerBuildingGroup } from '@/utils/factory-management/building-groups/power'
+  import { fixProducerFuel, fuelFixTarget, producerFuelPart, shouldShowFuelFix } from '@/utils/factory-management/power'
+  import { fixTargetSuffix } from '@/utils/numberFormatter'
   import { productRowId } from '@/utils/factory-management/products'
   import { useDebouncedAction } from '@/composables/useDebouncedAction'
 
@@ -326,6 +361,8 @@
     getDefaultRecipeForPowerProducer,
     getGameData,
   } = useGameDataStore()
+
+  const gameData = getGameData()
 
   const props = defineProps<{
     factory: Factory;
@@ -423,6 +460,23 @@
   const producerHasVariablePower = (producer: FactoryPowerProducer) => {
     const range = producerPowerRange(producer)
     return range.max !== range.min
+  }
+
+  // Fuel supply matching (see power.ts). Bound per producer so the template does not have to
+  // carry the factory and game data through every call.
+  const fuelFixDirection = (producer: FactoryPowerProducer) =>
+    shouldShowFuelFix(producer, props.factory, gameData)
+
+  // What the button would set the fuel rate to, named on the button itself.
+  const fuelFixLabel = (producer: FactoryPowerProducer) =>
+    fixTargetSuffix(fuelFixTarget(producer, props.factory, gameData))
+
+  const fuelFixPartName = (producer: FactoryPowerProducer) =>
+    getPartDisplayName(producerFuelPart(producer, gameData) ?? '')
+
+  const doFixProducerFuel = (producer: FactoryPowerProducer) => {
+    fixProducerFuel(producer, props.factory, gameData)
+    updateFactory(props.factory)
   }
 
   const updatePowerProducerSelection = (source: 'building' | 'recipe', producer: FactoryPowerProducer, factory: Factory) => {

--- a/web/src/utils/factory-management/power.spec.ts
+++ b/web/src/utils/factory-management/power.spec.ts
@@ -9,7 +9,13 @@ import {
 import { calculateFactories, calculateFactory, newFactory } from '@/utils/factory-management/factory'
 import { addProductToFactory } from '@/utils/factory-management/products'
 import { addInputToFactory } from '@/utils/factory-management/inputs'
-import { addPowerProducerToFactory } from '@/utils/factory-management/power'
+import {
+  addPowerProducerToFactory,
+  fixProducerFuel,
+  fuelFixTarget,
+  producerFuelPart,
+  shouldShowFuelFix,
+} from '@/utils/factory-management/power'
 import { addPowerProducerBuildingGroup } from '@/utils/factory-management/building-groups/power'
 import { addBuildingGroup } from '@/utils/factory-management/building-groups/common'
 import { calculateTotalPower } from '@/utils/statistics'
@@ -841,6 +847,170 @@ describe('power', () => {
         expect(factory.power.boostMw).toBe(400)
         expect(fuelFactory.power.boostPercent).toBe(0)
         expect(fuelFactory.power.boostMw).toBe(0)
+      })
+    })
+  })
+
+  // #### A generator burning fuel the factory itself supplies: the planner knows the supply and
+  // every other claim on it, so the fuel rate it may carry is arithmetic rather than guesswork.
+  describe('fuel supply matching', () => {
+    let producer: FactoryPowerProducer
+
+    // 1280/min Liquid Fuel made on site, all of it fed to Fuel Generators.
+    const buildFuelPlant = () => {
+      factory = newFactory('Oil MegaFac')
+      addProductToFactory(factory, { id: 'LiquidFuel', amount: 1280, recipe: 'LiquidFuel' })
+      addPowerProducerToFactory(factory, {
+        building: 'generatorfuel',
+        fuelAmount: 1280,
+        recipe: 'GeneratorFuel_LiquidFuel',
+        updated: FactoryPowerChangeType.Fuel,
+      })
+      calculateFactories([factory], gameData)
+      producer = factory.powerProducers[0]
+    }
+
+    beforeEach(() => {
+      buildFuelPlant()
+    })
+
+    it('should offer nothing when the fuel exactly matches the supply', () => {
+      expect(factory.parts.LiquidFuel.amountRemaining).toBe(0)
+      expect(shouldShowFuelFix(producer, factory, gameData)).toBe(null)
+    })
+
+    it('should offer nothing when the factory supplies none of the fuel', () => {
+      const importer = newFactory('Generators only')
+      addPowerProducerToFactory(importer, {
+        building: 'generatorfuel',
+        fuelAmount: 1280,
+        recipe: 'GeneratorFuel_LiquidFuel',
+        updated: FactoryPowerChangeType.Fuel,
+      })
+      calculateFactories([importer], gameData)
+
+      expect(importer.parts.LiquidFuel.amountSupplied).toBe(0)
+      expect(shouldShowFuelFix(importer.powerProducers[0], importer, gameData)).toBe(null)
+      expect(fuelFixTarget(importer.powerProducers[0], importer, gameData)).toBe(null)
+    })
+
+    describe('another recipe takes a share of the same fuel', () => {
+      beforeEach(() => {
+        // Recycled Rubber eats 120/min of the same Liquid Fuel, leaving the generators short.
+        addProductToFactory(factory, { id: 'Rubber', amount: 240, recipe: 'Alternate_RecycledRubber' })
+        calculateFactories([factory], gameData)
+      })
+
+      it('should ask to trim down to what the other recipe leaves over', () => {
+        expect(factory.parts.LiquidFuel.amountRequiredProduction).toBe(120)
+        expect(factory.parts.LiquidFuel.amountRemaining).toBe(-120)
+
+        expect(shouldShowFuelFix(producer, factory, gameData)).toBe('trim')
+        expect(fuelFixTarget(producer, factory, gameData)).toBe(1160) // 1280 supplied - 120 to rubber
+      })
+
+      it('should leave the part satisfied once trimmed', () => {
+        fixProducerFuel(producer, factory, gameData)
+        calculateFactories([factory], gameData)
+
+        expect(producer.ingredients[0].perMin).toBe(1160)
+        expect(factory.parts.LiquidFuel.amountRemaining).toBe(0)
+        expect(factory.parts.LiquidFuel.satisfied).toBe(true)
+        // The power follows the fuel: 1160/min at 12.5 MW an item.
+        expect(producer.powerProduced).toBe(14500)
+        // ...and there is nothing left to offer.
+        expect(shouldShowFuelFix(producer, factory, gameData)).toBe(null)
+      })
+    })
+
+    describe('spare fuel', () => {
+      beforeEach(() => {
+        factory.products[0].amount = 1500
+        calculateFactories([factory], gameData)
+      })
+
+      it('should ask to expand up to the spare fuel', () => {
+        expect(factory.parts.LiquidFuel.amountRemaining).toBe(220)
+
+        expect(shouldShowFuelFix(producer, factory, gameData)).toBe('expand')
+        expect(fuelFixTarget(producer, factory, gameData)).toBe(1500)
+      })
+
+      it('should burn the lot once expanded', () => {
+        fixProducerFuel(producer, factory, gameData)
+        calculateFactories([factory], gameData)
+
+        expect(producer.ingredients[0].perMin).toBe(1500)
+        expect(factory.parts.LiquidFuel.amountRemaining).toBe(0)
+        expect(shouldShowFuelFix(producer, factory, gameData)).toBe(null)
+      })
+
+      it('should ignore an export request being met from the same surplus', () => {
+        const consumer = newFactory('Turbofuel')
+        calculateFactories([factory, consumer], gameData)
+        addInputToFactory(consumer, { factoryId: factory.id, outputPart: 'LiquidFuel', amount: 200 })
+        calculateFactories([factory, consumer], gameData)
+
+        // Only the 20/min the export does not claim is this generator's to take.
+        expect(fuelFixTarget(producer, factory, gameData)).toBe(1300)
+      })
+    })
+
+    // A surplus the sink is mopping up is still spare fuel — burning it beats sinking it, and the
+    // sink's own count shrinks by itself on the next calculation.
+    it('should still offer the surplus when a sink is placed on the fuel', () => {
+      factory = newFactory('Coal power')
+      addProductToFactory(factory, { id: 'Coal', amount: 500, recipe: 'Extract_Coal' })
+      addPowerProducerToFactory(factory, {
+        building: 'generatorcoal',
+        fuelAmount: 300,
+        recipe: 'GeneratorCoal_Coal',
+        updated: FactoryPowerChangeType.Fuel,
+      })
+      factory.partDisposal = { Coal: { sinks: 1, depots: 0 } }
+      calculateFactories([factory], gameData)
+      producer = factory.powerProducers[0]
+
+      expect(factory.parts.Coal.amountRequiredSink).toBe(200) // Sunk, so nothing "remains"
+      expect(factory.parts.Coal.amountRemaining).toBe(0)
+
+      expect(shouldShowFuelFix(producer, factory, gameData)).toBe('expand')
+      expect(fuelFixTarget(producer, factory, gameData)).toBe(500)
+    })
+
+    describe('generators with no fuel rate to set', () => {
+      it('should offer nothing for a geothermal generator', () => {
+        const geo = newFactory('Geothermal')
+        addPowerProducerToFactory(geo, {
+          building: 'geothermalgenerator',
+          buildingAmount: 2,
+          recipe: 'GeneratorGeoThermal_Pure',
+          updated: FactoryPowerChangeType.Building,
+        })
+        calculateFactories([geo], gameData)
+
+        expect(producerFuelPart(geo.powerProducers[0], gameData)).toBe(null)
+        expect(shouldShowFuelFix(geo.powerProducers[0], geo, gameData)).toBe(null)
+      })
+
+      // The augmenter has ingredients once its groups are fed matrixes, but the rate comes from
+      // the building count — writing a fuel figure here would be overwritten on the next pass.
+      it('should offer nothing for an alien power augmenter supplying matrixes', () => {
+        const augmented = newFactory('Augmenters')
+        addProductToFactory(augmented, { id: 'AlienPowerFuel', amount: 30, recipe: 'AlienPowerFuel' })
+        addPowerProducerToFactory(augmented, {
+          building: 'alienpoweraugmenter',
+          buildingAmount: 2,
+          recipe: 'AlienPowerAugmenter',
+          updated: FactoryPowerChangeType.Building,
+        })
+        calculateFactories([augmented], gameData)
+        augmented.powerProducers[0].buildingGroups[0].supplyMatrixes = true
+        calculateFactories([augmented], gameData)
+
+        expect(augmented.powerProducers[0].ingredients[0].part).toBe('AlienPowerFuel')
+        expect(producerFuelPart(augmented.powerProducers[0], gameData)).toBe(null)
+        expect(shouldShowFuelFix(augmented.powerProducers[0], augmented, gameData)).toBe(null)
       })
     })
   })

--- a/web/src/utils/factory-management/power.ts
+++ b/web/src/utils/factory-management/power.ts
@@ -276,3 +276,115 @@ export const calculateGridBoost = (factories: Factory[], gameData: DataInterface
     factory.power.boostUnfueledBuildings = unfueledBuildings
   })
 }
+
+// ---------------------------------------------------------------------------
+// Matching a generator's fuel draw to what the factory can supply
+// ---------------------------------------------------------------------------
+//
+// A generator burning fuel the factory makes itself is the one consumer the planner can settle
+// without the user reaching for a calculator: the fuel's supply is known, every other claim on it
+// (production, exports, the other generators) is known, and what is left over is exactly what this
+// generator may burn. The three functions below mirror products.ts's shouldShowFix /
+// fixProductTarget / fixProduct, and are shaped the same way so the two rows behave alike.
+
+// The fuel a producer burns — ingredients[0], the same convention power.ts uses throughout.
+// Null for the generators whose draw is not the user's to dial: Geothermal has no fuel at all, and
+// an Alien Power Augmenter's matrix demand is synthesised from its building groups
+// (see calculateFuellessPowerProducer), so a rate set here would be overwritten on the next pass.
+export const producerFuelPart = (
+  producer: FactoryPowerProducer,
+  gameData: DataInterface
+): string | null => {
+  if (!producer.recipe || !producer.building) {
+    return null
+  }
+
+  const recipe = getPowerRecipe(producer.recipe, gameData)
+  if (!recipe || recipe.ingredients.length === 0) {
+    return null
+  }
+
+  return producer.ingredients[0]?.part ?? null
+}
+
+// The fuel rate that would leave the part exactly balanced, without setting it. The buttons name
+// this figure, so the user can see what they are agreeing to before pressing rather than after.
+//
+// amountRemainingPreSink carries the whole calculation: it is supply minus every claim on the
+// part, this generator's own draw included, so adding that draw back turns "what is spare" into
+// "what this generator may burn". A second recipe eating the same fuel — Recycled Rubber, say —
+// is therefore handled for free: its share sits in amountRequiredProduction and never reaches the
+// allowance. Pre-sink because the AWESOME Sink only ever takes what nothing else claimed, so a
+// surplus currently being sunk is still spare fuel, and burning it shrinks the sunk amount by
+// itself on the next recalculation.
+//
+// Null when the question cannot be answered: no fuel to dial, no part ledger yet, or a factory
+// with no supply of the fuel at all, where the only honest answer is "bring some in".
+export const fuelFixTarget = (
+  producer: FactoryPowerProducer,
+  factory: Factory,
+  gameData: DataInterface
+): number | null => {
+  const fuelPart = producerFuelPart(producer, gameData)
+  if (!fuelPart) {
+    return null
+  }
+
+  const partData = factory.parts[fuelPart]
+  if (!partData || partData.amountSupplied <= 0) {
+    return null
+  }
+
+  // ?? amountRemaining for plans saved before pre-sink surplus was tracked; the two only differ
+  // once a sink is placed, which those plans could not have done either.
+  const spare = (producer.ingredients[0]?.perMin ?? 0) +
+    (partData.amountRemainingPreSink ?? partData.amountRemaining)
+
+  // Floored at zero: when the factory's other demands already outstrip the supply there is
+  // nothing left over, and zero means turn the generator off rather than burn fuel that isn't
+  // there. Formatted because the ledger arrives carrying float noise.
+  return Math.max(0, formatNumberFully(spare, 3))
+}
+
+// Which way the fuel draw would have to move to match supply, or null to offer nothing.
+// Named for the action rather than for the sign of the shortfall: a fuel deficit means this
+// generator has to burn less, which is the opposite of what a product's deficit asks for.
+export const shouldShowFuelFix = (
+  producer: FactoryPowerProducer,
+  factory: Factory,
+  gameData: DataInterface
+): 'trim' | 'expand' | null => {
+  const target = fuelFixTarget(producer, factory, gameData)
+  if (target === null) {
+    return null
+  }
+
+  const current = producer.ingredients[0]?.perMin ?? 0
+
+  if (target < current) {
+    return 'trim'
+  }
+
+  if (target > current) {
+    return 'expand'
+  }
+
+  return null
+}
+
+// Sets the fuel rate to fuelFixTarget. The caller must call updateFactory afterwards, as with
+// fixProduct — the power, the buildings and the building groups are all derived from it.
+export const fixProducerFuel = (
+  producer: FactoryPowerProducer,
+  factory: Factory,
+  gameData: DataInterface
+): void => {
+  const target = fuelFixTarget(producer, factory, gameData)
+  if (target === null) {
+    console.error('power: fixProducerFuel: no fuel target could be calculated!', producer)
+    return
+  }
+
+  producer.fuelAmount = target
+  producer.updated = FactoryPowerChangeType.Fuel
+}

--- a/web/src/utils/factory-setups/fuel-supply-matching.spec.ts
+++ b/web/src/utils/factory-setups/fuel-supply-matching.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Factory } from '@/interfaces/planner/FactoryInterface'
+import { calculateFactories } from '@/utils/factory-management/factory'
+import { fixProducerFuel, fuelFixTarget, shouldShowFuelFix } from '@/utils/factory-management/power'
+import { createFuelSupplyMatchingScenario } from '@/utils/factory-setups/fuel-supply-matching'
+import { gameData } from '@/utils/gameData'
+
+// The template exists to demonstrate one thing, so the numbers on the buttons are the thing to
+// pin: a template that has drifted into showing nothing teaches nothing.
+describe('Fuel supply matching template', () => {
+  let overDrawing: Factory
+  let spareFuel: Factory
+
+  beforeEach(() => {
+    const factories = createFuelSupplyMatchingScenario().getFactories()
+    calculateFactories(factories, gameData)
+    ;[overDrawing, spareFuel] = factories
+  })
+
+  it('should leave the fuel as the only loose end', () => {
+    // Everything the chain makes on the way through is consumed by the next step, so the only
+    // part either factory has anything left over of is the Plastic it exists to make.
+    for (const factory of [overDrawing, spareFuel]) {
+      expect(factory.parts.PolymerResin.amountRemaining).toBe(0)
+      expect(factory.parts.Water.amountRemaining).toBe(0)
+      expect(factory.parts.Rubber.amountRemaining).toBe(0)
+      expect(factory.parts.LiquidOil.amountRemaining).toBe(0)
+      expect(factory.parts.Plastic.amountRemaining).toBe(480)
+      // Nothing is imported: each factory stands on its own.
+      expect(factory.inputs).toEqual([])
+    }
+  })
+
+  it('should offer a trim on the over-drawing factory', () => {
+    const part = overDrawing.parts.LiquidFuel
+    expect(part.amountSupplied).toBe(640)
+    expect(part.amountRequiredProduction).toBe(240) // Recycled Plastic's share
+    expect(part.amountRequiredPower).toBe(640)
+    expect(part.amountRemaining).toBe(-240)
+
+    const producer = overDrawing.powerProducers[0]
+    expect(producer.powerProduced).toBe(8000)
+    expect(shouldShowFuelFix(producer, overDrawing, gameData)).toBe('trim')
+    expect(fuelFixTarget(producer, overDrawing, gameData)).toBe(400)
+  })
+
+  it('should offer an expand on the spare fuel factory, at the same figure', () => {
+    const part = spareFuel.parts.LiquidFuel
+    expect(part.amountRequiredPower).toBe(240)
+    expect(part.amountRemaining).toBe(160)
+
+    const producer = spareFuel.powerProducers[0]
+    expect(producer.powerProduced).toBe(3000)
+    expect(shouldShowFuelFix(producer, spareFuel, gameData)).toBe('expand')
+    expect(fuelFixTarget(producer, spareFuel, gameData)).toBe(400)
+  })
+
+  it('should balance both factories on 5,000 MW once the button is pressed', () => {
+    for (const factory of [overDrawing, spareFuel]) {
+      fixProducerFuel(factory.powerProducers[0], factory, gameData)
+      calculateFactories([factory], gameData)
+
+      expect(factory.powerProducers[0].fuelAmount).toBe(400)
+      expect(factory.powerProducers[0].powerProduced).toBe(5000)
+      expect(factory.parts.LiquidFuel.amountRemaining).toBe(0)
+      expect(factory.parts.LiquidFuel.satisfied).toBe(true)
+      expect(shouldShowFuelFix(factory.powerProducers[0], factory, gameData)).toBe(null)
+    }
+  })
+})

--- a/web/src/utils/factory-setups/fuel-supply-matching.ts
+++ b/web/src/utils/factory-setups/fuel-supply-matching.ts
@@ -1,0 +1,61 @@
+import { Factory, FactoryPowerChangeType } from '@/interfaces/planner/FactoryInterface'
+import { newFactory } from '@/utils/factory-management/factory'
+import { addProductToFactory } from '@/utils/factory-management/products'
+import { addPowerProducerToFactory } from '@/utils/factory-management/power'
+
+/**
+ * The Oil MegaFac's fuel problem, shrunk to two self-contained factories.
+ *
+ * A factory that makes its own Liquid Fuel and burns it in Fuel-Powered Generators has an obvious
+ * answer to "how much may the generators burn" — right up until a second recipe wants the same
+ * fuel. Here that is Recycled Plastic, which eats 240/min of the 640/min made, leaving the
+ * generators 400. Neither factory is *broken*: each is one number away from balanced, and the
+ * number is the one the generator row now offers to set.
+ *
+ * The two differ only in what the generators are set to, so the pair shows both directions
+ * against the same answer:
+ *
+ *   Over-drawing  — generators on 640, 240 too much → "Trim to supply (400)", 8,000 → 5,000 MW
+ *   Spare fuel    — generators on 240, 160 too little → "Expand to supply (400)", 3,000 → 5,000 MW
+ *
+ * The chain closes on itself deliberately, so the fuel is the only loose end: crude makes Liquid
+ * Fuel and drops Polymer Resin, Residual Rubber turns that resin into Rubber, and Recycled Plastic
+ * turns the Rubber back into Plastic — the factory's one output — taking a share of the fuel on
+ * the way through. Water and crude are extracted on site, so nothing is imported either.
+ */
+export const createFuelSupplyMatchingScenario = (): { getFactories: () => Factory[] } => {
+  const overDrawing = newFactory('Fuel Power (over-drawing)', 0, 1)
+  const spareFuel = newFactory('Fuel Power (spare fuel)', 1, 2)
+
+  const factories = [overDrawing, spareFuel]
+
+  // Both factories are the same plant; only the generators differ.
+  const addPlant = (factory: Factory, generatorFuel: number) => {
+    addProductToFactory(factory, { id: 'LiquidOil', recipe: 'Extract_LiquidOil', amount: 960 })
+    addProductToFactory(factory, { id: 'Water', recipe: 'Extract_Water', amount: 480 })
+
+    // 960 crude → 640 Liquid Fuel, dropping 480 Polymer Resin.
+    addProductToFactory(factory, { id: 'LiquidFuel', recipe: 'LiquidFuel', amount: 640 })
+
+    // The resin and the water go back in: 480 + 480 → 240 Rubber.
+    addProductToFactory(factory, { id: 'Rubber', recipe: 'ResidualRubber', amount: 240 })
+
+    // Recycled Plastic is the competing claim on the fuel: 240 Rubber + 240 Liquid Fuel → 480
+    // Plastic. Whatever the generators are set to, 400/min is what is left for them.
+    addProductToFactory(factory, { id: 'Plastic', recipe: 'Alternate_Plastic_1', amount: 480 })
+
+    addPowerProducerToFactory(factory, {
+      building: 'generatorfuel',
+      fuelAmount: generatorFuel,
+      recipe: 'GeneratorFuel_LiquidFuel',
+      updated: FactoryPowerChangeType.Fuel,
+    })
+  }
+
+  addPlant(overDrawing, 640) // Burning everything it makes, forgetting the Plastic line
+  addPlant(spareFuel, 240) // Leaving 160/min of fuel doing nothing
+
+  return {
+    getFactories: () => factories,
+  }
+}


### PR DESCRIPTION
Closes #656.

## What

A generator burning fuel its own factory makes now offers to match its draw to the supply, with the same green **Expand to supply** / yellow **Trim to supply** pair the product rows carry, and the figure it would land on named on the button.

This is the Oil MegaFac case: 1,280 Liquid Fuel a minute made on site, all 1,280 fed to Fuel-Powered Generators, but Recycled Rubber takes 120 and a Packager takes 40 — so the generators are 160 over. The row now offers **Trim to supply (1120)**.

## How the figure is worked out

`fuelFixTarget` = the fuel part's pre-sink surplus **plus this generator's own draw**. `amountRemainingPreSink` is already supply minus every claim on the part (this generator's included), so adding that draw back turns "what is spare" into "what this generator may burn".

That means a second recipe eating the same fuel, exports to other factories, and another generator on the same fuel are all accounted for with no iteration — their shares sit in the part ledger and never reach this generator's allowance.

Pre-sink rather than post-sink because the AWESOME Sink is a leftovers consumer, not a real claim: burning a surplus the sink is currently mopping up beats sinking it, and the sink's count shrinks by itself on the next calculation.

## When it is offered

Only where there is something to match against:

- Nothing when the factory supplies none of the fuel — the honest answer there is "bring some in", not "trim to zero".
- Nothing for **Geothermal Generators** (no fuel at all) or **Alien Power Augmenters**, whose Alien Power Matrix demand is synthesised from their building groups, so a rate written here would be overwritten on the next pass.
- Nothing when the draw already matches.

## Layout

The producer row now carries `flex-wrap`. It is the widest row in the planner (two autocompletes, two number fields and the output chip) and already ran a hair past the card at 1440px; a button on the end tipped it well over and left it clipped and unreachable. It stays on one line at 1920px.

## The template

A debug scenario, **"#656: Generator fuel draw"**, shows the case without needing a real plan. Two self-contained factories, each making 640/min Liquid Fuel from its own crude with Recycled Plastic taking 240 of it, differing only in what the generators are set to:

| Factory | Generators on | Offers | Result |
| --- | --- | --- | --- |
| over-drawing | 640 | Trim to supply (400) | 8,000 → 5,000 MW |
| spare fuel | 240 | Expand to supply (400) | 3,000 → 5,000 MW |

The chain closes on itself deliberately, so the fuel is the only loose end: crude makes Liquid Fuel and drops Polymer Resin, Residual Rubber turns that resin into Rubber, and Recycled Plastic turns the Rubber back into Plastic — the factory's one output — taking its share of the fuel on the way. Nothing is imported and every part but the Plastic balances to exactly zero.

The over-drawing factory also offers `Satisfy (880)` on its Liquid Fuel product, deliberately: making more fuel and burning less are both real answers to the same shortage, and the two buttons are the two ends of it.

## Also

The debug rows in the Templates dialog were Vuetify's stock `secondary`, a colour belonging to no palette the app uses. They are the product blue now — the same one Add Factory and the product chips carry — so the dialog reads as two kinds of row rather than three kinds of colour.

## Changes

- `web/src/utils/factory-management/power.ts` — `producerFuelPart`, `fuelFixTarget`, `shouldShowFuelFix`, `fixProducerFuel`, shaped to mirror `products.ts`'s `shouldShowFix` / `fixProductTarget` / `fixProduct`.
- `web/src/components/planner/products/PowerProducer.vue` — the two buttons, their tooltips, and the row wrap.
- `web/src/utils/factory-setups/fuel-supply-matching.ts` — the template plan.
- `web/src/components/Templates.vue` — the template entry and the debug row colour.
- `CHANGELOG.md` — a v0.7 section.

## Testing

- 10 new engine tests in `power.spec.ts`: balanced, no local supply, another recipe taking a share (trim), spare fuel (expand), an export competing for the same surplus, a sunk surplus, and both fuel-less generator types.
- 5 new component tests in `PowerProducer.spec.ts`: which button renders, the figure on it, and that pressing it sets the rate and recalculates.
- 4 tests in `fuel-supply-matching.spec.ts` pinning the figures the template shows — a template that has drifted into showing nothing teaches nothing.
- Full suite green: 117 files, 2,277 tests.
- Driven in a real browser twice: against Mael's MegaPlan with the Oil MegaFac set to the reported numbers (`Expand to supply (1120)` → `Trim to supply (1120)` → fuel 1,120, 16,000 → 14,000 MW, remainder 0, button gone), and against the new template loaded from the Templates dialog (both buttons as described, both factories landing on 400 / 5,000 MW). Layout re-checked at 1440px and 1920px.

## Note

Only the fuel (`ingredients[0]`) is considered. A Nuclear Power Plant short of its supplemental **water** is not offered anything — the right answer there would be the smaller of the two targets, which is worth doing separately rather than folding in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsd2KCKYuEG1GyG6kdouHM