### PR TITLE
fix(backend): make room revocation fail closed and cover in-flight handshakes

### DIFF
--- a/backend/src/realtime/connection.ts
+++ b/backend/src/realtime/connection.ts
@@ -27,6 +27,10 @@ export class Connection {
   readonly rooms = new Map<string, RoomSession>()
   userId: string | null = null
   username: string | null = null
+  /** The account's token generation as the greeting token claimed it; null for a visitor. */
+  tokenVersion: number | null = null
+  /** Set the moment a hello starts, so a second one cannot race it into the account index. */
+  helloStarted = false
   helloDone = false
   isAlive = true
   helloTimer: NodeJS.Timeout | null = null
@@ -38,6 +42,16 @@ export class Connection {
 
   constructor (readonly socket: WebSocket, readonly ip: string) {}
 
+  /**
+   * Every server-side kick goes through `close` or `terminate`, so this is the one
+   * question a handshake or a queued op has to ask before it may finish: has this
+   * connection been cut off since the work started? Nothing that reads true here may
+   * become authorized again, however far through it already is.
+   */
+  get invalidated (): boolean {
+    return this.closed || this.socket.readyState > WebSocket.OPEN
+  }
+
   allowMessage (): boolean {
     return this.messages.allow()
   }
@@ -48,7 +62,9 @@ export class Connection {
   }
 
   send (message: ServerMessage): void {
-    if (this.socket.readyState !== WebSocket.OPEN) return
+    // `closed` as well as the socket state: a kick flips it first, and the close
+    // handshake is asynchronous, so a fan-out in between must not still be written.
+    if (this.closed || this.socket.readyState !== WebSocket.OPEN) return
     // Snapshots are large and the process is single: a client that cannot drain
     // is dropped rather than allowed to grow the heap without bound.
     if (this.socket.bufferedAmount > WS_MAX_BUFFERED_BYTES) {

--- a/backend/src/realtime/room.gateway.ts
+++ b/backend/src/realtime/room.gateway.ts
@@ -157,6 +157,10 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect, On
   // ===== Message dispatch =====
 
   private async onMessage (connection: Connection, data: WebSocket.RawData): Promise<void> {
+    // A kick is asynchronous at the socket layer, so frames keep arriving after it.
+    // None of them may be acted on.
+    if (connection.invalidated) return
+
     if (!connection.allowMessage()) {
       connection.send(error('rate_limited', 'Too many messages.'))
       connection.close(WS_POLICY_VIOLATION, 'message rate exceeded')
@@ -214,6 +218,14 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect, On
     // Cleared before any await, so a slow database can never be reported as 4401.
     connection.clearHelloTimer()
 
+    // One handshake per socket. Two in flight would each claim a slot in the account
+    // index and only the last would ever be given back on disconnect.
+    if (connection.helloStarted) {
+      connection.close(CLOSE_CODES.unauthorized, 'hello already in progress')
+      return
+    }
+    connection.helloStarted = true
+
     const parsed = parseClientMessage(raw)
     if (!parsed.success || parsed.data.type !== 'hello') {
       connection.close(CLOSE_CODES.unauthorized, 'expected hello')
@@ -237,6 +249,15 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect, On
       }
     }
 
+    // The account index is claimed before the read, not after it. A rotation that
+    // commits while this handshake is reading closes the sockets it can find, and a
+    // handshake absent from the index is not one of them: it would then finish and
+    // register itself holding the generation the rotation just killed.
+    connection.userId = user?.id ?? null
+    connection.username = user?.username ?? null
+    connection.tokenVersion = user?.tokenVersion ?? null
+    this.registry.registerUser(connection)
+
     // The one read the handshake makes, and it answers both questions: whether the token
     // has been superseded, and what the account's rooms revision is.
     let account: AccountState | null = null
@@ -249,6 +270,10 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect, On
       return
     }
 
+    // Claiming the slot is only half of it: the kick landed while this frame was
+    // suspended, so the greeting has to notice it rather than complete over the top.
+    if (connection.invalidated) return
+
     // A token the account has superseded is refused exactly as an unsigned one is: 4401 is
     // what puts the client through its sign-in-again path.
     if (user && (account === null || !tokenVersionMatches(user.tokenVersion, account.tokenVersion))) {
@@ -258,10 +283,7 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect, On
 
     const roomsRevision = account?.roomsRevision ?? null
 
-    connection.userId = user?.id ?? null
-    connection.username = user?.username ?? null
     connection.helloDone = true
-    this.registry.registerUser(connection)
 
     connection.send({
       type: 'hello_ok',
@@ -270,6 +292,33 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect, On
       roomsRevision,
       connectionId: connection.id,
     })
+  }
+
+  /**
+   * Whether the account behind this socket is still on the generation it greeted with.
+   * A read that fails refuses the caller without closing: a database blip is not a
+   * reason to put someone through the sign-out path, and refusing already denies the
+   * only thing at stake, which is content this socket has not been handed yet.
+   */
+  private async accountStillCurrent (connection: Connection): Promise<boolean> {
+    // An anonymous visitor has no account to revoke; the room's own checks answer for it.
+    if (connection.userId === null) return true
+
+    let stored: number | null
+    try {
+      stored = await this.accounts.tokenVersionOf(connection.userId)
+    } catch (cause) {
+      this.logger.error('Could not re-check the account behind a socket', cause)
+      this.counters.record('server', 'ws_token_recheck_failed')
+      connection.send(error('internal_error', 'The server could not verify your session.'))
+      return false
+    }
+
+    if (connection.invalidated) return false
+    if (stored !== null && tokenVersionMatches(connection.tokenVersion, stored)) return true
+
+    connection.close(CLOSE_CODES.unauthorized, 'token revoked')
+    return false
   }
 
   /** A visitor token is signed with the same secret, so the shape is the check. */
@@ -285,6 +334,11 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect, On
   // ===== join / leave =====
 
   private async handleJoin (connection: Connection, message: ClientJoinMessage): Promise<void> {
+    // Join is the frame that hands over a whole plan, so it re-asks the question the
+    // handshake answered once. `connection.userId` records who greeted, never who may
+    // still read, and a generation that moved under a socket is not visible from here.
+    if (!await this.accountStillCurrent(connection)) return
+
     const access = await this.access.authorizeWithContent(message.roomId, {
       userId: connection.userId,
       visitorToken: message.visitorToken,
@@ -378,11 +432,17 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect, On
     }
 
     const actor = connection.userId ?? ANONYMOUS_ACTOR
-    const outcome = await this.ops.apply(message, actor, () =>
-      this.access.authorizeWithContent(message.roomId, {
+    const outcome = await this.ops.apply(message, actor, async () => {
+      // Evaluated inside the room's queue, which is where the wait happens: an op that
+      // got through the door before the kick must not commit after it. The room's own
+      // checks cannot see this, because an account revocation leaves the membership
+      // intact and only takes the socket.
+      if (connection.invalidated) return { status: 'denied' }
+      return this.access.authorizeWithContent(message.roomId, {
         userId: connection.userId,
         visitorToken: session.visitorToken,
-      }))
+      })
+    })
 
     switch (outcome.status) {
       case 'applied':
@@ -621,6 +681,10 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect, On
 
       const roomsRevision = await this.rooms.roomsRevisionOf(userId)
       for (const connection of connections) {
+        // A handshake holds a slot in this index from before it is finished, so that a
+        // revocation can reach it. It is not a client yet, and must not be sent frames
+        // ahead of its own `hello_ok`.
+        if (!connection.helloDone) continue
         this.deliver(connection, { type: 'rooms_changed', roomsRevision })
       }
     }
@@ -667,20 +731,40 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect, On
 
     for (const connection of connections) {
       const session = connection.rooms.get(roomId)
-      const access = await this.access.authorize(roomId, {
-        userId: connection.userId,
-        visitorToken: session?.visitorToken,
-      })
-      // Anything short of a clean grant kicks. A room that would refuse this socket
-      // a join must not keep answering the one it already holds.
-      if (access.status === 'granted') continue
 
+      let granted: boolean
+      try {
+        const access = await this.access.authorize(roomId, {
+          userId: connection.userId,
+          visitorToken: session?.visitorToken,
+        })
+        // Anything short of a clean grant kicks. A room that would refuse this socket
+        // a join must not keep answering the one it already holds.
+        granted = access.status === 'granted'
+      } catch (cause) {
+        // The sweep exists because access has already been withdrawn, so "could not
+        // tell" is the one answer that cannot be taken back: the socket goes on taking
+        // the op fan-out forever. It is dropped on a code the client reconnects from,
+        // and the join that follows re-runs the real check.
+        this.logger.error(`Could not re-check access to room ${roomId}`, cause)
+        this.counters.record('server', 'ws_access_recheck_failed')
+        this.kick(connection, roomId, WS_INTERNAL_ERROR, 'access re-check failed')
+        continue
+      }
+
+      if (granted) continue
       this.deliver(connection, error('forbidden', 'Your access to this room was revoked.', roomId))
-      connection.close(CLOSE_CODES.forbidden, 'access revoked')
-      // The close handshake is asynchronous, and the room must not go on showing a
-      // field held by a socket that has already been cut off.
-      if (this.locks.release(roomId, connection)) this.broadcastFieldLocks(roomId)
+      this.kick(connection, roomId, CLOSE_CODES.forbidden, 'access revoked')
     }
+  }
+
+  /**
+   * The close handshake is asynchronous, and the room must not go on showing a field
+   * held by a socket that has already been cut off.
+   */
+  private kick (connection: Connection, roomId: string, code: number, reason: string): void {
+    connection.close(code, reason)
+    if (this.locks.release(roomId, connection)) this.broadcastFieldLocks(roomId)
   }
 }
 

--- a/backend/src/rooms/rooms.service.ts
+++ b/backend/src/rooms/rooms.service.ts
@@ -191,8 +191,12 @@ export class RoomsService {
       await this.rooms.updateOne({ roomId }, { $set: { passwordHash }, $inc: { passwordVersion: 1 } })
     })
 
-    await this.finishMetaMutation(userId, roomId, 'password_set')
+    // The kick rides on that write, as unshare's does, and for the same reason: emitted
+    // after the tail below, a failure part-way would leave the outstanding tokens dead
+    // to a fresh join while the sockets already holding them went on taking the fan-out.
     this.events.emit('access_revoked', { roomId, scope: 'visitors' })
+
+    await this.finishMetaMutation(userId, roomId, 'password_set')
 
     return (await this.requireRoom(roomId)).passwordVersion
   }
@@ -204,8 +208,11 @@ export class RoomsService {
       await this.rooms.updateOne({ roomId }, { $set: { passwordHash: null }, $inc: { passwordVersion: 1 } })
     })
 
-    await this.finishMetaMutation(userId, roomId, 'password_removed')
+    // Same shape as setPassword: the version bump voids every outstanding visitor token
+    // whether the password went or changed, so the kick belongs to that write alone.
     this.events.emit('access_revoked', { roomId, scope: 'visitors' })
+
+    await this.finishMetaMutation(userId, roomId, 'password_removed')
 
     return (await this.requireRoom(roomId)).passwordVersion
   }

--- a/backend/test/utils/gate.ts
+++ b/backend/test/utils/gate.ts
@@ -1,0 +1,34 @@
+/**
+ * A promise a test opens by hand. Parking one side of a race inside a real code path
+ * is how these suites stage an interleaving without serialising the two sides with
+ * awaits, which would prove nothing.
+ */
+export class Gate {
+  /** Arrivals, so a test can prove the seam was actually reached. */
+  entered = 0
+
+  private open!: () => void
+  private readonly opened = new Promise<void>(resolve => { this.open = resolve })
+
+  async wait (): Promise<void> {
+    this.entered += 1
+    await this.opened
+  }
+
+  release (): void {
+    this.open()
+  }
+}
+
+/** Polls until the condition holds, so a test never races the seam it installed. */
+export const until = async (
+  condition: () => boolean,
+  what: string,
+  timeoutMs = 5_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs
+  while (!condition()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`)
+    await new Promise(resolve => setTimeout(resolve, 5))
+  }
+}

--- a/backend/test/ws-handshake-revocation-race.spec.ts
+++ b/backend/test/ws-handshake-revocation-race.spec.ts
@@ -1,0 +1,191 @@
+import { randomUUID } from 'node:crypto'
+
+import { CLOSE_CODES, PROTOCOL_VERSION } from 'common'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { makeFactory } from 'common/testing'
+import request from 'supertest'
+import type { ClientMessage, ClientOpMessage, RoomDiff } from 'common'
+import type { Connection } from 'mongoose'
+
+import { AccountTokenService } from '../src/auth/account-token.service'
+import { Gate, until } from './utils/gate'
+import { RoomAccessService } from '../src/realtime/room-access.service'
+import { RoomOpService } from '../src/realtime/room-op.service'
+import { TestClient, closeAll } from './utils/ws-client'
+import { TestContext, VERSION_HEADERS, awaitConnection, createTestApp, destroyTestApp } from './utils/test-app'
+import { TestUser, buildIndexes, call, registerAndLogin, resetRooms } from './utils/rooms'
+import { wsConnectionLimiter } from '../src/realtime/ws-throttle'
+
+const PASSWORD = 'ficsit-forever'
+
+/**
+ * Revocation closes the sockets it can see. A handshake still reading account state is
+ * not one of them, and a message already inside the op queue is past every check the
+ * gateway makes on arrival. Both windows are staged here rather than described.
+ */
+describe('revocation against work that is already in flight', () => {
+  let context: TestContext
+  let connection: Connection
+  let url: string
+  let owner: TestUser
+  let member: TestUser
+  let roomId: string
+  let clients: TestClient[]
+  let restore: (() => void) | null
+
+  const post = (path: string, as?: TestUser) => call(context.app, 'post', path, as)
+
+  const changePassword = (token: string, newPassword: string) =>
+    request(context.app.getHttpServer())
+      .post('/me/password')
+      .set(VERSION_HEADERS)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: PASSWORD, newPassword })
+
+  const revisionOf = async () => (await connection.collection('rooms').findOne({ roomId }))?.revision
+
+  const joined = async (token: string) => {
+    const client = await TestClient.greet(url, token)
+    clients.push(client)
+    client.send({ type: 'join', roomId })
+    await client.next('snapshot')
+    await client.next('presence')
+    return client
+  }
+
+  const op = (diff: RoomDiff, baseRevision: number): ClientOpMessage =>
+    ({ type: 'op', roomId, opId: randomUUID(), baseRevision, diff })
+
+  /** The socket may already be gone, which is the outcome under test, not an error. */
+  const trySend = (client: TestClient, message: ClientMessage) => {
+    try {
+      client.send(message)
+    } catch {
+      // Nothing to do: a closed socket is exactly what should have happened.
+    }
+  }
+
+  beforeAll(async () => {
+    context = await createTestApp({ unthrottled: true })
+    connection = await awaitConnection(context.app)
+    url = context.wsUrl
+    await buildIndexes(context.app)
+  })
+
+  afterAll(async () => {
+    await destroyTestApp(context)
+  })
+
+  beforeEach(async () => {
+    clients = []
+    restore = null
+    wsConnectionLimiter.reset()
+    await resetRooms(context.app)
+    owner = await registerAndLogin(context.app, 'owner')
+    member = await registerAndLogin(context.app, 'member')
+    roomId = randomUUID()
+    await post('/rooms', owner).send({ roomId, name: 'Iron Line', factories: [makeFactory({ id: 1 })] })
+    await post(`/rooms/${roomId}/share`, owner).send({})
+    await post(`/rooms/${roomId}/join`, member).send({})
+  })
+
+  afterEach(() => {
+    restore?.()
+    closeAll(clients)
+  })
+
+  /**
+   * The handshake reads the account, the rotation commits and closes every socket it can
+   * find, and only then does the handshake finish. Winning that window used to hand the
+   * connection a live session on a token that will never be accepted again.
+   */
+  it('refuses a handshake that was in flight when the account was revoked', async () => {
+    const gate = new Gate()
+    const accounts = context.app.get(AccountTokenService)
+    const original = accounts.accountState.bind(accounts)
+    restore = () => { accounts.accountState = original }
+
+    accounts.accountState = async userId => {
+      // Read first, then park: the state this handshake decides on is the pre-rotation one.
+      const state = await original(userId)
+      await gate.wait()
+      return state
+    }
+
+    const client = await TestClient.open(url)
+    clients.push(client)
+    client.send({ type: 'hello', protocolVersion: PROTOCOL_VERSION, token: member.token })
+    await until(() => gate.entered === 1, 'the handshake to reach the account read')
+
+    await changePassword(member.token, 'brand-new')
+    gate.release()
+
+    await expect(client.waitForClose(2_000)).resolves.toMatchObject({
+      code: CLOSE_CODES.unauthorized,
+    })
+    await client.expectSilence('hello_ok')
+
+    trySend(client, { type: 'join', roomId })
+    trySend(client, op({ factories: [makeFactory({ id: 2, name: 'Won the race' })] }, 0))
+
+    await client.expectSilence('snapshot')
+    expect(await revisionOf()).toBe(0)
+  })
+
+  /**
+   * One apply per room, in arrival order. An op that reached the queue before the socket
+   * was revoked is past every check the gateway makes on arrival, and its own authorizer
+   * still sees an intact membership: the account's tokens went, not the room's grant.
+   */
+  it('does not commit an op that was already queued when the socket was revoked', async () => {
+    const ownerClient = await joined(owner.token)
+    const memberClient = await joined(member.token)
+
+    const gate = new Gate()
+    const access = context.app.get(RoomAccessService)
+    const originalAuthorize = access.authorizeWithContent.bind(access)
+    const ops = context.app.get(RoomOpService)
+    const originalApply = ops.apply.bind(ops)
+    let queued = 0
+    restore = () => {
+      access.authorizeWithContent = originalAuthorize
+      ops.apply = originalApply
+    }
+
+    // Parks the head of the room queue, so the next op arrives behind it.
+    access.authorizeWithContent = async (id, credentials) => {
+      if (gate.entered === 0) await gate.wait()
+      return originalAuthorize(id, credentials)
+    }
+    ops.apply = (message, actor, authorize) => {
+      queued += 1
+      return originalApply(message, actor, authorize)
+    }
+
+    ownerClient.send(op({ factories: [makeFactory({ id: 2, name: 'Owner edit' })] }, 0))
+    await until(() => gate.entered === 1, 'the owner\'s op to park in the queue')
+
+    memberClient.send(op({ factories: [makeFactory({ id: 3, name: 'Queued behind it' })] }, 1))
+    await until(() => queued === 2, 'the member\'s op to reach the queue')
+
+    // The socket is revoked with its op already past the door.
+    await changePassword(member.token, 'brand-new')
+    gate.release()
+
+    await expect(ownerClient.next('op_ack')).resolves.toMatchObject({ revision: 1 })
+    await expect(memberClient.waitForClose(2_000)).resolves.toMatchObject({
+      code: CLOSE_CODES.unauthorized,
+    })
+
+    // A third op behind the queued one, which is what makes the assertion exact: the
+    // queue is FIFO, so this settles only after the member's op has had its turn, and
+    // its own base revision is the count of what committed in between.
+    ownerClient.send(op({ factories: [makeFactory({ id: 4, name: 'After the queue' })] }, 1))
+
+    await expect(ownerClient.nextOneOf(['op_ack', 'op_reject'])).resolves.toMatchObject({
+      type: 'op_ack',
+      revision: 2,
+    })
+    expect(await revisionOf()).toBe(2)
+  })
+})

--- a/backend/test/ws-revocation-fail-closed.spec.ts
+++ b/backend/test/ws-revocation-fail-closed.spec.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from 'node:crypto'
+
+import { CLOSE_CODES } from 'common'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { makeFactory } from 'common/testing'
+import type { ClientOpMessage, RoomDiff } from 'common'
+import type { Connection } from 'mongoose'
+
+import { FailingStepRunner, TestUser, buildIndexes, call, registerAndLogin, resetRooms } from './utils/rooms'
+import { RoomAccessService } from '../src/realtime/room-access.service'
+import { until } from './utils/gate'
+import { TestClient, closeAll } from './utils/ws-client'
+import { TestContext, awaitConnection, createTestApp, destroyTestApp } from './utils/test-app'
+import { WS_INTERNAL_ERROR } from '../src/realtime/realtime.constants'
+import { wsConnectionLimiter } from '../src/realtime/ws-throttle'
+
+/**
+ * A revocation lever commits in one write, and everything after it is bookkeeping that
+ * can fail. If the kick rides on that bookkeeping it is skipped entirely when the
+ * bookkeeping throws, and `broadcastOp` hands the owner's private plan to a socket that
+ * was supposed to be gone — for as long as it stays quiet and answers pings.
+ */
+describe('revocation is fail-closed, whatever happens after the write', () => {
+  let context: TestContext
+  let connection: Connection
+  let url: string
+  let owner: TestUser
+  let member: TestUser
+  let roomId: string
+  let clients: TestClient[]
+  let restore: (() => void) | null
+  const steps = new FailingStepRunner()
+
+  const post = (path: string, as?: TestUser) => call(context.app, 'post', path, as)
+  const put = (path: string, as?: TestUser) => call(context.app, 'put', path, as)
+  const del = (path: string, as?: TestUser) => call(context.app, 'delete', path, as)
+
+  const revisionOf = async () => (await connection.collection('rooms').findOne({ roomId }))?.revision
+
+  const joined = async (token?: string, visitorToken?: string) => {
+    const client = await TestClient.greet(url, token)
+    clients.push(client)
+    client.send({ type: 'join', roomId, visitorToken })
+    await client.next('snapshot')
+    await client.next('presence')
+    return client
+  }
+
+  const visitorToken = async (password: string): Promise<string> =>
+    (await post(`/rooms/${roomId}/auth`).send({ password })).body.visitorToken
+
+  const op = (diff: RoomDiff, baseRevision = 0): ClientOpMessage =>
+    ({ type: 'op', roomId, opId: randomUUID(), baseRevision, diff })
+
+  /** The owner edits the plan, so any peer still in the room is fanned out to. */
+  const ownerEdits = async (ownerClient: TestClient, baseRevision: number) => {
+    ownerClient.send(op({ factories: [makeFactory({ id: 2, name: 'Private line' })] }, baseRevision))
+    await ownerClient.next('op_ack')
+  }
+
+  beforeAll(async () => {
+    context = await createTestApp({ stepRunner: steps, unthrottled: true })
+    connection = await awaitConnection(context.app)
+    url = context.wsUrl
+    await buildIndexes(context.app)
+  })
+
+  afterAll(async () => {
+    await destroyTestApp(context)
+  })
+
+  beforeEach(async () => {
+    clients = []
+    restore = null
+    steps.reset()
+    wsConnectionLimiter.reset()
+    await resetRooms(context.app)
+    owner = await registerAndLogin(context.app, 'owner')
+    member = await registerAndLogin(context.app, 'member')
+    roomId = randomUUID()
+    await post('/rooms', owner).send({ roomId, name: 'Iron Line', factories: [makeFactory({ id: 1 })] })
+    await post(`/rooms/${roomId}/share`, owner).send({})
+    await post(`/rooms/${roomId}/join`, member).send({})
+    await put(`/rooms/${roomId}/password`, owner).send({ password: 'ficsit' })
+  })
+
+  afterEach(() => {
+    restore?.()
+    steps.reset()
+    closeAll(clients)
+  })
+
+  describe('a password rotation whose bookkeeping fails after the write', () => {
+    it('still kicks the visitor and stops fanning the plan out to them', async () => {
+      const visitor = await joined(undefined, await visitorToken('ficsit'))
+      const ownerClient = await joined(owner.token)
+
+      // The hash and the version bump have committed; the revision bump has not.
+      steps.failAt = 'bump-rooms-revision'
+      expect((await put(`/rooms/${roomId}/password`, owner).send({ password: 'ficsit-2' })).status)
+        .toBe(500)
+      steps.reset()
+
+      await ownerEdits(ownerClient, 0)
+
+      await visitor.expectSilence('op_apply')
+      await visitor.expectSilence('snapshot')
+      await expect(visitor.waitForClose(2_000)).resolves.toMatchObject({
+        code: CLOSE_CODES.forbidden,
+      })
+    })
+
+    it('leaves the member, whose access a rotation never touched', async () => {
+      const memberClient = await joined(member.token)
+      const ownerClient = await joined(owner.token)
+
+      steps.failAt = 'bump-rooms-revision'
+      await put(`/rooms/${roomId}/password`, owner).send({ password: 'ficsit-2' })
+      steps.reset()
+
+      await ownerEdits(ownerClient, 0)
+
+      await expect(memberClient.next('op_apply')).resolves.toMatchObject({ roomId, revision: 1 })
+      expect(memberClient.closeInfo).toBeNull()
+    })
+  })
+
+  /**
+   * Removal carries the same version bump and the same emit-after-the-chain shape, but
+   * a room with no password lets every visitor in, so the sweep grants rather than
+   * kicks. What has to be true is that the sweep runs at all: it is the write that owes
+   * it, not the bookkeeping, and only that ordering holds when the bookkeeping throws.
+   */
+  describe('a password removal whose bookkeeping fails after the write', () => {
+    it('still re-checks every socket in the room', async () => {
+      const visitor = await joined(undefined, await visitorToken('ficsit'))
+      await joined(owner.token)
+
+      const access = context.app.get(RoomAccessService)
+      const original = access.authorize.bind(access)
+      let rechecks = 0
+      restore = () => { access.authorize = original }
+      access.authorize = (id, credentials) => {
+        rechecks += 1
+        return original(id, credentials)
+      }
+
+      steps.failAt = 'bump-rooms-revision'
+      expect((await del(`/rooms/${roomId}/password`, owner)).status).toBe(500)
+      steps.reset()
+
+      await until(() => rechecks > 0, 'the revocation sweep to re-check the room')
+      // Nobody is refused: the room is open now, which is what the removal meant.
+      expect(visitor.closeInfo).toBeNull()
+    })
+  })
+
+  /**
+   * The other way the kick goes missing: the sweep runs but cannot read the state it
+   * decides on. Guessing "still allowed" is the one answer that cannot be taken back,
+   * so the socket goes — with a code it may reconnect on, because a database blip is
+   * not a reason to sign anybody out.
+   */
+  describe('a sweep that cannot re-check the room', () => {
+    it('drops the socket rather than leaving it in the room', async () => {
+      const visitor = await joined(undefined, await visitorToken('ficsit'))
+      const ownerClient = await joined(owner.token)
+
+      const access = context.app.get(RoomAccessService)
+      const original = access.authorize.bind(access)
+      restore = () => { access.authorize = original }
+      access.authorize = async () => { throw new Error('injected access read failure') }
+
+      await put(`/rooms/${roomId}/password`, owner).send({ password: 'ficsit-2' })
+
+      await expect(visitor.waitForClose(2_000)).resolves.toMatchObject({
+        code: WS_INTERNAL_ERROR,
+      })
+      await expect(ownerClient.waitForClose(2_000)).resolves.toMatchObject({
+        code: WS_INTERNAL_ERROR,
+      })
+      expect(await revisionOf()).toBe(0)
+    })
+  })
+})

--- a/common/src/schemas/events.ts
+++ b/common/src/schemas/events.ts
@@ -62,6 +62,10 @@ export const EVENT_REASONS = [
   'share_id_allocation_exhausted',
   'ws_handshake_internal_error',
   'ws_message_handler_error',
+  /** A socket was dropped because its account could not be re-read on join. */
+  'ws_token_recheck_failed',
+  /** A revocation sweep could not read the room, so it dropped the sockets instead. */
+  'ws_access_recheck_failed',
   /** A socket asked to be answered with a whole plan more often than any client needs to. */
   'ws_snapshot_reject_rate_exceeded',
   'room_access_unstable_race',


### PR DESCRIPTION
No manual steps or intervention required.

## What was wrong

Two ways a socket could keep access to a room after it had lost it.

**Revocation was not fail closed.** `setPassword` commits the new hash and the
`passwordVersion` bump, and that write alone is what kills every outstanding visitor
token. The kick that acts on it was emitted only after `finishMetaMutation`, which reads
memberships and bumps account revisions. Anything in that tail throwing skipped the kick
altogether. `broadcastOp` then hands every changed factory to whatever is registered for
the room with no further check, so a visitor who should have been gone kept receiving the
private plan indefinitely, for as long as it stayed quiet and answered pings. That is a
lot worse than the millisecond fan-out window the design document accepts.

The sweep had a second way of not happening: `revokeAccess` re-reads access per socket,
and a read that threw left the whole sweep logged and abandoned. "Could not tell" was
being resolved as "still allowed", which is the one answer that cannot be taken back.

**A handshake in flight survived revocation.** `handleHello` read account state before
registering the connection in the account index. A rotation committing in that window
closed every socket it could find, and a socket still being greeted was not one of them.
The handshake then finished, registered itself holding the generation the rotation had
just killed, and `join` and `op` authorize from `connection.userId` without ever asking
again. Winning that window bought continuing access, owner writes included.

## What changed

- The visitor kick now rides on the password write in `setPassword` and `removePassword`,
  ahead of the bookkeeping, exactly as `unshare` already did.
- `revokeAccess` fails closed per socket. A re-check that throws drops that socket on
  `1011` rather than `4403`, so a database blip costs a reconnect instead of signing
  somebody out, and the join that follows re-runs the real check.
- The handshake claims its slot in the account index before the account read, and checks
  whether it was kicked while suspended before it completes. A second hello racing the
  first is refused, so only one claim per socket is ever made.
- The token generation the greeting arrived with is retained on the connection.
- `Connection.send` drops frames once the connection has been closed, so a fan-out that
  overlaps the asynchronous close handshake cannot still be written.

## Where I re-validate, and why there

Both places, because the two failure modes are different sizes.

`join` re-reads the account's token generation and compares it against the one retained
on the connection. That is the frame that hands over a whole plan, it already makes three
or four reads, and one more projected single-field read on the same index every
authenticated REST call uses is proportionate to what it is protecting. Claiming the
index slot early closes the in-process race on its own; the read on join is what covers a
generation that moved without this process hearing about it.

`op` re-validates from the connection's own invalidated flag rather than from the
database, checked inside the room's apply queue. Ops are the hot path and a read each
would be out of proportion, and an op cannot leak content that join did not already hand
over. The flag placement matters more than its cost: the queue is where the waiting
happens, so an op that got through the door before the kick is refused after it. The
room's own checks cannot see this case, because an account revocation leaves the
membership intact and takes only the socket.

## The other kick paths

`setPassword` was the exploitable one. `removePassword` had the same shape and is fixed
the same way, though its sweep grants rather than kicks: a room with no password lets
every visitor in, which is what the removal meant. `unshare`, `leave` and room `delete`
were already sound. `unshare` emits on its epoch write. `leave` emits immediately after
the membership deletion, and the steps before it cannot withdraw access without it.
`delete` emits on the tombstone write, and a tombstoned room refuses every join
regardless.

## Tests

Six new cases across two suites, written against the old code first. Five failed on it,
and the failures are the bugs rather than a proxy for them: the revoked visitor's queue
held an `op_apply` carrying the owner's whole factory, the queued op committed and stole
the next revision, and the delayed handshake was never closed at all. The sixth passes on
both and is there to catch over-kicking, since a fix that closes everything would satisfy
the other five.

- a rotation whose bookkeeping throws at `bump-rooms-revision`: the visitor takes no
  further `op_apply` and no room content, and is closed 4403
- the member, whose access a rotation never touched, keeps taking the fan-out
- the same injected failure on removal: the sweep still re-checks every socket in the room
- a sweep that cannot read the room drops the sockets rather than leaving them in it
- a handshake parked inside the account read while the rotation commits: no `hello_ok`,
  closed 4401, and nothing it sends afterwards joins or writes
- an op already in the room queue when its socket was revoked: it does not commit, proved
  by a third op whose base revision is the count of what committed in between

The races are staged with a gate inside the real code path rather than serialised with
awaits. No existing test was weakened, deleted or relaxed.

`cd backend && pnpm exec vitest run`: 36 files, 518 passed, 0 failed (512 before this
branch). `pnpm run lint` from the root: clean, 0 errors. `common` and the backend build
both compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
