### PR TITLE
fix(web): make a plan import atomic and tied to the tab it was confirmed for

### DIFF
--- a/web/src/components/planner/ImportPlanDialog.vue
+++ b/web/src/components/planner/ImportPlanDialog.vue
@@ -1,10 +1,15 @@
 <template>
+  <!-- Sealed while an import is running. The dialog being modal is what keeps the tab bar
+       out of reach until the replacement has landed, so a dismissable one would hand back
+       the very window the import has to be protected from. -->
   <app-dialog
     v-model="open"
     card-class="border-md"
+    :closable="!busy"
     data-testid="import-plan-dialog"
     icon="fas fa-file-import"
     max-width="720"
+    :persistent="busy"
     title="Import a plan"
   >
     <p class="mb-4 text-body-2">

--- a/web/src/components/planner/PlannerGlobalActions.spec.ts
+++ b/web/src/components/planner/PlannerGlobalActions.spec.ts
@@ -448,3 +448,216 @@ describe('Component: PlannerGlobalActions clipboard', () => {
     expect(appStore.getCurrentTab().name).toBe('Keep Me')
   })
 })
+
+/**
+ * An import empties a tab and refills it, and until it finishes the tab holds neither plan.
+ * These are about that gap: which tab it belongs to, what happens when the replacement turns
+ * out to be unloadable, and what the dialog is allowed to claim while it is still open.
+ */
+describe('Component: PlannerGlobalActions import safety', () => {
+  let appStore: ReturnType<typeof useAppStore>
+  let readText: ReturnType<typeof vi.fn>
+
+  /**
+   * Wired to the planner's own `clear-all` handler. Mounted bare the emit goes nowhere, and
+   * the destructive half of an import simply does not happen, which is the half these are about.
+   */
+  const mountSubject = () =>
+    mount(PlannerGlobalActions, {
+      global: { plugins: [vuetify], stubs: { Templates: true } },
+      props: { onClearAll: () => appStore.clearFactories() },
+    })
+
+  const at = (testId: string) => document.body.querySelector<HTMLElement>(`[data-testid="${testId}"]`)
+
+  const importFromClipboard = async (subject: VueWrapper) => {
+    const button = subject.findAll('button').find(b => b.text().includes('Import plan'))
+    if (!button) throw new Error('Button "Import plan" not found')
+    await button.trigger('click')
+    await flushPromises()
+    at('import-from-clipboard')!.click()
+    await flushPromises()
+  }
+
+  /** Long enough for the timer the import used to hide its work behind. */
+  const afterAnyPendingTimer = async () => {
+    await new Promise(resolve => setTimeout(resolve, 350))
+    await flushPromises()
+  }
+
+  const secondTab = () => appStore.addTab(
+    { name: 'Second', factories: [newFactory('Beta')] },
+    { activate: false },
+  )
+
+  const fullPlan = () => JSON.stringify({
+    name: 'Pasted Plan',
+    factories: [newFactory('Pasted')],
+    powerTarget: 1234,
+    groups: [{ id: 'new', name: 'Incoming', color: '#2196f3', order: 0 }],
+    depotUploadTier: 2,
+  })
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    localStorage.clear()
+    setActivePinia(createPinia())
+    appStore = useAppStore()
+
+    readText = vi.fn()
+    vi.stubGlobal('navigator', { clipboard: { writeText: vi.fn(), readText } })
+    vi.stubGlobal('confirm', vi.fn(() => true))
+
+    appStore.getCurrentTab().name = 'Original'
+    appStore.getCurrentTab().powerTarget = 4000
+    appStore.getCurrentTab().factories = [newFactory('Mine')]
+    appStore.getFactories()
+  })
+
+  it('lands the plan in the tab it was confirmed for, whatever the user switches to next', async () => {
+    const destination = appStore.getCurrentTab()
+    const otherId = secondTab()
+    const prepareLoader = vi.spyOn(appStore, 'prepareLoader').mockResolvedValue(undefined)
+    readText.mockResolvedValue(fullPlan())
+
+    const subject = mountSubject()
+    await importFromClipboard(subject)
+    // The moment the dialog lets go, the user goes back to the other tab.
+    appStore.activateTab(otherId)
+    await afterAnyPendingTimer()
+
+    const other = appStore.getTab(otherId)!
+    expect(other.name).toBe('Second')
+    expect(other.powerTarget).toBeUndefined()
+    // Normalised to an empty list by the load the tab switch runs, which is the point: what
+    // it must never hold is the group that arrived with the imported plan.
+    expect(other.groups ?? []).toHaveLength(0)
+    expect(other.factories.map(factory => factory.name)).toEqual(['Beta'])
+
+    expect(destination.name).toBe('Pasted Plan')
+    expect(destination.powerTarget).toBe(1234)
+    expect(destination.depotUploadTier).toBe(2)
+    expect(prepareLoader.mock.calls[0][0]).toHaveLength(1)
+    subject.unmount()
+  })
+
+  // The tab the user moved to is somebody else's plan as well, and it was never named in
+  // anything they agreed to.
+  it('never announces a plan into a synced tab it was not confirmed for', async () => {
+    const destination = appStore.getCurrentTab()
+    const otherId = secondTab()
+    appStore.setTabState(otherId, { kind: 'synced', shared: true, role: 'owner', revision: 1 })
+    const landed = vi.fn()
+    eventBus.on('planLanded', landed)
+    vi.spyOn(appStore, 'prepareLoader').mockResolvedValue(undefined)
+    readText.mockResolvedValue(fullPlan())
+
+    const subject = mountSubject()
+    await importFromClipboard(subject)
+    appStore.activateTab(otherId)
+    await afterAnyPendingTimer()
+
+    expect(landed).toHaveBeenCalledTimes(1)
+    expect(landed).toHaveBeenCalledWith(destination.id)
+    expect(landed).not.toHaveBeenCalledWith(otherId)
+
+    const other = appStore.getTab(otherId)!
+    expect(other.name).toBe('Second')
+    expect(other.factories.map(factory => factory.name)).toEqual(['Beta'])
+    eventBus.off('planLanded', landed)
+    subject.unmount()
+  })
+
+  // Valid JSON, with a factories array in it, and nothing in that array the loader can read.
+  it('turns away a plan it cannot load without touching the one already there', async () => {
+    const prepareLoader = vi.spyOn(appStore, 'prepareLoader').mockResolvedValue(undefined)
+    readText.mockResolvedValue(JSON.stringify({ name: 'Broken', factories: [{ name: 'No parts' }] }))
+
+    const subject = mountSubject()
+    await importFromClipboard(subject)
+    await afterAnyPendingTimer()
+
+    expect(appStore.getCurrentTab().factories.map(factory => factory.name)).toEqual(['Mine'])
+    expect(appStore.getCurrentTab().name).toBe('Original')
+    expect(prepareLoader).not.toHaveBeenCalled()
+    expect(at('import-error')?.textContent).toContain('cannot load it')
+    expect(at('import-plan-dialog')).not.toBeNull()
+    subject.unmount()
+  })
+
+  it('puts the outgoing plan back when the load itself fails', async () => {
+    vi.spyOn(appStore, 'prepareLoader')
+      .mockRejectedValueOnce(new Error('the load chain died'))
+      .mockResolvedValue(undefined)
+    readText.mockResolvedValue(fullPlan())
+
+    const subject = mountSubject()
+    await importFromClipboard(subject)
+    await afterAnyPendingTimer()
+
+    expect(appStore.getCurrentTab().factories.map(factory => factory.name)).toEqual(['Mine'])
+    expect(appStore.getCurrentTab().name).toBe('Original')
+    expect(appStore.getCurrentTab().powerTarget).toBe(4000)
+    expect(at('import-error')?.textContent).toContain('put back')
+    expect(at('import-plan-dialog')).not.toBeNull()
+    subject.unmount()
+  })
+
+  // The dialog closing is the app saying the plan is in. It has to be true when it says it.
+  it('reports nothing until the replacement has actually landed', async () => {
+    let finishTheLoad: () => void = () => {}
+    vi.spyOn(appStore, 'prepareLoader')
+      .mockImplementation(() => new Promise<void>(resolve => { finishTheLoad = resolve }))
+    readText.mockResolvedValue(fullPlan())
+
+    const subject = mountSubject()
+    await importFromClipboard(subject)
+
+    // The load is still running, so nothing has any business saying it is done. The dialog
+    // is still up and still busy, which is also what holds the tab bar out of reach.
+    expect(at('import-plan-dialog')).not.toBeNull()
+    expect(at('import-from-clipboard')?.className).toContain('v-card--disabled')
+    expect(at('import-error')).toBeNull()
+
+    finishTheLoad()
+    await flushPromises()
+
+    expect(at('import-from-clipboard')?.className ?? '').not.toContain('v-card--disabled')
+    expect(appStore.getCurrentTab().name).toBe('Pasted Plan')
+    subject.unmount()
+  })
+
+  it('replaces the whole tab with the imported plan, settings and all', async () => {
+    const prepareLoader = vi.spyOn(appStore, 'prepareLoader').mockResolvedValue(undefined)
+    readText.mockResolvedValue(fullPlan())
+
+    const subject = mountSubject()
+    await importFromClipboard(subject)
+
+    const tab = appStore.getCurrentTab()
+    expect(tab.name).toBe('Pasted Plan')
+    expect(tab.powerTarget).toBe(1234)
+    expect(tab.groups).toEqual([{ id: 'new', name: 'Incoming', color: '#2196f3', order: 0 }])
+    expect(tab.depotUploadTier).toBe(2)
+    expect(tab.depotExpansionTier).toBeUndefined()
+    expect(prepareLoader.mock.calls[0][0]?.map(factory => factory.name)).toEqual(['Pasted'])
+    expect(at('import-error')).toBeNull()
+    subject.unmount()
+  })
+
+  // Queued rather than run, a load lands whenever the running one lets go, which is long
+  // after this would have reported success.
+  it('refuses to start while the planner is already loading a plan', async () => {
+    appStore.loadInFlight = true
+    const prepareLoader = vi.spyOn(appStore, 'prepareLoader').mockResolvedValue(undefined)
+    readText.mockResolvedValue(fullPlan())
+
+    const subject = mountSubject()
+    await importFromClipboard(subject)
+
+    expect(prepareLoader).not.toHaveBeenCalled()
+    expect(appStore.getCurrentTab().factories.map(factory => factory.name)).toEqual(['Mine'])
+    expect(at('import-error')?.textContent).toContain('still loading')
+    subject.unmount()
+  })
+})

--- a/web/src/components/planner/PlannerGlobalActions.vue
+++ b/web/src/components/planner/PlannerGlobalActions.vue
@@ -142,10 +142,12 @@
   import { confirmDialog } from '@/utils/helpers'
   import { downloadPlan, serializePlan } from '@/utils/plan-backup'
   import type { PlanBlob } from '@/utils/plan-backup'
+  import type { Factory, FactoryTab } from '@/interfaces/planner/FactoryInterface'
   import { markTabEdited } from '@/utils/sync-intent'
   import eventBus from '@/utils/eventBus'
 
-  const { getFactories, getCurrentTab, getTabState, prepareLoader, forceCalculation } = useAppStore()
+  const appStore = useAppStore()
+  const { getFactories, getCurrentTab, getTabState, prepareLoader, forceCalculation } = appStore
   const { powerTarget } = usePowerTarget()
   const options = usePlannerOptions()
 
@@ -259,101 +261,220 @@
   }
 
   /**
+   * The shapes the loader walks straight into without checking. A blob can be valid JSON
+   * carrying a factories array and still be missing these, in which case the load throws
+   * part way through with the destination tab already emptied. Checked here instead, so a
+   * plan that cannot load is turned away before anything is destroyed.
+   */
+  const assertLoadable = (factories: unknown[]) => {
+    factories.forEach((entry, index) => {
+      const unreadable = (what: string) =>
+        new Error(`Factory ${index + 1} in it has no ${what}, so the planner cannot load it.`)
+
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) throw unreadable('readable record')
+      const factory = entry as Record<string, unknown>
+      if (!Array.isArray(factory.products)) throw unreadable('list of products')
+      if (!Array.isArray(factory.inputs)) throw unreadable('list of imports')
+      if (!factory.parts || typeof factory.parts !== 'object' || Array.isArray(factory.parts)) {
+        throw unreadable('satisfaction data')
+      }
+      if (factory.powerProducers !== undefined && !Array.isArray(factory.powerProducers)) {
+        throw unreadable('readable list of power producers')
+      }
+    })
+  }
+
+  /**
+   * Everything the destination tab held, kept until the replacement has landed. The array
+   * copy is shallow on purpose: a load rewrites the factories arriving, never these, and a
+   * deep clone of a big plan costs seconds on the main thread.
+   */
+  const snapshotTab = (tab: FactoryTab) => ({
+    factories: [...tab.factories],
+    name: tab.name,
+    powerTarget: tab.powerTarget,
+    groups: tab.groups,
+    plannerVersion: tab.plannerVersion,
+    depotUploadTier: tab.depotUploadTier,
+    depotExpansionTier: tab.depotExpansionTier,
+  })
+
+  const restoreTab = async (tab: FactoryTab, outgoing: ReturnType<typeof snapshotTab>) => {
+    tab.name = outgoing.name
+    tab.powerTarget = outgoing.powerTarget
+    tab.groups = outgoing.groups
+    tab.plannerVersion = outgoing.plannerVersion
+    tab.depotUploadTier = outgoing.depotUploadTier
+    tab.depotExpansionTier = outgoing.depotExpansionTier
+    tab.factories = outgoing.factories
+
+    // The store keeps the plan it was loading under this key and picks it up on the next
+    // load as a recovery copy. Left there it would put the import that just failed straight
+    // back over the plan being restored.
+    try {
+      localStorage.removeItem('preLoadFactories')
+    } catch (cause) {
+      console.error('applyPlanBlob: could not clear the recovery copy', cause)
+    }
+
+    // The failed load hid the planner, so the restored plan needs drawing or the tab reads
+    // empty until the page is reloaded. Guarded on its own: a restore that cannot draw has
+    // still put the data back, which is the half that matters.
+    try {
+      if (getCurrentTab()?.id === tab.id) await prepareLoader(outgoing.factories)
+    } catch (cause) {
+      console.error('applyPlanBlob: the outgoing plan was restored but could not be drawn', cause)
+    }
+  }
+
+  /**
+   * Replaces the destination tab's settings with the pasted plan's (keeping its id), so the
+   * plan is calculated against its own settings rather than the outgoing tab's. Writes to
+   * the tab it is handed rather than to whichever is current, which is the whole point.
+   */
+  const applyPastedTabSettings = (tab: FactoryTab, parsedPlan: PlanBlob) => {
+    tab.powerTarget = Number(parsedPlan.powerTarget) || 0
+    markTabEdited('powerTarget')
+    if (parsedPlan.name) tab.name = parsedPlan.name
+    tab.plannerVersion = parsedPlan.plannerVersion
+    // Assigned rather than merged, and assigned even when the blob has none: clearing
+    // the factories cannot take memberless groups with it, so anything left here
+    // belongs to the plan being replaced.
+    tab.groups = parsedPlan.groups
+    // Assigned unconditionally for the same reason. A blob written before these
+    // existed means "not stated", which reads as fully researched — inheriting the
+    // outgoing tab's tiers instead would silently size the pasted plan against
+    // somebody else's save.
+    tab.depotUploadTier = parsedPlan.depotUploadTier
+    tab.depotExpansionTier = parsedPlan.depotExpansionTier
+    // Declared for whatever the blob actually stated. An absent value is not
+    // declarable — the diff cannot carry "cleared" — so a blob that states none
+    // leaves the room's own settings alone rather than silently clearing them.
+    declarePastedTabFields(parsedPlan)
+  }
+
+  /** A legacy bare-array blob states none of the tab settings, so none of them survive it. */
+  const clearLegacyTabSettings = (tab: FactoryTab) => {
+    delete tab.plannerVersion
+    // A blob from before groups existed has none, so anything here belongs to the plan
+    // being replaced.
+    delete tab.groups
+    // Same for the Depot tiers: a bare-array blob predates them entirely.
+    delete tab.depotUploadTier
+    delete tab.depotExpansionTier
+  }
+
+  const refusal = (error: unknown) => error instanceof Error
+    ? `That does not look like a plan the planner wrote. ${error.message}`
+    : 'That does not look like a plan the planner wrote.'
+
+  /**
    * The one path a plan comes back in by, whatever carried it here. Reports rather
    * than alerts: an import that fails belongs in the dialog it failed in, where the
    * other way in is still one click away.
+   *
+   * The whole plan is read and checked before the destination is touched, the destination
+   * is decided once and everything is written against that tab, the outgoing plan is kept
+   * until the replacement has landed, and the load is awaited. Nothing here reports success
+   * for work that has not finished.
+   *
+   * There used to be a 250ms timer between emptying the tab and loading the replacement. It
+   * dates from the load being synchronous: `prepareLoader` set the factories the instant it
+   * was called, and the pause was what let the planner tear the cleared cards down first.
+   * The loader has done that waiting itself for a long time now (it hides the planner,
+   * yields a frame and pauses before it commits anything), so the timer bought nothing and
+   * cost a window in which the user could switch tabs and take the import with them.
    */
-  const applyPlanBlob = (plan: string): true | string => {
+  const applyPlanBlob = async (plan: string): Promise<true | string> => {
+    let parsedPlan: PlanBlob | Factory[]
+    let factoriesToLoad: Factory[]
+    let isLegacy = false
+
     try {
-      const parsedPlan = JSON.parse(plan)
+      parsedPlan = JSON.parse(plan)
       // Legacy blobs are a bare Factory[] array; new ones are a full tab
       // { name, factories, powerTarget }.
-      const isLegacy = Array.isArray(parsedPlan)
-      const factoriesToLoad = isLegacy ? parsedPlan : parsedPlan.factories
+      isLegacy = Array.isArray(parsedPlan)
+      factoriesToLoad = (isLegacy ? parsedPlan : (parsedPlan as PlanBlob)?.factories) as Factory[]
       if (!Array.isArray(factoriesToLoad)) {
         throw new Error('Plan does not contain a factories array.')
       }
-      if (isLegacy) {
-        const tab = getCurrentTab()
-        if (tab) {
-          delete tab.plannerVersion
-          // A blob from before groups existed has none, so anything here belongs to the plan
-          // being replaced.
-          delete tab.groups
-          // Same for the Depot tiers: a bare-array blob predates them entirely.
-          delete tab.depotUploadTier
-          delete tab.depotExpansionTier
-        }
-      }
+      assertLoadable(factoriesToLoad)
+    } catch (error) {
+      recordEvent('plan_import_invalid')
+      return refusal(error)
+    }
 
+    // A load already running would queue this one rather than run it, and a queued load
+    // lands whenever the running one lets go, long after this has returned. Ask again once
+    // the planner is idle rather than report a replacement that has not happened.
+    if (appStore.loadInFlight) {
+      return 'The planner is still loading a plan. Wait for it to finish, then try the import again.'
+    }
+
+    // Decided ONCE, before anything is cleared, and every write below goes to this tab
+    // rather than to whichever happens to be current at the time. This is the tab the
+    // confirmation named, and it is the only tab this import is allowed to touch.
+    const destination = getCurrentTab()
+    if (!destination) {
+      recordEvent('plan_import_invalid')
+      return 'There is no tab open to import into.'
+    }
+
+    const outgoing = snapshotTab(destination)
+
+    try {
+      // Nothing awaits between emptying the tab and handing the replacement to the loader,
+      // so nothing can get in between the two and redirect it.
       emit('clear-all')
       // Announced as it is dropped in, before the load that draws it: this knows a
       // plan arrived and in which tab, and that is all it knows. Whoever cares
       // waits for the load themselves. The rooms store offers a local tab to the
       // cloud once it has drawn, which nothing else would.
-      const destination = getCurrentTab()
-      if (destination) eventBus.emit('planLanded', destination.id)
+      eventBus.emit('planLanded', destination.id)
 
-      setTimeout(() => {
-        // Replace the current tab's settings with the pasted plan's (keeps its id) before
-        // loading, so the plan is calculated against its own settings rather than the
-        // outgoing tab's.
-        if (!isLegacy) {
-          powerTarget.value = Number(parsedPlan.powerTarget) || 0
-          const tab = getCurrentTab()
-          if (tab && parsedPlan.name) {
-            tab.name = parsedPlan.name
-          }
-          if (tab) {
-            tab.plannerVersion = parsedPlan.plannerVersion
-            // Assigned rather than merged, and assigned even when the blob has none: clearing
-            // the factories cannot take memberless groups with it, so anything left here
-            // belongs to the plan being replaced.
-            tab.groups = parsedPlan.groups
-            // Assigned unconditionally for the same reason. A blob written before these
-            // existed means "not stated", which reads as fully researched — inheriting the
-            // outgoing tab's tiers instead would silently size the pasted plan against
-            // somebody else's save.
-            tab.depotUploadTier = parsedPlan.depotUploadTier
-            tab.depotExpansionTier = parsedPlan.depotExpansionTier
-            // Declared for whatever the blob actually stated. An absent value is not
-            // declarable — the diff cannot carry "cleared" — so a blob that states none
-            // leaves the room's own settings alone rather than silently clearing them.
-            declarePastedTabFields(parsedPlan)
-          }
-        }
-        prepareLoader(factoriesToLoad)
-      }, 250)
+      if (isLegacy) clearLegacyTabSettings(destination)
+      else applyPastedTabSettings(destination, parsedPlan as PlanBlob)
+
+      await prepareLoader(factoriesToLoad)
       return true
     } catch (error) {
+      // The replacement failed somewhere after the tab was emptied, so put back what was
+      // there and say so. Reporting success over a plan that is now half gone is the one
+      // outcome there is no way back from.
+      await restoreTab(destination, outgoing)
       recordEvent('plan_import_invalid')
-      return error instanceof Error
-        ? `That does not look like a plan the planner wrote. ${error.message}`
-        : 'That does not look like a plan the planner wrote.'
+      console.error('applyPlanBlob: the import failed and the outgoing plan was restored', error)
+      return 'That plan could not be loaded, so your original plan has been put back. Try the import again, or check the file.'
     }
   }
 
   const runImport = async (read: () => Promise<string>, whenRefused: string) => {
     if (!confirmReplace()) return
 
+    // Held for the whole import, not just the read. The dialog is modal while it is busy,
+    // which is what keeps the tab bar out of reach until the replacement has landed, and
+    // the `finally` is what stops a thrown error leaving it that way for good.
     importing.value = true
     importError.value = ''
-    let text: string
     try {
-      text = await read()
-    } catch {
-      importing.value = false
-      importError.value = whenRefused
-      return
-    }
-    importing.value = false
+      let text: string
+      try {
+        text = await read()
+      } catch {
+        importError.value = whenRefused
+        return
+      }
 
-    const result = applyPlanBlob(text)
-    if (result !== true) {
-      importError.value = result
-      return
+      const result = await applyPlanBlob(text)
+      if (result !== true) {
+        importError.value = result
+        return
+      }
+      importOpen.value = false
+    } finally {
+      importing.value = false
     }
-    importOpen.value = false
   }
 
   /**


### PR DESCRIPTION
No manual steps or intervention required.

## What was wrong

Importing a plan replaced the current tab in this order: check that `factories` is an array, empty the tab, announce the landing, wait 250ms on a timer, then replace the tab settings and start the load without awaiting it. `applyPlanBlob` had already returned `true` and the dialog had already closed and reported success before any of the second half ran.

Two separate failures came out of that.

**The import could land in the wrong tab.** Switching tabs inside the 250ms window left the confirmed tab emptied and dropped the imported plan, its name, power target, groups and Depot tiers into whichever tab happened to be open when the timer fired. The confirmation named only the first tab, so nothing warned that the second could be overwritten. Where that second tab is synced or shared, the replacement propagates to everyone else in the room, who agreed to nothing.

**Success was reported before the work was done, or valid.** A blob that was syntactically fine and carried a factories array, but whose factories the loader cannot read, passed the only check there was. The tab was emptied, the dialog closed saying the import worked, and the load then failed asynchronously with nothing left to restore.

## What the 250ms wait was for

It dates from the load being synchronous. When the loader was introduced (#308), `prepareLoader` called `setFactories` the instant it was invoked, with no hiding, no yielded frame and no pause of its own. The timer was what let the planner tear down the cards `clear-all` had just emptied before the new plan started stamping itself in. It is the same "wait for the planner to comply" pause that still sits in `forceRecalc`.

`runLoad` has done that waiting itself for a long time now. It emits `plannerShow: false`, yields a frame through `nextPaint()`, and pauses 50ms before it reads or commits anything. So the outer timer bought nothing, and all it cost was a window in which the destination could change underneath the import. Nothing replaces it: awaiting `prepareLoader` is the wait, and it is a real one.

## What it does now

- Reads and checks the **whole** plan before touching anything. `assertLoadable` covers the shapes the loader walks straight into without checking (products, imports, satisfaction data, power producers), which is exactly the class of blob that used to pass the array check and then throw part way through the load.
- Decides the destination tab **once**, before anything is cleared, and writes every part of the replacement against that tab object rather than against `getCurrentTab()` at the time. The tab settings, the `planLanded` announcement and the load all target the tab the confirmation named.
- Nothing awaits between emptying the tab and handing the replacement to the loader, so there is no window for anything to get in between the two.
- Keeps the outgoing plan in a snapshot until the replacement has landed, and puts it back if any step fails, saying so in the dialog instead of reporting success. The store's own `preLoadFactories` recovery copy is cleared as part of the restore, since it holds the import that just failed and would otherwise be picked up by the next load.
- Awaits the load. The dialog stays open and busy for the whole operation, released in a `finally` so a thrown error cannot leave it stuck.

On blocking navigation: I have preferred the design that does not need it, and the dialog staying modal while busy is what covers the small remaining window inside the loader itself (before `beginLoading` pins the tab it is pushing into). Closing that last window outright would mean giving `prepareLoader` a target tab id, which is a change in `app-store.ts`, and I have deliberately not touched that file here.

One behaviour change worth calling out: an import asked for while another load is already running is now refused with a message rather than queued. A queued load lands whenever the running one lets go, which is long after this has returned, so it cannot be awaited and its success cannot be honestly reported.

## Validation

- `pnpm exec vitest run --silent --coverage` in `web`: 167 files, 3222 passed, 1 skipped.
- `pnpm exec vue-tsc --noEmit` in `web`: clean.
- `pnpm run lint` from the root: clean, no new warnings.

Seven new tests in `PlannerGlobalActions.spec.ts`, all of which I checked fail against the code before this change and pass after it. No existing test was weakened or removed, and the 24 that were already there stay green either way. They cover: the plan landing in the tab it was confirmed for while the user switches away mid-import; a synced tab never being announced or written to as a destination it was not confirmed for; a structurally invalid plan that passes the array check leaving the original untouched and reporting an error; a failure inside the load putting the outgoing plan back; the success path replacing name, power target, groups and Depot tiers from the imported plan; and the dialog refusing to claim success while the load is still running.

They mount the component wired to the planner's own `clear-all` handler. Mounted bare, as the existing tests are, the emit goes nowhere and the destructive half of an import never happens, which is the half these are about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
