### PR TITLE
test(repo): make the schema and concurrency proofs bite

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -54,6 +54,20 @@ jobs:
       - name: Lint check
         run: pnpm lint-check
 
+      # Nothing ran `common`'s own checks: its specs are excluded from
+      # tsconfig.build.json, so `pnpm build` never saw them, and neither sibling suite
+      # loads them. The zod schema in there is the whole data boundary. Checked in this
+      # job because it is the one that already installs the package; `--filter` resolves
+      # from the workspace root, so the backend working directory does not matter.
+      - name: Lint check Common
+        run: pnpm --filter common lint-check
+
+      - name: Typecheck Common
+        run: pnpm --filter common typecheck
+
+      - name: Test Common
+        run: pnpm --filter common exec vitest run
+
       # Builds `common` first, then `nest build`. vue-tsc's equivalent on web:
       # a type error fails the job rather than reaching the image.
       - name: Build Backend

--- a/common/src/schemas/factory.spec.ts
+++ b/common/src/schemas/factory.spec.ts
@@ -3,7 +3,9 @@ import type { z } from 'zod'
 
 import { CAPS } from '../caps'
 import { makeFactory, makeFactoryTab } from '../testing/fixtures'
+import { presentKeys, withoutKey } from '../testing/schema-walk'
 import type { Factory, FactoryTab } from '../types/factory'
+import * as planSchemas from './factory'
 import {
   factorySchema,
   factoryTabSchema,
@@ -297,5 +299,29 @@ describe('invitePasswordSchema', () => {
     { length: 101, accepted: false },
   ])('a $length character password is accepted: $accepted', ({ length, accepted }) => {
     expect(invitePasswordSchema.safeParse('p'.repeat(length)).success).toBe(accepted)
+  })
+})
+
+/**
+ * Mutation cover for the fixture. "Keeps every persisted field" above only proves the keys the
+ * fixture happens to carry, and it passes just as green when a key it never sets is deleted
+ * from the schema. This runs the same round trip against a schema with one key removed, for
+ * every key the fixture does carry, and each one has to be noticed.
+ *
+ * `web/src/sync/schema-parity.spec.ts` runs the same table over a plan the planner builds for
+ * real, which reaches the keys a hand-written fixture cannot.
+ */
+describe('every key the fixture carries is load-bearing', () => {
+  const tab = makeFactoryTab()
+  const covered = presentKeys(factoryTabSchema, tab, planSchemas)
+
+  it.each(covered)('dropping %s from the schema breaks the round trip', key => {
+    // Owner labels carry dots of their own (`...requirements.*`), so split on the last one.
+    const split = key.lastIndexOf('.')
+    const mutant = withoutKey(factoryTabSchema, key.slice(0, split), key.slice(split + 1), planSchemas)
+    const parsed = mutant.safeParse(JSON.parse(JSON.stringify(tab)))
+
+    expect(parsed.success).toBe(true)
+    expect(parsed.data).not.toEqual(tab)
   })
 })

--- a/common/src/testing/fixtures.ts
+++ b/common/src/testing/fixtures.ts
@@ -21,6 +21,8 @@ export const makeFactory = (overrides: Partial<Factory> = {}): Factory => ({
       parts: { OreIron: 30 },
       powerUsage: 4,
       powerProduced: 0,
+      somersloops: 1,
+      clockSetByUser: true,
       type: ItemType.Product,
     }],
     buildingGroupsTrayOpen: false,
@@ -64,7 +66,21 @@ export const makeFactory = (overrides: Partial<Factory> = {}): Factory => ({
   buildingMaterialCosts: {},
   requirementsSatisfied: true,
   exportCalculator: {
-    IronIngot: { selected: null, factorySettings: {} },
+    IronIngot: {
+      selected: null,
+      factorySettings: {
+        // Belt and pipe splits are stored state the calculator writes lazily, so a fixture
+        // that leaves them out cannot notice them being dropped from the schema.
+        2: {
+          trainTime: 123,
+          droneTime: 123,
+          truckTime: 123,
+          tractorTime: 123,
+          beltGroups: [{ id: 1, mark: 4, amount: 20 }, { id: 2, mark: 4, amount: 10 }],
+          pipeGroups: [{ id: 1, mark: 2, amount: 300 }],
+        },
+      },
+    },
   },
   partDisposal: { IronIngot: { sinks: 2, depots: 1 } },
   dependencies: { requests: {}, metrics: {} },
@@ -78,8 +94,12 @@ export const makeFactory = (overrides: Partial<Factory> = {}): Factory => ({
   syncStatePower: {},
   syncStateCustomBuildings: { 'cb-1': { building: 'portal', amount: 1, ingredientAmount: 10 } },
   displayOrder: 0,
-  tasks: [],
-  notes: '',
+  // Both states: `completed` is the half a fixture with no tasks can never prove.
+  tasks: [
+    { title: 'Build the smelters', completed: false },
+    { title: 'Route the belts', completed: true },
+  ],
+  notes: 'Feeds the assembly line',
   checklistEnabled: true,
   checklistPanelHidden: false,
   checklistExports: { '2:IronIngot': true },

--- a/common/src/testing/schema-walk.ts
+++ b/common/src/testing/schema-walk.ts
@@ -1,0 +1,181 @@
+import { z } from 'zod'
+
+/**
+ * Test-only introspection over the zod plan schemas.
+ *
+ * The schemas strip unknown keys, so they are the only thing between the wire and the
+ * database. A round-trip that deep-equals its input only proves the keys the input happened
+ * to carry; a key nothing populates is untested however green the suite looks. These helpers
+ * close that by reading the key list off the schema itself:
+ *
+ * - `declaredKeys` is every key the schema defines.
+ * - `presentKeys` is every one of those a given plan actually carries.
+ * - `withoutKey` returns the same schema with one key removed, so a spec can prove its own
+ *   round-trip assertion would have failed if that key were dropped.
+ *
+ * Keys are reported as `<object>.<key>` where `<object>` names the object schema that owns
+ * them, not the path they were reached by. One shared sub-schema is therefore one entry:
+ * `buildingGroupSchema.purity` is satisfied by any group that carries a purity, rather than
+ * demanding one on a power producer's groups, which never have them.
+ */
+
+type AnyDef = { type: string } & Record<string, unknown>
+type Shape = Record<string, z.ZodType>
+
+const defOf = (schema: z.ZodType): AnyDef => (schema as unknown as { _zod: { def: AnyDef } })._zod.def
+
+/** Wrapper types that hold exactly one inner schema and no keys of their own. */
+const WRAPPERS = new Set(['optional', 'nullable', 'default', 'prefault', 'nonoptional', 'readonly'])
+
+const unwrap = (schema: z.ZodType): z.ZodType => {
+  let current = schema
+  while (WRAPPERS.has(defOf(current).type)) current = defOf(current).innerType as z.ZodType
+  return current
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/** A module of exported schemas, so owners are named rather than described by their path. */
+export type SchemaNames = Record<string, unknown>
+
+/**
+ * One label per object schema in the tree, resolved from the schema alone so every walk of it
+ * agrees. Named exports win; anything anonymous (an inline `z.object` on one field) falls back
+ * to the path it is first reached by.
+ */
+export const labelObjects = (root: z.ZodType, names: SchemaNames = {}): Map<z.ZodType, string> => {
+  const exported = new Map<z.ZodType, string>()
+  for (const [name, value] of Object.entries(names)) {
+    if (!value || typeof value !== 'object' || !('_zod' in value)) continue
+    const inner = unwrap(value as z.ZodType)
+    if (defOf(inner).type === 'object' && !exported.has(inner)) exported.set(inner, name)
+  }
+
+  const labels = new Map<z.ZodType, string>()
+  const walk = (schema: z.ZodType, path: string): void => {
+    const node = unwrap(schema)
+    const def = defOf(node)
+
+    if (def.type === 'array') return walk(def.element as z.ZodType, `${path}[]`)
+    if (def.type === 'record') return walk(def.valueType as z.ZodType, `${path}.*`)
+    if (def.type !== 'object' || labels.has(node)) return
+
+    labels.set(node, exported.get(node) ?? path ?? 'root')
+    for (const [key, value] of Object.entries(def.shape as Shape)) {
+      walk(value, path ? `${path}.${key}` : key)
+    }
+  }
+
+  walk(root, '')
+  return labels
+}
+
+/** Every `<object>.<key>` the schema defines, sorted. */
+export const declaredKeys = (root: z.ZodType, names: SchemaNames = {}): string[] => {
+  const labels = labelObjects(root, names)
+  const found = new Set<string>()
+
+  for (const [node, owner] of labels) {
+    for (const key of Object.keys(defOf(node).shape as Shape)) found.add(`${owner}.${key}`)
+  }
+
+  return [...found].sort()
+}
+
+/**
+ * Every `<object>.<key>` the schema defines that `value` actually carries somewhere. An
+ * absent or `undefined` field is not carried; `null` is, because null is a stored choice.
+ */
+export const presentKeys = (root: z.ZodType, value: unknown, names: SchemaNames = {}): string[] => {
+  const labels = labelObjects(root, names)
+  const found = new Set<string>()
+
+  const walk = (schema: z.ZodType, subject: unknown): void => {
+    if (subject === undefined || subject === null) return
+    const node = unwrap(schema)
+    const def = defOf(node)
+
+    if (def.type === 'array') {
+      if (Array.isArray(subject)) for (const entry of subject) walk(def.element as z.ZodType, entry)
+      return
+    }
+    if (def.type === 'record') {
+      if (isRecord(subject)) for (const entry of Object.values(subject)) walk(def.valueType as z.ZodType, entry)
+      return
+    }
+    if (def.type !== 'object' || !isRecord(subject)) return
+
+    const owner = labels.get(node)
+    for (const [key, child] of Object.entries(def.shape as Shape)) {
+      if (subject[key] === undefined) continue
+      found.add(`${owner}.${key}`)
+      walk(child, subject[key])
+    }
+  }
+
+  walk(root, value)
+  return [...found].sort()
+}
+
+/**
+ * The same schema with `<owner>.<key>` removed, for proving a round-trip notices the loss.
+ *
+ * The rebuilt copy keeps the shape and the nullability that decide what survives a parse, and
+ * drops the size caps and refinements, which decide what is rejected outright. That is the
+ * point of the mutant: it must strip the key and otherwise behave, so the only thing the
+ * spec's own assertion can be reacting to is the missing key.
+ */
+export const withoutKey = (
+  root: z.ZodType,
+  owner: string,
+  key: string,
+  names: SchemaNames = {},
+): z.ZodType => {
+  const labels = labelObjects(root, names)
+  const cache = new Map<z.ZodType, z.ZodType>()
+
+  const rebuild = (schema: z.ZodType): z.ZodType => {
+    const cached = cache.get(schema)
+    if (cached) return cached
+
+    const def = defOf(schema)
+    let result: z.ZodType
+
+    switch (def.type) {
+      case 'optional':
+        result = rebuild(def.innerType as z.ZodType).optional()
+        break
+      case 'nullable':
+        result = rebuild(def.innerType as z.ZodType).nullable()
+        break
+      case 'default':
+      case 'prefault':
+        result = rebuild(def.innerType as z.ZodType).default(def.defaultValue as never)
+        break
+      case 'array':
+        result = z.array(rebuild(def.element as z.ZodType))
+        break
+      case 'record':
+        result = z.record(def.keyType as z.ZodType<string>, rebuild(def.valueType as z.ZodType))
+        break
+      case 'object': {
+        const owns = labels.get(schema) === owner
+        const shape: Shape = {}
+        for (const [name, child] of Object.entries(def.shape as Shape)) {
+          if (owns && name === key) continue
+          shape[name] = rebuild(child)
+        }
+        result = z.object(shape)
+        break
+      }
+      default:
+        result = schema
+    }
+
+    cache.set(schema, result)
+    return result
+  }
+
+  return rebuild(root)
+}

--- a/web/e2e/README.md
+++ b/web/e2e/README.md
@@ -24,7 +24,7 @@ The harness refuses to start if either port is taken rather than picking another
 | File | What it proves |
 | --- | --- |
 | `two-devices` | An edit reaches the account's other device inside 2s; both mirrors end deep-equal. |
-| `concurrency` | Same-factory edits converge on one winner; different-factory edits both survive, whether the edit is an add or a note. |
+| `concurrency` | Both devices' first op is held at the socket until both exist and are checked to carry the same base revision, then released together. One comes back `stale_base` and rebases: a same-factory tie lands on that device's write, and different-factory edits both survive, whether the edit is an add or a note. |
 | `tab-lifecycle` | Create, rename (through the tab settings dialog), delete and drag-reorder all reach a second device once it opens the plan from the panel; a hidden plan stays hidden across a reload and Show restores it; a member's rename field is disabled with the reason shown; signing in from the signed-out convert button turns it into the real conversion on the same open dialog; a plan filled in after signing in reaches the cloud through tab settings and comes down on the next device. |
 | `sidebar-tabs` | The docked sidebar lists the tab you are on, whether local, synced or joined; a tab too big to render in one flush opens behind the loading overlay, and a small one opens instantly. |
 | `new-tab-chooser` | Local is offered to anyone; picking synced without an account signs in on the same dialog and still makes the tab. A plan hidden in this browser is listed on the plus button and comes back whole when opened from there. |
@@ -41,7 +41,7 @@ The harness refuses to start if either port is taken rather than picking another
 | `preferences` | A synced preference set on one device is there on the next device's first login. |
 | `login-chooser` | An interactive sign-in is fronted by the plan chooser; "Not now" opens nothing, and a reload with a persisted session never asks. Open-all on a device that has never seen the account downloads every plan whole, the unselected one included, and a plan left open there catches up on what it missed while the device was away. |
 | `helper-resilience` | `addNamedFactory` still finds the card it made when the app's focus is stolen out from under it, which is the flake that has taken unrelated tests down with it. |
-| `version-gate` | A 426 raises the persistent refresh prompt and leaves the planner usable. |
+| `version-gate` | A 426 raises the persistent refresh prompt and leaves the planner usable. The version the client sends is also rewritten on the wire so the real API answers the 426 itself, which is what proves the gate, the header name and its CORS allowance rather than only the prompt. |
 | `field-locks` | A focused note disables the same field for the other client and keeps it disabled while its holder types; blur and a ten-second idle both hand it back, and a second factory's note is never covered. |
 | `loading-tab` | A client rendering a big plan makes no writes: no op it sends carries a removal, and both devices end holding every factory. Covered for a tab re-entered, a client with edits still unsent, and a return to the planner from another page. |
 

--- a/web/e2e/helpers/network.ts
+++ b/web/e2e/helpers/network.ts
@@ -36,11 +36,24 @@ export interface WsGate {
    * assert that something was never sent, as opposed to never having an effect.
    */
   sent: () => Record<string, unknown>[]
+  /** Every frame the server has sent this client, parsed. Its side of the conversation. */
+  received: () => Record<string, unknown>[]
   /**
    * Stops forwarding this client's ops to the server. Resolves once one has been
    * swallowed, so a test can say "an op is in flight" and mean it.
    */
   holdOps: () => Promise<void>
+  /**
+   * Queues this client's ops instead of forwarding them, and resolves with the
+   * first one queued. Unlike `holdOps` nothing is thrown away, so `releaseOps`
+   * puts the client back where it would have been.
+   *
+   * This is what makes a concurrent edit concurrent: two clients each holding an
+   * op built against the same revision, neither yet seen by the server.
+   */
+  stallOps: () => Promise<Record<string, unknown>>
+  /** Forwards everything `stallOps` queued, in order, and stops queueing. */
+  releaseOps: () => void
   /** Drops the live socket and refuses every reconnect until `restore`. */
   kill: () => Promise<void>
   restore: () => void
@@ -55,9 +68,16 @@ export const installWsGate = async (page: Page): Promise<WsGate> => {
   let connections = 0
   let killed = false
   let holding = false
+  let stalling = false
   let announceHeld: (() => void) | null = null
+  let announceStalled: ((op: Record<string, unknown>) => void) | null = null
   const sent: Record<string, unknown>[] = []
+  const received: Record<string, unknown>[] = []
+  /** Frames `stallOps` took off the wire, with the socket that has to send them on. */
+  const queued: { server: WebSocketRoute, message: string | Buffer }[] = []
   const live = new Set<{ client: WebSocketRoute, server: WebSocketRoute }>()
+
+  const isOp = (message: string | Buffer): boolean => String(message).includes('"type":"op"')
 
   await page.routeWebSocket(/\/ws$/, ws => {
     connections++
@@ -73,19 +93,36 @@ export const installWsGate = async (page: Page): Promise<WsGate> => {
     ws.onMessage(message => {
       // Recorded before the hold, so a swallowed frame still counts as one the client
       // chose to put on the wire — which is the thing under test.
+      let parsed: Record<string, unknown> | null = null
       try {
-        sent.push(JSON.parse(String(message)) as Record<string, unknown>)
+        parsed = JSON.parse(String(message)) as Record<string, unknown>
+        sent.push(parsed)
       } catch {
         // A frame this harness cannot read is not one any assertion is about.
       }
-      if (holding && String(message).includes('"type":"op"')) {
+      if (holding && isOp(message)) {
         announceHeld?.()
         announceHeld = null
         return
       }
+      if (stalling && isOp(message)) {
+        queued.push({ server, message })
+        if (parsed) {
+          announceStalled?.(parsed)
+          announceStalled = null
+        }
+        return
+      }
       server.send(message)
     })
-    server.onMessage(message => ws.send(message))
+    server.onMessage(message => {
+      try {
+        received.push(JSON.parse(String(message)) as Record<string, unknown>)
+      } catch {
+        // Same as above: unreadable frames are nothing any assertion is about.
+      }
+      ws.send(message)
+    })
 
     ws.onClose((code, reason) => {
       live.delete(pair)
@@ -100,10 +137,20 @@ export const installWsGate = async (page: Page): Promise<WsGate> => {
   return {
     connections: () => connections,
     sent: () => [...sent],
+    received: () => [...received],
     holdOps: () => new Promise<void>(resolve => {
       holding = true
       announceHeld = resolve
     }),
+    stallOps: () => new Promise<Record<string, unknown>>(resolve => {
+      stalling = true
+      announceStalled = resolve
+    }),
+    releaseOps: () => {
+      stalling = false
+      announceStalled = null
+      for (const { server, message } of queued.splice(0)) server.send(message)
+    },
     kill: async () => {
       killed = true
       for (const pair of [...live]) {
@@ -115,7 +162,10 @@ export const installWsGate = async (page: Page): Promise<WsGate> => {
     restore: () => {
       killed = false
       holding = false
+      stalling = false
       announceHeld = null
+      announceStalled = null
+      queued.length = 0
     },
   }
 }

--- a/web/e2e/tests/concurrency.e2e.ts
+++ b/web/e2e/tests/concurrency.e2e.ts
@@ -1,72 +1,179 @@
+import type { Page } from '@playwright/test'
+
+import { registerUser } from '../helpers/accounts'
 import { expect, test } from '../helpers/fixtures'
+import { installWsGate } from '../helpers/network'
+import type { WsGate } from '../helpers/network'
 import {
   addFactory,
+  createSyncedTab,
   expectMirroredNote,
   expectQuiesced,
   mirroredFactories,
   mirroredNote,
   mirrorRevision,
+  openPlanner,
+  outstandingIntent,
+  selectTab,
   setFactoryNote,
   waitForRevision,
 } from '../helpers/planner'
-import { syncedPair } from '../helpers/rooms'
-import type { SyncedPair } from '../helpers/rooms'
+import { showPlan } from '../helpers/rooms'
+import type { ClientFactory } from '../helpers/rooms'
+import type { TestUser } from '../helpers/accounts'
 
 /**
- * The state before the race is itself a converged one, so every assertion waits
- * for the revision to move first. `accepted` is how many of the two ops the
- * server must have taken for the case to have been exercised at all.
+ * The contract these tests exist for: the server takes an op only at the exact revision it
+ * was built against, so same-factory ties are last write wins and different factories both
+ * survive through a rebase.
+ *
+ * Firing two UI actions off together does not exercise it. One client's op is routinely
+ * accepted and broadcast before the other has finished building its own, and then nothing
+ * collided: a fully sequential run converges, and a suite that only checks convergence calls
+ * that a pass. So both clients' first op is held at the socket here, both are checked to
+ * carry the same `baseRevision`, and only then are they let go together. One of them has to
+ * come back `stale_base`, and the rebase that follows is the thing being proved.
  */
-const raceResolved = async (
-  { roomId, first, second }: SyncedPair,
-  baseRevision: number,
-  accepted: number,
-): Promise<void> => {
-  for (const page of [first, second]) {
-    await waitForRevision(page, roomId, baseRevision + accepted)
-  }
-  await expectQuiesced([first, second], roomId)
+
+interface GatedPair {
+  user: TestUser
+  roomId: string
+  first: Page
+  second: Page
+  firstGate: WsGate
+  secondGate: WsGate
+}
+
+interface OpFrame extends Record<string, unknown> {
+  type: string
+  baseRevision: number
+}
+
+/** `syncedPair`, with a gate on each device's socket so its ops can be held. */
+const gatedPair = async (
+  client: ClientFactory,
+  request: Parameters<typeof registerUser>[0],
+  seed: string[] = [],
+): Promise<GatedPair> => {
+  const user = await registerUser(request)
+
+  let firstGate!: WsGate
+  const first = await openPlanner(await client({ user }), '/', async page => {
+    firstGate = await installWsGate(page)
+  })
+  const roomId = await createSyncedTab(first)
+  for (const name of seed) await addFactory(first, { name, note: `seeded ${name}` })
+
+  let secondGate!: WsGate
+  const second = await openPlanner(await client({ user }), '/', async page => {
+    secondGate = await installWsGate(page)
+  })
+  await showPlan(second, user, roomId)
+  await selectTab(second, roomId)
+  await expect(second.locator('input.factory-name')).toHaveCount(seed.length, { timeout: 20_000 })
+
+  return { user, roomId, first, second, firstGate, secondGate }
 }
 
 /**
- * `raceResolved` proves the engine is settled, not that `localStorage.factoryTabs`
- * has caught up: the mirror is written on the persistence debounce while the meta
- * these checks read is written eagerly, so the two can disagree for a moment. Both
- * clients being equally behind passes the convergence check as well. Every note
- * read below therefore polls — the expected values are unchanged.
+ * The revision both devices are idle at. `expectConverged` cannot answer this: it needs a
+ * non-empty plan, and half of these races start from an empty room.
  */
+const settledRevision = async ({ roomId, first, second }: GatedPair): Promise<number> => {
+  await expect.poll(async () => {
+    const revisions = await Promise.all([first, second].map(page => mirrorRevision(page, roomId)))
+    const intent = await Promise.all([first, second].map(page => outstandingIntent(page, roomId)))
+    return revisions[0] !== null && revisions[0] === revisions[1] && intent.every(count => count === 0)
+  }, {
+    timeout: 30_000,
+    message: 'the two devices never agreed on a revision to race from',
+  }).toBe(true)
+
+  return await mirrorRevision(first, roomId) as number
+}
+
+const opsSent = (gate: WsGate): OpFrame[] =>
+  gate.sent().filter(frame => frame.type === 'op') as OpFrame[]
+
+const staleRejects = (gate: WsGate): Record<string, unknown>[] =>
+  gate.received().filter(frame => frame.type === 'op_reject' && frame.reason === 'stale_base')
+
+/**
+ * Holds both devices' next op, checks they were built against the same revision, and releases
+ * them together. That check is what separates a collision from a queue.
+ */
+const raceOneOpEach = async (
+  pair: GatedPair,
+  edits: () => Promise<unknown>,
+  baseRevision: number,
+): Promise<void> => {
+  const firstOp = pair.firstGate.stallOps()
+  const secondOp = pair.secondGate.stallOps()
+
+  await edits()
+
+  const [fromFirst, fromSecond] = await Promise.all([firstOp, secondOp]) as OpFrame[]
+
+  // The whole point. Two ops built against the same state, neither yet seen by the server:
+  // without this the "race" is satisfied by one device finishing before the other starts.
+  expect(fromFirst.baseRevision, 'the first device did not build its op against the shared revision')
+    .toBe(baseRevision)
+  expect(fromSecond.baseRevision, 'the second device did not build its op against the shared revision')
+    .toBe(baseRevision)
+
+  pair.firstGate.releaseOps()
+  pair.secondGate.releaseOps()
+}
+
+/** Which device the server refused, once exactly one of them has been refused. */
+const rejectedDevice = async (pair: GatedPair): Promise<'first' | 'second'> => {
+  await expect.poll(
+    () => staleRejects(pair.firstGate).length + staleRejects(pair.secondGate).length,
+    { timeout: 30_000, message: 'neither op was refused, so the two never actually collided' },
+  ).toBe(1)
+
+  return staleRejects(pair.firstGate).length === 1 ? 'first' : 'second'
+}
+
+/** The refused device rebased and sent again, which is the path the contract rests on. */
+const expectRebaseResend = async (
+  gate: WsGate,
+  baseRevision: number,
+): Promise<void> => {
+  await expect.poll(
+    () => opsSent(gate).filter(op => op.baseRevision > baseRevision).length,
+    { timeout: 30_000, message: 'the refused device never resent its edit on the new revision' },
+  ).toBeGreaterThan(0)
+}
 
 const factoryNamesIn = async (
   ...args: Parameters<typeof mirroredFactories>
 ): Promise<string[]> => (await mirroredFactories(...args)).map(factory => factory.name).sort()
 
-test('two clients editing the same factory converge on one winner', async ({
-  client,
-  request,
-}) => {
-  const pair = await syncedPair(client, request, ['Contested'])
-  const { roomId, first, second } = pair
-  const base = await mirrorRevision(first, roomId) as number
+test('two clients editing the same factory land on the later write', async ({ client, request }) => {
+  const pair = await gatedPair(client, request, ['Contested'])
+  const { roomId, first, second, firstGate, secondGate } = pair
+  const base = await settledRevision(pair)
 
-  const fromFirst = 'the first device got there'
-  const fromSecond = 'the second device got there'
+  const notes = { first: 'the first device got there', second: 'the second device got there' }
 
-  await Promise.all([
-    setFactoryNote(first, 0, fromFirst),
-    setFactoryNote(second, 0, fromSecond),
-  ])
+  await raceOneOpEach(pair, () => Promise.all([
+    setFactoryNote(first, 0, notes.first),
+    setFactoryNote(second, 0, notes.second),
+  ]), base)
 
-  // One accepted op is the floor here: the two edits collide on one record, and
-  // the plan's rule for that is last write wins.
-  await raceResolved(pair, base, 1)
+  const refused = await rejectedDevice(pair)
+  await expectRebaseResend(refused === 'first' ? firstGate : secondGate, base)
 
-  // Which one won is the server's business; that they agree is the contract.
-  await expect.poll(() => mirroredNote(first, roomId, 'Contested'), {
-    message: 'neither concurrent edit survived',
-  }).toMatch(new RegExp(`^(${fromFirst}|${fromSecond})$`))
+  // Last write wins, and with the collision forced the winner is not a coin toss: the op the
+  // server took first is superseded by the refused device's rebase, which adopts that state,
+  // overlays the edit its user actually made and sends it on the revision that op created.
+  // Two ops are therefore committed, and the note that survives is the refused device's.
+  for (const page of [first, second]) await waitForRevision(page, roomId, base + 2)
+  await expectQuiesced([first, second], roomId)
 
-  const winner = await mirroredNote(first, roomId, 'Contested') as string
-  await expectMirroredNote(second, roomId, 'Contested', winner)
+  await expectMirroredNote(first, roomId, 'Contested', notes[refused])
+  await expectMirroredNote(second, roomId, 'Contested', notes[refused])
 })
 
 /**
@@ -74,17 +181,21 @@ test('two clients editing the same factory converge on one winner', async ({
  * is the case that needs no UI to declare anything.
  */
 test('two clients adding a factory each keep both of them', async ({ client, request }) => {
-  const pair = await syncedPair(client, request)
-  const { roomId, first, second } = pair
-  const base = await mirrorRevision(first, roomId) as number
+  const pair = await gatedPair(client, request)
+  const { roomId, first, second, firstGate, secondGate } = pair
+  const base = await settledRevision(pair)
 
-  await Promise.all([
+  await raceOneOpEach(pair, () => Promise.all([
     addFactory(first, { name: 'Alpha', note: 'added on the first device' }),
     addFactory(second, { name: 'Bravo', note: 'added on the second device' }),
-  ])
+  ]), base)
 
-  // Different records, so both ops have to be taken; neither may be swallowed.
-  await raceResolved(pair, base, 2)
+  const refused = await rejectedDevice(pair)
+  await expectRebaseResend(refused === 'first' ? firstGate : secondGate, base)
+
+  // Different records, so both ops have to be committed; neither may be swallowed.
+  for (const page of [first, second]) await waitForRevision(page, roomId, base + 2)
+  await expectQuiesced([first, second], roomId)
 
   for (const page of [first, second]) {
     await expect.poll(() => factoryNamesIn(page, roomId), {
@@ -101,20 +212,53 @@ test('two clients adding a factory each keep both of them', async ({ client, req
  * rather than carried onto the snapshot, and one of the two is simply lost.
  */
 test('two clients annotating different factories keep both notes', async ({ client, request }) => {
-  const pair = await syncedPair(client, request, ['Smelters', 'Constructors'])
-  const { roomId, first, second } = pair
-  const base = await mirrorRevision(first, roomId) as number
+  const pair = await gatedPair(client, request, ['Smelters', 'Constructors'])
+  const { roomId, first, second, firstGate, secondGate } = pair
+  const base = await settledRevision(pair)
 
-  await Promise.all([
+  await raceOneOpEach(pair, () => Promise.all([
     setFactoryNote(first, 0, 'the first device wrote this'),
     setFactoryNote(second, 1, 'the second device wrote this'),
-  ])
+  ]), base)
 
-  // Different records again, so neither op may be swallowed.
-  await raceResolved(pair, base, 2)
+  const refused = await rejectedDevice(pair)
+  await expectRebaseResend(refused === 'first' ? firstGate : secondGate, base)
+
+  for (const page of [first, second]) await waitForRevision(page, roomId, base + 2)
+  await expectQuiesced([first, second], roomId)
 
   for (const page of [first, second]) {
     await expectMirroredNote(page, roomId, 'Smelters', 'the first device wrote this')
     await expectMirroredNote(page, roomId, 'Constructors', 'the second device wrote this')
   }
+})
+
+/**
+ * The negative control for the gate itself. A refused op must be refused for being stale and
+ * nothing else, and the device that was taken must never see a rejection: without this the
+ * tests above would pass just as well on a server that refused everything.
+ */
+test('only the second op is refused, and only for its revision', async ({ client, request }) => {
+  const pair = await gatedPair(client, request, ['Contested'])
+  const { roomId, first, second, firstGate, secondGate } = pair
+  const base = await settledRevision(pair)
+
+  await raceOneOpEach(pair, () => Promise.all([
+    setFactoryNote(first, 0, 'one'),
+    setFactoryNote(second, 0, 'two'),
+  ]), base)
+
+  const refused = await rejectedDevice(pair)
+  const accepted = refused === 'first' ? secondGate : firstGate
+
+  for (const page of [first, second]) await waitForRevision(page, roomId, base + 2)
+  await expectQuiesced([first, second], roomId)
+
+  const rejections = (gate: WsGate) => gate.received().filter(frame => frame.type === 'op_reject')
+  expect(rejections(accepted), 'the device the server took was refused as well').toEqual([])
+  expect(rejections(refused === 'first' ? firstGate : secondGate).map(frame => frame.reason))
+    .toEqual(['stale_base'])
+
+  // And the note is still one of the two, rather than something a failed merge invented.
+  await expect.poll(() => mirroredNote(first, roomId, 'Contested')).toMatch(/^(one|two)$/)
 })

--- a/web/e2e/tests/version-gate.e2e.ts
+++ b/web/e2e/tests/version-gate.e2e.ts
@@ -1,9 +1,13 @@
-import { PROTOCOL_VERSION } from 'common'
+import { APP_VERSION_HEADER, PROTOCOL_VERSION } from 'common'
+import type { VersionMismatchBody } from 'common'
 
 import { API_URL } from '../config'
 import { expect, test } from '../helpers/fixtures'
 import { registerUser } from '../helpers/accounts'
 import { addFactory, openPlanner, settle } from '../helpers/planner'
+
+/** Anything that is not `PROTOCOL_VERSION`; the gate matches exactly. */
+const STALE_VERSION = '0.0.1-stale'
 
 test('a 426 from the API raises the refresh prompt and leaves the planner usable', async ({
   client,
@@ -39,4 +43,49 @@ test('a 426 from the API raises the refresh prompt and leaves the planner usable
   await addFactory(page, { name: 'Still editable', note: 'made while out of date' })
   await expect(page.locator('input.factory-name')).toHaveValue('Still editable')
   await expect(prompt).toBeVisible()
+})
+
+/**
+ * The same prompt, with nothing fabricated. The test above serves the 426 from inside the
+ * browser, so it only ever proved the prompt renders — the gate itself, the header name it
+ * reads and the CORS allowance that lets that name reach it are all untouched by it.
+ *
+ * Here the version the client sends is rewritten on the wire and the real API answers. The
+ * header is named from the shared constant rather than written out, so the rename to
+ * `X-Planner-Version` moves this test with it instead of leaving it asserting on a name
+ * nothing sends any more. `fallback` rather than `continue`, so the client-address header
+ * the account helper adds further down the chain still gets applied.
+ */
+test('the real API refuses a stale version, and that is what raises the prompt', async ({
+  client,
+  request,
+}) => {
+  const user = await registerUser(request)
+  const context = await client({ user })
+  const page = await openPlanner(context)
+
+  const refused = page.waitForResponse(
+    response => response.url().startsWith(API_URL) && response.status() === 426,
+    { timeout: 30_000 },
+  )
+
+  await context.route(`${API_URL}/**`, route => route.fallback({
+    headers: {
+      ...route.request().headers(),
+      [APP_VERSION_HEADER.toLowerCase()]: STALE_VERSION,
+    },
+  }))
+
+  await page.reload()
+
+  const body = await (await refused).json() as VersionMismatchBody
+  expect(body.code).toBe('version_mismatch')
+  expect(body.requiredVersion).toBe(PROTOCOL_VERSION)
+  // The gate read the header this client actually sent, which is the half a fabricated
+  // response cannot show and the half a header rename breaks.
+  expect(body.receivedVersion).toBe(STALE_VERSION)
+
+  await settle(page)
+  await expect(page.getByTestId('version-prompt')).toBeVisible()
+  await expect(page.getByTestId('version-refresh')).toBeVisible()
 })

--- a/web/src/sync/schema-parity.spec.ts
+++ b/web/src/sync/schema-parity.spec.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { parseFactory, parseFactoryTab } from 'common'
+import { factoryTabSchema, parseFactory, parseFactoryTab, truncateFactoryTab } from 'common'
 import type { FactoryTab } from 'common'
+// Reached by path rather than through the `common` barrel: both are test-only, and neither
+// belongs in the bundle the barrel produces.
+import * as planSchemas from '../../../common/src/schemas/factory'
+import { declaredKeys, presentKeys, withoutKey } from '../../../common/src/testing/schema-walk'
 import { addCustomBuildingToFactory } from '@/utils/factory-management/custom-buildings'
 import { addPowerProducerToFactory } from '@/utils/factory-management/power'
 import { addProductToFactory } from '@/utils/factory-management/products'
@@ -14,7 +18,15 @@ import {
 } from '@/utils/factory-management/checklist'
 import { setDepotCount, setSinkCount } from '@/utils/factory-management/disposal'
 import { setSyncState } from '@/utils/factory-management/syncState'
-import { Factory, FactoryPowerChangeType } from '@/interfaces/planner/FactoryInterface'
+import {
+  addTransportGroup,
+  initializeCalculatorFactoryPart,
+  initializeCalculatorFactorySettings,
+  initializeTransportGroups,
+} from '@/utils/factory-management/exportCalculator'
+import { createGroup, moveFactoryToGroup } from '@/utils/factory-management/factory-groups'
+import { addBuildingGroup } from '@/utils/factory-management/building-groups/common'
+import { Factory, FactoryPowerChangeType, ItemType } from '@/interfaces/planner/FactoryInterface'
 import { gameData } from '@/utils/gameData'
 
 /**
@@ -22,62 +34,154 @@ import { gameData } from '@/utils/gameData'
  * and the database. A stored field the schema has never heard of is therefore deleted from a
  * synced tab by every op, adoption and share — silently, with nothing to notice it by.
  *
- * `common/src/schemas/factory.spec.ts` proves the same thing against a hand-written fixture.
- * This proves it against what the app actually builds: `newFactory()` plus a real calculation
- * pass, with every feature that arrived from main exercised. A field added to the interface and
- * forgotten in the schema fails here even if nobody updates the fixture.
+ * This proves it against what the app actually builds, through the functions the UI calls.
+ * A deep-equal round trip only ever covers the keys its input happened to carry, so the input
+ * is measured against the schema rather than trusted, and the mutation table at the bottom
+ * fails for any key that could be deleted from the schema without this suite noticing.
  */
-describe('schema parity with what the planner actually stores', () => {
-  let factories: Factory[]
-  let mine: Factory
 
-  const build = (): Factory[] => {
-    const producer = newFactory('Refinery', 0, 1)
-    const consumer = newFactory('Assembly', 1, 2)
+/**
+ * Everything the planner persists, built the way the planner builds it. One function rather
+ * than a `beforeEach` so the mutation table can be derived from a plan at module load.
+ */
+const buildPlan = (): { factories: Factory[], tab: FactoryTab, mine: Factory, consumer: Factory } => {
+  const producer = newFactory('Refinery', 0, 1)
+  const consumer = newFactory('Assembly', 1, 2)
 
-    addProductToFactory(producer, { id: 'IronIngot', amount: 120, recipe: 'IngotIron' })
-    // An extraction group, for `extractorBuilding` and `purity`.
-    addProductToFactory(producer, { id: 'OreBauxite', amount: 120, recipe: 'Extract_OreBauxite' })
-    // A resource well, for `satellites`.
-    addProductToFactory(producer, { id: 'LiquidOil', amount: 60, recipe: 'Extract_LiquidOil_Well' })
-    addPowerProducerToFactory(producer, {
-      building: 'generatorcoal',
-      powerAmount: 75,
-      recipe: 'GeneratorCoal_Coal',
-      updated: FactoryPowerChangeType.Power,
-    })
-    // Costs parts to run, which is the only custom building that does.
-    addCustomBuildingToFactory(producer, { building: 'portal', amount: 2 })
+  addProductToFactory(producer, { id: 'IronIngot', amount: 120, recipe: 'IngotIron' })
+  // An extraction group, for `extractorBuilding` and `purity`.
+  addProductToFactory(producer, { id: 'OreBauxite', amount: 120, recipe: 'Extract_OreBauxite' })
+  // A resource well, for `satellites`.
+  addProductToFactory(producer, { id: 'LiquidOil', amount: 60, recipe: 'Extract_LiquidOil_Well' })
+  // Leaves Heavy Oil Residue behind, which is what puts by-products on the record.
+  addProductToFactory(producer, { id: 'Plastic', amount: 20, recipe: 'Plastic' })
+  addPowerProducerToFactory(producer, {
+    building: 'generatorcoal',
+    powerAmount: 75,
+    recipe: 'GeneratorCoal_Coal',
+    updated: FactoryPowerChangeType.Power,
+  })
+  // Uranium Waste, so a producer's `byproduct` is a record rather than null.
+  addPowerProducerToFactory(producer, {
+    building: 'generatornuclear',
+    buildingAmount: 1,
+    recipe: 'GeneratorNuclear_NuclearFuelRod',
+    updated: FactoryPowerChangeType.Building,
+  })
+  // The Alien Power Augmenter, the only building the Supply Matrixes toggle applies to.
+  addPowerProducerToFactory(producer, {
+    building: 'alienpoweraugmenter',
+    buildingAmount: 2,
+    recipe: 'AlienPowerAugmenter',
+    updated: FactoryPowerChangeType.Building,
+  })
+  // Costs parts to run, which is the only custom building that does.
+  addCustomBuildingToFactory(producer, { building: 'portal', amount: 2 })
 
-    consumer.inputs.push({ factoryId: 1, outputPart: 'IronIngot', amount: 60 })
+  consumer.inputs.push({ factoryId: 1, outputPart: 'IronIngot', amount: 60 })
 
-    return [producer, consumer]
+  const factories = [producer, consumer]
+  calculateFactories(factories, gameData, { origin: 'recalculate' })
+
+  const mine = factories[0]
+
+  // Every user-set field the merge from main introduced, set the way the UI sets it.
+  setSinkCount(mine, 'IronIngot', 3)
+  setDepotCount(mine, 'IronIngot', 2)
+
+  const extraction = mine.products[1].buildingGroups[0]
+  extraction.extractorBuilding = 'minermk2'
+  extraction.purity = 'pure'
+  mine.products[2].buildingGroups[0].satellites = { impure: 1, normal: 2, pure: 3 }
+
+  // Somersloops and a hand-dialled clock, then a second group so the split is real.
+  const ingots = mine.products[0]
+  ingots.buildingGroups[0].somersloops = 1
+  ingots.buildingGroups[0].clockSetByUser = true
+  ingots.buildingGroups[0].overclockPercent = 137.5
+  addBuildingGroup(ingots, ItemType.Product, mine)
+
+  // Production Amplifier: matrix-fed augmenter buildings, which create their own fuel demand.
+  mine.powerProducers[2].buildingGroups[0].supplyMatrixes = true
+
+  // Tasks, both states, because `completed` is the half a fixture with no tasks never proves.
+  mine.tasks.push({ title: 'Build the smelters', completed: false })
+  mine.tasks.push({ title: 'Route the belts', completed: true })
+  mine.notes = 'Feeds the assembly line'
+  mine.icon = 'iron'
+
+  setChecklistEnabled(mine, true)
+  toggleChecklistProduct(mine, ingots)
+  toggleChecklistPowerProducer(mine, mine.powerProducers[0])
+  toggleChecklistExport(mine, 2, 'IronIngot', 60)
+  toggleChecklistInput(consumer, consumer.inputs[0])
+
+  // Stamps syncState, syncStatePower (with its `building`) and syncStateCustomBuildings.
+  setSyncState(mine)
+
+  calculateFactories(factories, gameData, { origin: 'recalculate' })
+
+  // The export calculator, opened on an export and given both a belt and a pipe split.
+  initializeCalculatorFactoryPart(mine, 'IronIngot')
+  initializeCalculatorFactorySettings(mine, 'IronIngot', '2')
+  const beltSettings = mine.exportCalculator.IronIngot.factorySettings['2']
+  initializeTransportGroups(beltSettings, 60, 'belts')
+  addTransportGroup(beltSettings, 60, 'belts')
+
+  initializeCalculatorFactoryPart(mine, 'LiquidOil')
+  initializeCalculatorFactorySettings(mine, 'LiquidOil', '2')
+  const pipeSettings = mine.exportCalculator.LiquidOil.factorySettings['2']
+  initializeTransportGroups(pipeSettings, 300, 'pipes')
+  addTransportGroup(pipeSettings, 300, 'pipes')
+
+  const tab: FactoryTab = {
+    id: 'f2a0c1b2-0000-4000-8000-000000000001',
+    name: 'Round trip',
+    factories,
+    powerTarget: 2400,
+    depotUploadTier: 1,
+    depotExpansionTier: 3,
+    plannerVersion: '0.7.0',
   }
 
+  // Reorders `factories` in place, so the two are handed back by name rather than by index.
+  const group = createGroup(factories, tab, 'Smelting', '#ff0000')
+  moveFactoryToGroup(factories, tab, mine.id, group.id)
+
+  return { factories, tab, mine, consumer }
+}
+
+/** What the wire and the database actually see: JSON, then the truncate step, then zod. */
+const wireCopy = (tab: FactoryTab): FactoryTab =>
+  truncateFactoryTab(JSON.parse(JSON.stringify(tab)) as FactoryTab)
+
+const DECLARED = declaredKeys(factoryTabSchema, planSchemas)
+
+/**
+ * Keys the schema declares that the planner has never written. Kept in the schema because it is
+ * also what a plan stored by an older build is read back through, and listed here rather than
+ * silently tolerated: each one is asserted absent below, so a build that starts writing it
+ * fails this spec instead of quietly leaving the list stale.
+ */
+const NEVER_WRITTEN = [
+  // PowerItem doubles as the game data's power-recipe ingredient shape, and every rate the
+  // planner stores on a producer's ingredients is a `perMin`.
+  'powerItemSchema.amount',
+  // A product's own building requirement only ever draws power. Generation is counted on the
+  // factory's building map instead, where `buildingRequirementSchema.powerProduced` is covered.
+  'productBuildingRequirementSchema.powerProduced',
+]
+
+const COVERED = DECLARED.filter(key => !NEVER_WRITTEN.includes(key))
+
+describe('schema parity with what the planner actually stores', () => {
+  let factories: Factory[]
+  let tab: FactoryTab
+  let mine: Factory
+  let consumer: Factory
+
   beforeEach(() => {
-    factories = build()
-    calculateFactories(factories, gameData, { origin: 'recalculate' })
-    mine = factories[0]
-
-    // Every user-set field the merge from main introduced, set the way the UI sets it.
-    setSinkCount(mine, 'IronIngot', 3)
-    setDepotCount(mine, 'IronIngot', 2)
-
-    const extraction = mine.products[1].buildingGroups[0]
-    extraction.extractorBuilding = 'minermk2'
-    extraction.purity = 'pure'
-    mine.products[2].buildingGroups[0].satellites = { impure: 1, normal: 2, pure: 3 }
-
-    setChecklistEnabled(mine, true)
-    toggleChecklistProduct(mine, mine.products[0])
-    toggleChecklistPowerProducer(mine, mine.powerProducers[0])
-    toggleChecklistExport(mine, 2, 'IronIngot', 60)
-    toggleChecklistInput(factories[1], factories[1].inputs[0])
-
-    // Stamps syncState, syncStatePower (with its `building`) and syncStateCustomBuildings.
-    setSyncState(mine)
-
-    calculateFactories(factories, gameData, { origin: 'recalculate' })
+    ({ factories, tab, mine, consumer } = buildPlan())
   })
 
   /** Guards the guard: a spec that stopped exercising a field would still pass deep-equal. */
@@ -90,14 +194,26 @@ describe('schema parity with what the planner actually stores', () => {
     expect(mine.powerProducers[0].completed).toBe(true)
     expect(mine.checklistExports['2:IronIngot']).toBe(true)
     expect(mine.checklistExportSyncedAmounts['2:IronIngot']).toBe(60)
-    expect(factories[1].inputs[0].completed).toBe(true)
+    expect(consumer.inputs[0].completed).toBe(true)
     expect(mine.products[1].buildingGroups[0].purity).toBe('pure')
     expect(mine.products[1].buildingGroups[0].extractorBuilding).toBe('minermk2')
     expect(mine.products[2].buildingGroups[0].satellites).toEqual({ impure: 1, normal: 2, pure: 3 })
     expect(Object.keys(mine.syncStateCustomBuildings)).toHaveLength(1)
-    expect(Object.values(mine.syncStatePower)[0].building).toBe('generatorcoal')
+    expect(mine.syncStatePower[mine.powerProducers[0].id].building).toBe('generatorcoal')
     expect(Object.values(mine.parts).some(part => part.amountRequiredSink !== undefined)).toBe(true)
     expect(Object.values(mine.parts).some(part => part.isSinkable !== undefined)).toBe(true)
+
+    // The state no fixture here used to carry, which is what let it be deleted unnoticed.
+    expect(mine.tasks).toEqual([
+      { title: 'Build the smelters', completed: false },
+      { title: 'Route the belts', completed: true },
+    ])
+    expect(mine.exportCalculator.IronIngot.factorySettings['2'].beltGroups).toHaveLength(2)
+    expect(mine.exportCalculator.LiquidOil.factorySettings['2'].pipeGroups).toHaveLength(2)
+    expect(mine.products[0].buildingGroups[0].somersloops).toBe(1)
+    expect(mine.powerProducers[2].buildingGroups[0].supplyMatrixes).toBe(true)
+    expect(mine.powerProducers[1].byproduct).toEqual({ part: 'NuclearWaste', amount: expect.any(Number) })
+    expect(mine.products[3].byProducts?.length).toBeGreaterThan(0)
   })
 
   it.each([0, 1])('survives truncate + parse with nothing stripped (factory %i)', index => {
@@ -109,21 +225,11 @@ describe('schema parity with what the planner actually stores', () => {
   })
 
   it('survives the tab round trip, tab-level settings included', () => {
-    const tab: FactoryTab = {
-      id: 'f2a0c1b2-0000-4000-8000-000000000001',
-      name: 'Round trip',
-      factories: JSON.parse(JSON.stringify(factories)) as Factory[],
-      powerTarget: 2400,
-      depotUploadTier: 1,
-      depotExpansionTier: 3,
-      plannerVersion: '0.6.0',
-      groups: [{ id: 'g-1', name: 'Smelting', color: '#ff0000', order: 0 }],
-    }
-
-    const parsed = parseFactoryTab(structuredClone(tab))
+    const wire = wireCopy(tab)
+    const parsed = parseFactoryTab(structuredClone(wire))
 
     expect(parsed.success).toBe(true)
-    expect(parsed.data).toEqual(tab)
+    expect(parsed.data).toEqual(wire)
   })
 
   // The depot tiers decide what an Uploader moves, so a tab that lost them would report a
@@ -140,5 +246,37 @@ describe('schema parity with what the planner actually stores', () => {
     expect(parsed.success).toBe(true)
     expect(parsed.data?.depotUploadTier).toBe(0)
     expect(parsed.data?.depotExpansionTier).toBe(0)
+  })
+
+  /**
+   * The round trip above can only prove a key survives if the plan carries it. This says the
+   * plan carries every key the schema knows about, so a field added to the schema and never
+   * round-tripped fails here rather than passing on an input that never mentions it.
+   */
+  it('exercises every key the schema declares', () => {
+    const present = new Set(presentKeys(factoryTabSchema, wireCopy(tab), planSchemas))
+    const uncovered = DECLARED.filter(key => !present.has(key))
+
+    expect(uncovered).toEqual(NEVER_WRITTEN)
+  })
+})
+
+/**
+ * Mutation cover. For every key the plan exercises, the same round trip is run against a schema
+ * with that one key removed, and has to notice. Without this a key could be deleted from
+ * `common/src/schemas/factory.ts` and the suite above would still be green, which is precisely
+ * how a field gets stripped at the wire and database boundary with nothing to notice it by.
+ */
+describe('every schema key is load-bearing', () => {
+  const wire = wireCopy(buildPlan().tab)
+
+  it.each(COVERED)('dropping %s from the schema breaks the round trip', key => {
+    // Owner labels carry dots of their own (`...requirements.*`), so split on the last one.
+    const split = key.lastIndexOf('.')
+    const mutant = withoutKey(factoryTabSchema, key.slice(0, split), key.slice(split + 1), planSchemas)
+    const parsed = mutant.safeParse(structuredClone(wire))
+
+    expect(parsed.success).toBe(true)
+    expect(parsed.data).not.toEqual(wire)
   })
 })


### PR DESCRIPTION
No manual steps or intervention required.

## Nothing is being stripped today

I checked this first, because it is the only part with user impact. I built a plan by driving the real persistence paths (products, extraction, a resource well, by-products, a nuclear generator with its waste, an Alien Power Augmenter fed matrixes, somersloops, a hand-dialled clock, custom buildings, sinks and depot uploaders, checklist state, tasks with both completion states, export calculator belt and pipe splits, factory groups and every tab-level setting), then round-tripped it through the real `truncate` plus zod boundary and compared deeply.

487 stored key paths went in. 487 came back. No field is lost at the wire and database boundary as things stand, so there is nothing to fix in the schema and nothing for anyone to do on merge.

## The proof of that, though, had real holes

The old parity spec built a plan with no tasks and no export calculator groups, and the shared fixture in `common` had an empty task list and empty calculator settings. I confirmed what that costs by deleting `completed` from `factoryTaskSchema` and `beltGroups`/`pipeGroups` from `exportCalculatorFactorySettingsSchema` and running everything:

| Suite | With those keys deleted |
| --- | --- |
| `common` (153 tests) | all green |
| the old `web/src/sync/schema-parity.spec.ts` (5 tests) | all green |

Both of those mutations silently strip real user state. Both were invisible. The reciprocal TypeScript assertions in `common/src/schemas/factory.spec.ts` do not help, because structural assignment allows extra properties.

With this branch, both mutations fail the suite.

### How it is closed

`common/src/testing/schema-walk.ts` reads the key list off the zod schema rather than off a fixture. Three helpers: `declaredKeys` (every key the schema defines), `presentKeys` (every one of those a given plan actually carries) and `withoutKey` (the same schema with one key removed). Keys are named by the object schema that owns them, so one shared sub-schema is one entry and `buildingGroupSchema.purity` is satisfied by any group carrying a purity rather than demanding one on a power producer's groups, which never have them.

On the back of that:

1. **The parity input is built, not written.** `web/src/sync/schema-parity.spec.ts` now drives `addProductToFactory`, `addPowerProducerToFactory`, `addCustomBuildingToFactory`, `setSinkCount`/`setDepotCount`, the checklist toggles, `setSyncState`, `initializeTransportGroups`/`addTransportGroup`, `createGroup`/`moveFactoryToGroup` and two full calculation passes.
2. **Coverage is asserted.** `exercises every key the schema declares` compares the built plan against the schema's own key list. A field added to the schema that nobody round-trips now fails rather than passes. Two keys are listed as never written, each with its reason, and the list is asserted exact in both directions so it cannot quietly go stale: `powerItemSchema.amount` (the planner stores producer ingredient rates as `perMin`) and `productBuildingRequirementSchema.powerProduced` (a product's own building only draws power; generation is counted on the factory's building map, which is covered).
3. **Mutation cover.** Every key gets its own test that rebuilds the schema without it and asserts the round trip notices. **195 keys covered in `web`**, which is every key the schema declares bar those two. `common`'s own spec runs the same table over the shared fixture for the **112 keys** that fixture reaches, and the fixture itself now carries tasks in both states, belt and pipe groups, somersloops and a user-set clock, which also improves the backend specs that use it.

## The concurrency tests never created a conflict

The old tests fired both clients' UI actions with `Promise.all` and then checked convergence. Nothing gated either client's outgoing op, so one was routinely accepted and broadcast before the other had finished building its own, and a fully sequential run passed. I measured it: with the two edits run strictly one after the other, **the server issues zero rejections**. The rebase path, which is the whole contract, was never entered.

`installWsGate` gains `stallOps` and `releaseOps` (queue rather than discard, unlike the existing `holdOps`, which offline tests rely on and which is untouched) plus `received()` for the server's side of the conversation. Each test now:

1. holds both clients' first op at the socket,
2. asserts both carry the same `baseRevision` before anything is released, which is what makes it a conflict,
3. releases them together,
4. requires exactly one `op_reject` with reason `stale_base`, and requires that client to have resent on the new revision,
5. only then asserts convergence.

Both halves of the contract are covered explicitly. **Same factory:** the write that survives is the refused client's. That is correct and no longer a coin toss: the op the server took first is superseded by the refused client adopting that state, overlaying the edit its user actually made and sending it on the revision the first op created. Two ops commit, and the later one wins. **Different factories:** both survive, for an add (structural, inferred from the diff) and for a note (no structural signal, so only the intent declaration carries it).

There is also a negative control, because otherwise these would pass just as well against a server that refused everything: the accepted client must see no rejection at all, and the refused one must see exactly one, for `stale_base` and nothing else.

## The version gate now goes through the real boundary

`version-gate.e2e.ts` served its 426 from inside the browser, so it only ever proved the prompt renders. The gate, the header name it reads and the CORS allowance that lets that name reach it were all untouched by it.

The added test rewrites the version the client sends on the wire and lets the real API answer. It asserts the response body's `receivedVersion` is the stale value it sent, which is the half a fabricated response cannot show. The header is named from the exported `APP_VERSION_HEADER` rather than written out, so the rename to `X-Planner-Version` in #658 moves this test with it instead of leaving it asserting on a name nothing sends. It uses `route.fallback` rather than `continue` so the client-address header the account helper adds further down the chain still applies.

## `common` was not checked by anything

`build-backend.yml` built `common` and then ran the backend suite; the web workflow ran its own. Nothing ran `common`'s tests, its typecheck or its lint, and `tsconfig.build.json` excludes the specs, so `pnpm build` never saw them either. The zod schema in that package is the entire data boundary.

Backend Checks now runs `pnpm --filter common lint-check`, `pnpm --filter common typecheck` and `pnpm --filter common exec vitest run`. That job is the one that already installs the package, and `--filter` resolves from the workspace root so its backend working directory does not matter. The workflow parses as valid YAML and the three commands were run locally exactly as written.

## Validation

Everything below is output I saw, not an expectation.

| Command | Result |
| --- | --- |
| `cd common && pnpm exec vitest run` | 6 files, 265 tests passed (153 before) |
| `cd common && pnpm exec tsc --noEmit` | clean |
| `cd web && pnpm exec vitest run --silent --coverage` | 167 files, 3411 passed, 1 skipped |
| `cd web && pnpm exec vue-tsc --noEmit` | clean |
| `cd backend && pnpm exec vitest run` | 34 files, 512 tests passed, confirming the enriched fixture broke nothing |
| `pnpm run lint` from the root | passes, no files rewritten |
| `cd web && pnpm test:e2e` | see below |

Playwright ran here in full against the real stack. The four concurrency tests and both version gate tests pass, and so does the rest of the suite.

No existing test was weakened or deleted. The two concurrency tests that were kept assert strictly more than they used to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
