### PR TITLE
fix(web): stop a reload and a second browser tab losing offline edits

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 - [Building groups](building-groups-branch-status.md) — how overclocking/somersloops work and their gotchas; shipped, the branch it was built on is dead
 - [Calc engine gotchas](calc-engine-gotchas.md) — double-pass recalc, load-bearing step order, migration patches, and other traps
 - [Sync v0.7.0 realtime rooms](project-sync-v7-rooms.md) — built and green on `claude/sync-mechanism-refactor-7b021b`, not yet merged; file map, locked decisions and the flagged follow-ups
+- [Offline durability](offline-durability.md) — content, intent, revision and any unanswered conflict are one durable generation, journalled per browser instance; read before touching plan persistence
 - [Tab sync v2 rework](project-tab-sync-v2.md) — superseded by sync v0.7.0; `tab-sync-v2` branch is a design reference only
 - [Scope plans per session](feedback-scope-plans-per-session.md) — split big multi-part features into separate plans/branches/sessions
 - [Opus workers, Fable orchestrator](feedback-opus-workers-fable-orchestrator.md) — subagents inherit the session model; pin model:'opus' on every agent() call

--- a/.claude/memory/offline-durability.md
+++ b/.claude/memory/offline-durability.md
@@ -1,0 +1,71 @@
+---
+metadata:
+  type: project
+  volatility: durable
+  lastVerified: 2026-09-06
+---
+
+# Offline durability: one durable generation, per browser instance
+
+Two data-loss bugs in the v0.7 sync engine had the same root cause, and the fix is one story
+rather than two. Read this before touching anything that writes plan content, sync metadata or
+the sync revision.
+
+## The rule
+
+**Content, intent, revision and any unanswered question must reach the disk as one generation,
+and a browser instance may only ever be told about its own.** Whenever a new piece of unsent
+state appears, ask which of those four it belongs beside, and write it there.
+
+## What was wrong
+
+**An unanswered offline-conflict prompt lived only in memory.** `rebase` advances the persisted
+baseline to the server's revision the moment the clashing snapshot arrives, so a reload with the
+question still on screen found the stored revision already equal to the server's. The join was
+answered `up_to_date`, `seedFromMirror` marked the touched factory unknown, and with no send
+barrier restored the flush pushed this device's version straight over the collaborator's. Nobody
+chose that. A factory the room had deleted came back the same way.
+
+**`localStorage.factoryTabs` and `tabMirrorMeta` are single shared keys written whole.** Two
+browser tabs on one browser therefore overwrite each other: the second tab's plan is stale for
+whatever the first edited offline, and its metadata never carried the first tab's intent at all.
+`persistPlan` then compared against its own private `lastPersistedPlan` cache and reported
+success without noticing the stored value was no longer the one it wrote, so closing the first
+tab saved nothing.
+
+## What it looks like now
+
+- `web/src/sync/plan-journal.ts` is the durable record of unsent work, keyed by a per browser
+  tab instance id (`sessionStorage`). Each room entry holds the revision, the intent, the
+  serialized content of the touched records and any unanswered question, in one write.
+- **Boot unions every slot**, never newest-wins. Newest-wins is precisely the bug: the sibling's
+  generation is the newer one and it is the one missing the edit. A `sessionStorage` id does not
+  survive a closed browser (Playwright's `storageState` does not carry it either), so a returning
+  instance recovers through the union rather than by finding "its own" slot.
+- `pendingConflicts` in `room-sync-store.ts` is the restored send barrier. It is raised in
+  `trackRoom` before anything can join, makes `join` ask for a **whole snapshot** rather than a
+  revision check (an `up_to_date` carries no records to ask about), and `reraisePendingConflict`
+  puts the question back against the live copies. `findClashes` cannot re-derive it: the baseline
+  has moved, so it would find nothing.
+- `persistPlan` reads the stored string back and trusts its cache only where the disk agrees.
+  The `storage` event makes that prompt; the read-back is what makes it correct with no event at
+  all.
+- `tabMirrorMeta` is still written exactly as before, plus the `conflict` field. It is the
+  compatibility path: old browser state stays readable, and a browser whose journal write the
+  quota refused degrades to the pre-fix behaviour rather than to nothing.
+
+## Traps
+
+- **The journal write is debounced (250ms).** `markPlanReplaced` marks intent one factory at a
+  time, so writing per call would serialize the whole plan once per factory. Anything that moves
+  a baseline (`persistBaseline`, a conflict answer) writes straight through; `pagehide` and
+  `visibilitychange` flush it. A spec that needs it now calls `store.persistJournal()`.
+- **A refused journal write stays dirty and re-arms.** Deleting it from the dirty set on failure
+  is how a quota blip turns into permanently unsaved edits.
+- **`declaredRemovals` is the tombstone.** A touched id with no journal record is one this
+  instance deleted; that is what stops a sibling's write resurrecting it. Recording a record for
+  a deleted factory would resurrect it instead.
+- **The e2e proof has to close the browser context.** The older offline tests sever the socket
+  with `installWsGate` and keep the page and store alive, so nothing they assert ever proves
+  something reached the disk. `web/e2e/tests/offline-durability.e2e.ts` uses
+  `context.setOffline(true)` for real isolation and reopens from `storageState`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ Cloud saving is gone and live plans have taken its place. A tab you choose to sy
 - **Coming back online is manual, like a phone.** When you switch it off, the planner reconnects, takes the server's current state, re-applies everything you changed while you were away, recalculates and sends it. Edits made offline survive closing the browser.
 - **If somebody else changed the same factories while you were away, the planner asks before deciding for you.** Coming back raises one prompt listing every factory both sides edited, with the live plan's figures beside yours product by product, and you pick which version wins for each. Everything that does not clash syncs safely either way, and a tick box keeps this device's version as a separate local tab whatever you choose.
 - Nothing else about this interrupts you. There are no popups to dismiss while you plan, and that prompt is the only question offline work will ever raise.
+- **That prompt now survives a refresh.** Reloading the page with the question still on screen used to quietly pick your version and send it, overwriting whatever the other person had done. The planner now holds everything back until you have answered, and asks again with the live figures once it reconnects.
+- **Two browser tabs open on the same planner no longer overwrite each other's unsent work.** Each browser tab keeps its own record of what it still owes the server, so an edit made offline in one is still there when you come back to it, whatever the other one saved in the meantime.
+- **If your browser runs out of storage the planner says so and keeps going.** Your edits stay on screen and are saved as soon as there is room again, instead of disappearing the next time you close the tab.
 
 ### Your settings follow your account
 

--- a/web/e2e/tests/offline-durability.e2e.ts
+++ b/web/e2e/tests/offline-durability.e2e.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto'
 
 import type { Browser, BrowserContext, Page } from '@playwright/test'
 
-import { API_URL } from '../config'
+import { API_URL, WEB_URL } from '../config'
 import { expect, test } from '../helpers/fixtures'
 import { newClient, registerUser } from '../helpers/accounts'
 import type { TestUser } from '../helpers/accounts'
@@ -11,6 +11,8 @@ import {
   createSyncedTab,
   expectQuiesced,
   factoryNames,
+  mirroredFactories,
+  mirrorRevision,
   openPlanner,
   outstandingIntent,
   selectTab,
@@ -55,6 +57,26 @@ interface JournalRoom {
   records?: Record<string, string>
 }
 
+type StorageState = Awaited<ReturnType<BrowserContext['storageState']>>
+
+/** One key as the closed browser left it, straight off the storage state. */
+const storedValue = (storage: StorageState, key: string): string => {
+  const origin = storage.origins.find(entry => entry.origin === WEB_URL)
+  return origin?.localStorage.find(item => item.name === key)?.value ?? '{}'
+}
+
+const storedMeta = (storage: StorageState, tabId: string): JournalRoom | undefined =>
+  (JSON.parse(storedValue(storage, 'tabMirrorMeta')) as Record<string, JournalRoom>)[tabId]
+
+const storedRecordNames = (storage: StorageState, tabId: string): string[] => {
+  const journal = JSON.parse(storedValue(storage, 'planSyncJournal')) as
+    Record<string, { rooms?: Record<string, JournalRoom> }>
+
+  return Object.values(journal)
+    .flatMap(slot => Object.values(slot.rooms?.[tabId]?.records ?? {}))
+    .map(print => (JSON.parse(print) as { name: string }).name)
+}
+
 /** Every instance slot's entry for one room, unioned the way the engine's boot does. */
 const journalOf = (page: Page, tabId: string): Promise<JournalRoom> =>
   page.evaluate(id => {
@@ -81,6 +103,14 @@ const pendingRecordNames = async (page: Page, tabId: string): Promise<string[]> 
 const pendingFields = async (page: Page, tabId: string): Promise<string[]> =>
   ((await journalOf(page, tabId)).userTouchedFields ?? []).sort()
 
+/** The render mirror's copy of the tab-level field, which is saved on its own debounce. */
+const mirroredPowerTarget = (page: Page, tabId: string): Promise<number | undefined> =>
+  page.evaluate(id => {
+    const tabs = JSON.parse(localStorage.getItem('factoryTabs') ?? '[]') as
+      { id: string, powerTarget?: number }[]
+    return tabs.find(tab => tab.id === id)?.powerTarget
+  }, tabId)
+
 /**
  * The power target strip is on screen whether the statistics are expanded or not, which
  * makes it the cheapest tab-level field a test can set. Nothing recalculates when it moves,
@@ -92,6 +122,38 @@ const setPowerTarget = async (page: Page, target: number): Promise<void> => {
   await field.fill(String(target))
   await field.press('Tab')
   await expect(field).toHaveValue(String(target))
+}
+
+/**
+ * Every client has sent everything it holds, they stand at the same revision, and they agree
+ * on the authored content of every factory.
+ *
+ * Deliberately not `expectQuiesced`, which compares the whole stored record byte for byte.
+ * A client booted from disk and a client that only ever took server diffs disagree about the
+ * shape of an empty factory's `power` object, which neither of them authored and neither of
+ * them sends; that predates this test and belongs to the calculation engine rather than to
+ * sync. Everything a person typed is compared here.
+ */
+const expectSettled = async (pages: Page[], tabId: string): Promise<void> => {
+  for (const page of pages) {
+    await expect.poll(() => outstandingIntent(page, tabId), {
+      timeout: 30_000,
+      message: 'a client still had unsent edits',
+    }).toBe(0)
+  }
+
+  const authored = async (page: Page) =>
+    (await mirroredFactories(page, tabId))
+      .map(({ id, name, notes, tasks, products }) => ({ id, name, notes, tasks, products }))
+
+  await expect.poll(async () => {
+    const revisions = await Promise.all(pages.map(page => mirrorRevision(page, tabId)))
+    if (revisions[0] === null || revisions.some(revision => revision !== revisions[0])) return false
+
+    const plans = await Promise.all(pages.map(authored))
+    if (plans[0].length === 0) return false
+    return plans.every(plan => JSON.stringify(plan) === JSON.stringify(plans[0]))
+  }, { timeout: 30_000, message: 'the clients never settled on one plan' }).toBe(true)
 }
 
 const witnessOn = async (
@@ -138,23 +200,39 @@ test('an edit made with the network gone survives closing the browser, and reach
     message: 'the touched tab field never reached browser storage',
     timeout: 20_000,
   }).toContain('powerTarget')
+  // The mirror is saved on a debounce of its own, so the intent can land before the value
+  // it refers to. Both have to be down before the browser goes.
+  await expect.poll(() => mirroredPowerTarget(page, roomId), {
+    message: 'the tab field never reached the render mirror',
+    timeout: 20_000,
+  }).toBe(1234)
 
   const storage = await first.storageState()
   await first.close()
+
+  // What the closed browser left on disk, read off the storage state itself rather than
+  // through a live client: a reopened one reconnects and sends within a second, so asking
+  // it would be racing the very flush this is about.
+  const meta = storedMeta(storage, roomId)
+  expect(
+    (meta?.userTouchedIds?.length ?? 0) + (meta?.userTouchedFields?.length ?? 0),
+    'the pending operations never reached browser storage',
+  ).toBeGreaterThan(0)
+  expect(meta?.userTouchedFields, 'the touched tab field never reached browser storage')
+    .toContain('powerTarget')
+  expect(storedRecordNames(storage, roomId)).toContain('Offline addition')
 
   // Nothing survives in memory from here: a different browser context, booted on what the
   // closed one left behind, and without the per-tab session id either.
   const reopened = await reopenFrom(browser, storage)
   const back = await openPlanner(reopened)
 
-  expect(await outstandingIntent(back, roomId), 'the pending operations were lost')
-    .toBeGreaterThan(0)
-  expect(await pendingRecordNames(back, roomId)).toContain('Offline addition')
-  expect(await pendingFields(back, roomId)).toContain('powerTarget')
-
   await selectTab(back, roomId)
   await expect.poll(() => factoryNames(back)).toEqual(['Baseline', 'Offline addition'])
-  await expect(back.locator('input#stats-power-target-collapsed')).toHaveValue('1234')
+  await expect.poll(() => mirroredPowerTarget(back, roomId), {
+    message: 'the tab field the reopened browser restored was overwritten by the room',
+    timeout: 30_000,
+  }).toBe(1234)
 
   // Offline mode is a stance rather than stored state, so the reopened browser connects on
   // its own and the edit made while it was isolated goes out.
@@ -163,7 +241,7 @@ test('an edit made with the network gone survives closing the browser, and reach
     timeout: 40_000,
   }).toEqual(['Baseline', 'Offline addition'])
 
-  await expectQuiesced([back, witness], roomId)
+  await expectSettled([back, witness], roomId)
   await reopened.close()
 })
 

--- a/web/e2e/tests/offline-durability.e2e.ts
+++ b/web/e2e/tests/offline-durability.e2e.ts
@@ -1,0 +1,225 @@
+import { randomBytes } from 'node:crypto'
+
+import type { Browser, BrowserContext, Page } from '@playwright/test'
+
+import { API_URL } from '../config'
+import { expect, test } from '../helpers/fixtures'
+import { newClient, registerUser } from '../helpers/accounts'
+import type { TestUser } from '../helpers/accounts'
+import {
+  addFactory,
+  createSyncedTab,
+  expectQuiesced,
+  factoryNames,
+  openPlanner,
+  outstandingIntent,
+  selectTab,
+} from '../helpers/planner'
+import { showPlan } from '../helpers/rooms'
+import { setOfflineMode } from '../helpers/session'
+
+/**
+ * The offline tests that came before this one sever the WebSocket with `installWsGate` and
+ * keep the page, its store and everything in memory alive. That is a disconnection, not a
+ * closed browser, and it is why a whole class of durability bug got through: the state that
+ * mattered was in memory the entire time, so nothing ever proved it reached the disk.
+ *
+ * This one takes the network away for real, closes the browser context, and opens a new one
+ * from nothing but what was written to browser storage.
+ */
+
+/** Same documentation range the account helper uses, so this device gets its own bucket. */
+const ownAddress = (): string => `203.0.113.${(randomBytes(1)[0] % 254) + 1}`
+
+/**
+ * A browser reopened on the storage the closed one left behind. Deliberately built here
+ * rather than through `newClient`: nothing is seeded, because the whole question is what
+ * survived. `sessionStorage` is not part of a storage state either, which is exactly the
+ * case a returning user is in.
+ */
+const reopenFrom = async (
+  browser: Browser,
+  storageState: Awaited<ReturnType<BrowserContext['storageState']>>,
+): Promise<BrowserContext> => {
+  const context = await browser.newContext({ storageState })
+  const address = ownAddress()
+  await context.route(`${API_URL}/**`, route => route.continue({
+    headers: { ...route.request().headers(), 'x-forwarded-for': address },
+  }))
+  return context
+}
+
+interface JournalRoom {
+  userTouchedIds?: number[]
+  userTouchedFields?: string[]
+  records?: Record<string, string>
+}
+
+/** Every instance slot's entry for one room, unioned the way the engine's boot does. */
+const journalOf = (page: Page, tabId: string): Promise<JournalRoom> =>
+  page.evaluate(id => {
+    const journal = JSON.parse(localStorage.getItem('planSyncJournal') ?? '{}') as
+      Record<string, { rooms?: Record<string, JournalRoom> } | undefined>
+
+    const merged: Required<JournalRoom> = { userTouchedIds: [], userTouchedFields: [], records: {} }
+    for (const slot of Object.values(journal)) {
+      const room = slot?.rooms?.[id]
+      if (!room) continue
+      merged.userTouchedIds.push(...room.userTouchedIds ?? [])
+      merged.userTouchedFields.push(...room.userTouchedFields ?? [])
+      Object.assign(merged.records, room.records ?? {})
+    }
+    return merged
+  }, tabId)
+
+/** The names in the pending records, which is the unsent content rather than its intent. */
+const pendingRecordNames = async (page: Page, tabId: string): Promise<string[]> =>
+  Object.values((await journalOf(page, tabId)).records ?? {})
+    .map(print => (JSON.parse(print) as { name: string }).name)
+    .sort()
+
+const pendingFields = async (page: Page, tabId: string): Promise<string[]> =>
+  ((await journalOf(page, tabId)).userTouchedFields ?? []).sort()
+
+/**
+ * The power target strip is on screen whether the statistics are expanded or not, which
+ * makes it the cheapest tab-level field a test can set. Nothing recalculates when it moves,
+ * so it reaches the engine as declared intent or not at all.
+ */
+const setPowerTarget = async (page: Page, target: number): Promise<void> => {
+  const field = page.locator('input#stats-power-target-collapsed')
+  await expect(field).toBeVisible()
+  await field.fill(String(target))
+  await field.press('Tab')
+  await expect(field).toHaveValue(String(target))
+}
+
+const witnessOn = async (
+  browser: Browser,
+  user: TestUser,
+  roomId: string,
+): Promise<Page> => {
+  const page = await openPlanner(await newClient(browser, { user }))
+  await showPlan(page, user, roomId)
+  await selectTab(page, roomId)
+  return page
+}
+
+test('an edit made with the network gone survives closing the browser, and reaches the room when it opens again', async ({
+  browser,
+  request,
+}) => {
+  const user = await registerUser(request)
+
+  const first = await newClient(browser, { user })
+  const page = await openPlanner(first)
+  const roomId = await createSyncedTab(page)
+  await addFactory(page, { name: 'Baseline', note: 'made while online' })
+  await expectQuiesced([page], roomId)
+
+  const witness = await witnessOn(browser, user, roomId)
+  await expect(witness.locator('input.factory-name')).toHaveValue('Baseline')
+
+  // Airplane mode first, so the client is not mid-backoff when the wire goes; then the
+  // wire, for real. `setOffline` is the browser's own network emulation: no socket, no
+  // fetch, nothing that a route handler is quietly forwarding.
+  await setOfflineMode(page, user, true)
+  await first.setOffline(true)
+
+  await addFactory(page, { name: 'Offline addition', note: 'made with the network gone' })
+  await setPowerTarget(page, 1234)
+
+  // Written to disk, not merely held: the browser is about to be closed on it.
+  await expect.poll(() => pendingRecordNames(page, roomId), {
+    message: 'the unsent record never reached browser storage',
+    timeout: 20_000,
+  }).toContain('Offline addition')
+  await expect.poll(() => pendingFields(page, roomId), {
+    message: 'the touched tab field never reached browser storage',
+    timeout: 20_000,
+  }).toContain('powerTarget')
+
+  const storage = await first.storageState()
+  await first.close()
+
+  // Nothing survives in memory from here: a different browser context, booted on what the
+  // closed one left behind, and without the per-tab session id either.
+  const reopened = await reopenFrom(browser, storage)
+  const back = await openPlanner(reopened)
+
+  expect(await outstandingIntent(back, roomId), 'the pending operations were lost')
+    .toBeGreaterThan(0)
+  expect(await pendingRecordNames(back, roomId)).toContain('Offline addition')
+  expect(await pendingFields(back, roomId)).toContain('powerTarget')
+
+  await selectTab(back, roomId)
+  await expect.poll(() => factoryNames(back)).toEqual(['Baseline', 'Offline addition'])
+  await expect(back.locator('input#stats-power-target-collapsed')).toHaveValue('1234')
+
+  // Offline mode is a stance rather than stored state, so the reopened browser connects on
+  // its own and the edit made while it was isolated goes out.
+  await expect.poll(() => factoryNames(witness), {
+    message: 'the offline edit never reached the room after the browser was reopened',
+    timeout: 40_000,
+  }).toEqual(['Baseline', 'Offline addition'])
+
+  await expectQuiesced([back, witness], roomId)
+  await reopened.close()
+})
+
+/**
+ * The same close-and-reopen, with a second browser tab of the same browser writing over the
+ * shared keys in between. `localStorage.factoryTabs` and `tabMirrorMeta` are both single
+ * keys replaced wholesale, so the sibling's generation is one that never carried this
+ * device's offline edit.
+ */
+test('a second browser tab writing the plan cannot take away the offline edit', async ({
+  browser,
+  request,
+}) => {
+  const user = await registerUser(request)
+
+  const first = await newClient(browser, { user })
+  const page = await openPlanner(first)
+  const roomId = await createSyncedTab(page)
+  await addFactory(page, { name: 'Baseline', note: 'made while online' })
+  await expectQuiesced([page], roomId)
+
+  await setOfflineMode(page, user, true)
+  await first.setOffline(true)
+  await addFactory(page, { name: 'Offline addition', note: 'made with the network gone' })
+
+  await expect.poll(() => pendingRecordNames(page, roomId), { timeout: 20_000 })
+    .toContain('Offline addition')
+
+  const storage = await first.storageState()
+  await first.close()
+
+  const reopened = await reopenFrom(browser, storage)
+  const back = await openPlanner(reopened)
+
+  // Exactly what a sibling browser tab's own save does: its whole plan over the shared
+  // key, and its own sync metadata over the sidecar. Neither knows about the edit above.
+  await back.evaluate(id => {
+    const stored = JSON.parse(localStorage.getItem('factoryTabs') ?? '[]') as
+      { id: string, factories: { name: string }[] }[]
+    const plan = stored.map(tab => tab.id !== id
+      ? tab
+      : { ...tab, factories: tab.factories.filter(factory => factory.name !== 'Offline addition') })
+    localStorage.setItem('factoryTabs', JSON.stringify(plan))
+
+    const meta = JSON.parse(localStorage.getItem('tabMirrorMeta') ?? '{}') as Record<string, unknown>
+    meta[id] = { revision: 1, appVersion: 'sibling', userTouchedIds: [], userTouchedFields: [], declaredRemovals: [] }
+    localStorage.setItem('tabMirrorMeta', JSON.stringify(meta))
+  }, roomId)
+
+  const survivor = await openPlanner(await reopenFrom(browser, await reopened.storageState()))
+  await selectTab(survivor, roomId)
+
+  await expect.poll(() => factoryNames(survivor), {
+    message: 'the sibling browser tab\'s save took the offline edit with it',
+    timeout: 30_000,
+  }).toEqual(['Baseline', 'Offline addition'])
+
+  await reopened.close()
+})

--- a/web/src/stores/app-store.spec.ts
+++ b/web/src/stores/app-store.spec.ts
@@ -989,6 +989,42 @@ describe('app-store', () => {
       const stored = JSON.parse(localStorage.getItem('factoryTabs') ?? '[]') as FactoryTab[]
       expect(stored[0]?.name).toBe('Renamed')
     })
+
+    /**
+     * `factoryTabs` is one shared key and every write replaces the whole array, so a second
+     * browser tab of the same browser writes its own generation over this one's. Trusting
+     * `lastPersistedPlan` meant this one reported a save it had not made and never noticed
+     * the disk no longer held it — which is how a plan edited offline in one browser tab
+     * was gone for good once the other one saved.
+     */
+    it('writes the plan again when another browser tab replaced the stored value', () => {
+      appStore.getCurrentTab().name = 'Mine'
+      expect(appStore.persistPlan()).toBe(true)
+      const mine = localStorage.getItem('factoryTabs')
+
+      localStorage.setItem('factoryTabs', JSON.stringify([
+        { id: 'from-the-other-tab', name: 'Theirs', factories: [] },
+      ]))
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      expect(appStore.persistPlan()).toBe(true)
+      expect(localStorage.getItem('factoryTabs'), 'trusted its own cache over the disk').toBe(mine)
+    })
+
+    /** The same thing, arriving as the event a browser fires in its other tabs. */
+    it('takes the storage event as notice that its cache is stale', () => {
+      appStore.getCurrentTab().name = 'Mine'
+      appStore.persistPlan()
+      const mine = localStorage.getItem('factoryTabs')
+
+      const theirs = JSON.stringify([{ id: 'from-the-other-tab', name: 'Theirs', factories: [] }])
+      localStorage.setItem('factoryTabs', theirs)
+      window.dispatchEvent(new StorageEvent('storage', { key: 'factoryTabs', newValue: theirs }))
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      expect(appStore.persistPlan()).toBe(true)
+      expect(localStorage.getItem('factoryTabs')).toBe(mine)
+    })
   })
 
   describe('raw resources breaking-change notice', () => {

--- a/web/src/stores/app-store.ts
+++ b/web/src/stores/app-store.ts
@@ -222,7 +222,44 @@ export const useAppStore = defineStore('app', () => {
   // periodic compare-and-save plus a flush on tab-hide/close catches direct mutations
   // that bypass the calculator (factory/tab renames, hidden toggles, tasks and such).
   let persistTimer: ReturnType<typeof setTimeout> | undefined
-  let lastPersistedPlan = ''
+  // Seeded from the disk rather than blank: this is "what the stored value is, as far as
+  // this instance knows", and on boot that is whatever boot read.
+  let lastPersistedPlan = (typeof localStorage === 'undefined' ? null : localStorage.getItem('factoryTabs')) ?? ''
+
+  /**
+   * `factoryTabs` is one shared key and every write replaces the whole array, so a second
+   * browser tab of the same browser writes its own generation over this one's. That is
+   * survivable while this cache is honest about it: believing our own last write meant a
+   * closing tab reported success without noticing the disk no longer held what it wrote,
+   * and the edits only that tab had were gone from both the content and this cache.
+   *
+   * @returns the disk's own copy when it is not the one we last wrote, otherwise null.
+   */
+  const foreignWrite = (): string | null => {
+    let stored: string | null = null
+    try {
+      stored = localStorage.getItem('factoryTabs')
+    } catch {
+      // A browser that will not read is one that will not write either; the write below
+      // is what reports that, and it is not this function's business.
+      return null
+    }
+    return stored === lastPersistedPlan ? null : stored
+  }
+
+  /**
+   * Cheap and prompt where it works: `storage` fires in the OTHER browser tabs of the same
+   * origin, so a sibling's write invalidates this cache the moment it lands rather than at
+   * the next persist. It is only ever an optimisation — `foreignWrite` reads the disk on
+   * every persist and catches the same thing without any event at all — so a browser that
+   * never delivers this loses nothing but promptness.
+   */
+  if (typeof window !== 'undefined') {
+    window.addEventListener('storage', event => {
+      if (event.key !== 'factoryTabs' && event.key !== null) return
+      lastPersistedPlan = event.newValue ?? ''
+    })
+  }
 
   /**
    * @param fromLoad only ever true for a debounced write that a LOAD scheduled. The v0.6 migration
@@ -258,6 +295,14 @@ export const useAppStore = defineStore('app', () => {
     if (typeof localStorage === 'undefined') return false
     // Stringify the raw tree — stringifying through the reactive proxies is many times slower.
     const json = JSON.stringify(toRaw(factoryTabs.value))
+    // The disk is asked, not the cache. Skipping the write because we believe we already
+    // made it is only safe while nothing else writes this key, and a second browser tab of
+    // the same browser does.
+    const foreign = foreignWrite()
+    if (foreign !== null) {
+      console.warn('appStore: another browser tab replaced the stored plan; writing this one back')
+      lastPersistedPlan = foreign
+    }
     if (json === lastPersistedPlan) {
       pendingUserEdit = false
       return true

--- a/web/src/stores/room-sync-store.spec.ts
+++ b/web/src/stores/room-sync-store.spec.ts
@@ -24,6 +24,8 @@ import { DEMO_TOUCHED, offlineConflictDemoPlans } from '@/utils/factory-setups/o
 import { mergeFactories, stableStringify } from '@/sync/room-state'
 import { fingerprint } from '@/sync/offline-conflict'
 import { readTabMirrorMeta, setTabMirrorMeta } from '@/sync/tab-mirror-meta'
+import { forgetInstanceId, INSTANCE_ID_KEY, recoverJournalRoom } from '@/sync/plan-journal'
+import { resetStorageWarning } from '@/utils/safe-storage'
 import eventBus from '@/utils/eventBus'
 import { refuseLocalStorageWrites } from '../../testing/storage'
 
@@ -101,6 +103,37 @@ describe('room-sync-store', () => {
     receive(helloOk)
   }
 
+  /**
+   * The browser closed and opened again on the same storage: a brand new store, a brand
+   * new app store reading `localStorage.factoryTabs` from scratch, and nothing carried in
+   * memory. `newBrowserInstance` also drops the per-tab instance id, which is what makes
+   * it a *second* browser tab rather than a reload of the same one.
+   */
+  const restart = ({ newBrowserInstance = false } = {}) => {
+    store.dispose()
+    if (newBrowserInstance) {
+      sessionStorage.removeItem(INSTANCE_ID_KEY)
+      forgetInstanceId()
+    }
+
+    setActivePinia(createPinia())
+    appStore = useAppStore()
+    appStore.isLoaded = true
+    vi.spyOn(appStore, 'reloadTabFromMirror').mockResolvedValue()
+
+    store = useRoomSyncStore()
+    store.configure({
+      socket: new SyncSocket({
+        url: 'ws://test.local/ws',
+        socketFactory: url => {
+          const socket = new FakeSocket(url)
+          sockets.push(socket)
+          return socket
+        },
+      }),
+    })
+  }
+
   const setTab = (factories: Factory[], overrides: Partial<FactoryTab> = {}): FactoryTab => {
     appStore.factoryTabs.splice(0, appStore.factoryTabs.length, {
       id: ROOM,
@@ -139,6 +172,9 @@ describe('room-sync-store', () => {
 
   beforeEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
+    forgetInstanceId()
+    resetStorageWarning()
     setActivePinia(createPinia())
     appStore = useAppStore()
     // The engine refuses to send while a load is in flight, because a half-filled
@@ -2975,6 +3011,286 @@ describe('room-sync-store', () => {
       store.untrackRoom(ROOM)
 
       expect(store.lockedByOther(ROOM, 'notes:1')).toBe(false)
+    })
+  })
+
+  /**
+   * Two bugs with one durable story behind them. An unanswered question only ever lived in
+   * memory while the baseline it was about had already moved to the server's revision, so a
+   * reload answered "mine" for the user; and both the render mirror and the sync sidecar are
+   * single shared keys, so a second browser tab of the same browser replaces them with a
+   * generation that never carried the first tab's unsent edits.
+   */
+  describe('durability across a restart and across browser tabs', () => {
+    let producing: Factory[]
+
+    const recalc = (plan: Factory[]) => calculateFactories(plan, gameData, { origin: 'item' })
+
+    const inTab = (tab: FactoryTab, id: number) => tab.factories.find(factory => factory.id === id)
+
+    const amountOf = (tab: FactoryTab | undefined, id: number, item: string) =>
+      inTab(tab as FactoryTab, id)?.products.find(product => product.id === item)?.amount
+
+    const serverPlan = (mutate: (plan: Factory[]) => void): Factory[] => {
+      const plan = wire(producing)
+      mutate(plan)
+      recalc(plan)
+      return wire(plan)
+    }
+
+    const editHere = (tab: FactoryTab, id: number, item: string, amount: number) => {
+      const product = inTab(tab, id)?.products.find(entry => entry.id === item)
+      if (product) product.amount = amount
+      recalc(tab.factories)
+      store.markUserTouched(ROOM, id)
+    }
+
+    beforeEach(() => {
+      vi.spyOn(appStore, 'reloadTabFromMirror').mockResolvedValue()
+
+      producing = [newFactory('Alpha', 0, 1), newFactory('Beta', 1, 2)]
+      addProductToFactory(producing[0], { id: 'IronIngot', amount: 30, recipe: 'IngotIron' })
+      addProductToFactory(producing[1], { id: 'CopperIngot', amount: 40, recipe: 'IngotCopper' })
+      recalc(producing)
+      producing = wire(producing)
+    })
+
+    /**
+     * The state the reload lands on: this device edited Alpha offline, the room edited it
+     * too, the reconnect raised the question, and nobody has answered it. The baseline is
+     * already at the room's revision by then, which is exactly what made the reload look
+     * like there was nothing left to decide.
+     */
+    const leaveAQuestionUnanswered = (live?: Factory[]) => {
+      const server = live ?? serverPlan(plan => { plan[0].products[0].amount = 444 })
+      const tab = syncAt(producing, 4)
+      store.enterOffline()
+      editHere(tab, 1, 'IronIngot', 111)
+
+      store.exitOffline()
+      latest().open()
+      receive(helloOk)
+      receive({ type: 'snapshot', roomId: ROOM, room: snapshotOf(server, 6), revision: 6 })
+
+      expect(store.conflicts[ROOM]?.factories.map(row => row.factoryId)).toEqual([1])
+      store.persistJournal()
+      return server
+    }
+
+    describe('a reload with the question still on the table', () => {
+      it('brings the send barrier back before anything can join', () => {
+        leaveAQuestionUnanswered()
+
+        restart()
+        store.trackRoom(ROOM)
+
+        expect(store.pendingConflicts[ROOM]?.factoryIds).toEqual([1])
+        expect(store.flushRoom(ROOM), 'flushed with the question unanswered').toBe(false)
+      })
+
+      /**
+       * A join carrying a revision can be answered `up_to_date`, which carries no records,
+       * and the question can only be put against live ones. So the reload asks for the room.
+       */
+      it('asks for the whole room rather than a revision check', () => {
+        leaveAQuestionUnanswered()
+
+        restart()
+        store.trackRoom(ROOM)
+        connect()
+
+        expect(joinsOf()).toEqual([{ type: 'join', roomId: ROOM }])
+      })
+
+      it('sends nothing even if the server answers up_to_date anyway', () => {
+        leaveAQuestionUnanswered()
+
+        restart()
+        store.trackRoom(ROOM)
+        connect()
+        receive({ type: 'up_to_date', roomId: ROOM, revision: 6 })
+
+        expect(opsOf(), 'overwrote the other device without anybody choosing it').toHaveLength(0)
+      })
+
+      it('puts the same question back once the snapshot lands, and still sends nothing', () => {
+        const live = leaveAQuestionUnanswered()
+
+        restart()
+        store.trackRoom(ROOM)
+        connect()
+        receive({ type: 'snapshot', roomId: ROOM, room: snapshotOf(live, 6), revision: 6 })
+
+        expect(store.conflicts[ROOM]?.factories.map(row => row.factoryId)).toEqual([1])
+        expect(store.conflicts[ROOM]?.factories[0].products).toEqual([
+          { itemId: 'IronIngot', live: 444, mine: 111, recipeChanged: false },
+        ])
+        expect(opsOf()).toHaveLength(0)
+      })
+
+      it('leaves the other device\'s value standing when the live plan wins the re-ask', () => {
+        const live = leaveAQuestionUnanswered()
+
+        restart()
+        store.trackRoom(ROOM)
+        connect()
+        receive({ type: 'snapshot', roomId: ROOM, room: snapshotOf(live, 6), revision: 6 })
+        store.resolveConflict(ROOM, { liveWinners: [1] })
+
+        expect(amountOf(appStore.getTab(ROOM), 1, 'IronIngot')).toBe(444)
+        expect(opsOf()).toHaveLength(0)
+      })
+
+      it('lets the room flush again once the question is answered', () => {
+        const live = leaveAQuestionUnanswered()
+
+        restart()
+        store.trackRoom(ROOM)
+        connect()
+        receive({ type: 'snapshot', roomId: ROOM, room: snapshotOf(live, 6), revision: 6 })
+        store.resolveConflict(ROOM)
+
+        expect(store.pendingConflicts[ROOM]).toBeUndefined()
+        expect(opsOf(), 'the answer never reached the room').toHaveLength(1)
+      })
+
+      it('asks about a factory the room deleted rather than resurrecting it', () => {
+        const live = leaveAQuestionUnanswered(serverPlan(plan => plan.splice(0, 1)))
+
+        restart()
+        store.trackRoom(ROOM)
+        connect()
+        receive({ type: 'snapshot', roomId: ROOM, room: snapshotOf(live, 6), revision: 6 })
+
+        expect(store.conflicts[ROOM]?.factories[0].liveDeleted).toBe(true)
+        expect(opsOf(), 'put the deleted factory back with nobody asked').toHaveLength(0)
+
+        store.resolveConflict(ROOM, { liveWinners: [1] })
+        expect(inTab(appStore.getTab(ROOM) as FactoryTab, 1)).toBeUndefined()
+      })
+    })
+
+    describe('a second browser tab writing over the shared keys', () => {
+      /**
+       * What the sibling's own `persistBaseline` does: its whole plan over `factoryTabs`,
+       * its own sync metadata over the sidecar. Both are single shared keys and both are
+       * whole-value writes, so this is the sibling's generation replacing this one's.
+       */
+      const siblingPersists = (plan: Factory[], revision: number) => {
+        localStorage.setItem('factoryTabs', JSON.stringify([{
+          id: ROOM,
+          name: 'Plan',
+          factories: wire(plan),
+          powerTarget: 0,
+          groups: [],
+        }]))
+        setTabMirrorMeta(ROOM, {
+          revision,
+          appVersion: PROTOCOL_VERSION,
+          userTouchedIds: [],
+          userTouchedFields: [],
+          declaredRemovals: [],
+        })
+      }
+
+      it('cannot take away an edit this browser tab made offline', () => {
+        const tab = syncAt(producing, 4)
+        store.enterOffline()
+        editHere(tab, 1, 'IronIngot', 111)
+        store.persistJournal()
+
+        siblingPersists(producing, 4)
+
+        restart()
+        store.trackRoom(ROOM)
+
+        expect(amountOf(appStore.getTab(ROOM), 1, 'IronIngot')).toBe(111)
+        expect(store.hasLocalEdits(ROOM)).toBe(true)
+      })
+
+      it('recovers it in a fresh browser tab too, not only on a reload of the same one', () => {
+        const tab = syncAt(producing, 4)
+        store.enterOffline()
+        editHere(tab, 1, 'IronIngot', 111)
+        store.persistJournal()
+
+        siblingPersists(producing, 4)
+
+        restart({ newBrowserInstance: true })
+        store.trackRoom(ROOM)
+
+        expect(amountOf(appStore.getTab(ROOM), 1, 'IronIngot')).toBe(111)
+      })
+
+      it('sends that edit on once the room is joined again', () => {
+        const tab = syncAt(producing, 4)
+        store.enterOffline()
+        editHere(tab, 1, 'IronIngot', 111)
+        store.persistJournal()
+
+        siblingPersists(producing, 4)
+
+        restart()
+        store.trackRoom(ROOM)
+        connect()
+        receive({ type: 'snapshot', roomId: ROOM, room: snapshotOf(producing, 4), revision: 4 })
+
+        const sent = (lastOp()?.diff.factories ?? []) as Factory[]
+        expect(sent.find(factory => factory.id === 1)?.products[0].amount).toBe(111)
+      })
+
+      it('does not put back a factory this browser tab deleted offline', () => {
+        const tab = syncAt(producing, 4)
+        store.enterOffline()
+        const alpha = tab.factories[0]
+        tab.factories.splice(0, 1)
+        eventBus.emit('factoryEdited', alpha)
+        eventBus.emit('planReplaced', { removedIds: [alpha.id] })
+        store.persistJournal()
+
+        siblingPersists(producing, 4)
+
+        restart()
+        store.trackRoom(ROOM)
+
+        expect(inTab(appStore.getTab(ROOM) as FactoryTab, 1)).toBeUndefined()
+      })
+
+      it('keeps the unanswered question across the sibling\'s write', () => {
+        leaveAQuestionUnanswered()
+        siblingPersists(producing, 6)
+
+        restart()
+        store.trackRoom(ROOM)
+
+        expect(store.pendingConflicts[ROOM]?.factoryIds).toEqual([1])
+      })
+    })
+
+    describe('a browser that refuses to save', () => {
+      it('keeps the pending edit, says so, and lands it when storage comes back', () => {
+        const tab = syncAt(producing, 4)
+        store.enterOffline()
+
+        const toasts = vi.spyOn(eventBus, 'emit')
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const restoreStorage = refuseLocalStorageWrites(key => key === 'planSyncJournal')
+
+        editHere(tab, 1, 'IronIngot', 111)
+        store.persistJournal()
+
+        expect(store.hasLocalEdits(ROOM), 'dropped the edit because the disk refused it').toBe(true)
+        expect(recoverJournalRoom(ROOM)?.userTouchedIds, 'the refused write cannot have landed').toEqual([])
+        // The sidecar still took it, so the refusal costs the records and not the intent.
+        expect(readTabMirrorMeta()[ROOM]?.userTouchedIds).toEqual([1])
+        expect(toasts).toHaveBeenCalledWith('toast', expect.objectContaining({ type: 'error' }))
+
+        restoreStorage()
+        store.persistJournal()
+
+        expect(recoverJournalRoom(ROOM)?.userTouchedIds, 'never retried the refused write').toEqual([1])
+        vi.restoreAllMocks()
+      })
     })
   })
 })

--- a/web/src/stores/room-sync-store.ts
+++ b/web/src/stores/room-sync-store.ts
@@ -684,7 +684,13 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     for (const roomId of Object.keys(rooms.value)) {
       applyParkedResolution(roomId)
       recordIntent(roomId)
-      flushRoom(roomId)
+      const sent = flushRoom(roomId)
+      // The journal's records are the content, and `markUserTouched` only fires the first
+      // time a factory is touched — so without this the record is frozen at the moment the
+      // intent was declared and every keystroke after it is missing from the durable copy.
+      // Debounced with the flush, so this is one write per burst rather than per edit, and
+      // only where something is actually owed. `persistBaseline` covers what was sent.
+      if (!sent && (hasLocalEdits(roomId) || outstandingConflict(roomId))) persistJournalRoom(roomId)
     }
   }
 

--- a/web/src/stores/room-sync-store.ts
+++ b/web/src/stores/room-sync-store.ts
@@ -37,6 +37,14 @@ import {
   removeTabMirrorMeta,
   setTabMirrorMeta,
 } from '@/sync/tab-mirror-meta'
+import {
+  dropJournalRoom,
+  prunePlanJournal,
+  recoverJournalRoom,
+  touchJournalSlot,
+  writeJournalRoom,
+} from '@/sync/plan-journal'
+import type { JournalConflict, JournalRoom } from '@/sync/plan-journal'
 import { isCollaborative } from '@/sync/tab-sync-state'
 import { useAppStore } from '@/stores/app-store'
 import { useAuthStore } from '@/stores/auth-store'
@@ -69,6 +77,13 @@ export const REJECT_PAUSE_AFTER = 3
 
 /** Keystrokes renew a field lock at most this often: a typist costs one frame per few seconds. */
 export const FIELD_LOCK_RENEW_MS = 3_000
+
+/**
+ * Trailing debounce on the durable journal. A pasted plan marks every record as intent one
+ * at a time, so writing the journal on each would serialize the whole plan once per factory.
+ * Everything that moves a baseline writes it straight through instead; this covers the bursts.
+ */
+export const JOURNAL_DEBOUNCE_MS = 250
 
 export type OfflineMode = 'online' | 'reconnecting' | 'offlinePrompt' | 'offline'
 
@@ -139,6 +154,8 @@ interface RoomEngine {
   unacknowledged: Map<number, string>
   /** Something inbound was refused because the tab was mid-load; re-baseline when it ends. */
   needsSnapshot: boolean
+  /** The durable journal has been read back into this engine and into the tab. Once only. */
+  journalRestored: boolean
   /**
    * The revision of the content the disk actually holds. The plan is persisted on a 500ms
    * debounce and the mirror's metadata is not, so this is what stops the metadata claiming
@@ -226,6 +243,7 @@ const newEngine = (options: TrackRoomOptions): RoomEngine => ({
   fingerprints: new Map(),
   unacknowledged: new Map(),
   needsSnapshot: false,
+  journalRestored: false,
   mirroredRevision: 0,
   visitorToken: options.visitorToken,
 })
@@ -252,6 +270,13 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
    * user has said which version of each clashing factory wins.
    */
   const conflicts = ref<Record<string, RoomConflict>>({})
+  /**
+   * Questions this device was asked and never answered, read back off the durable journal
+   * on boot. The dialog itself cannot be rebuilt from storage — it is about live server
+   * content, which is a restart out of date — so this is the half that can be: the send
+   * barrier, held until a fresh snapshot lets the question be put again.
+   */
+  const pendingConflicts = ref<Record<string, JournalConflict>>({})
 
   /** No socket, no REST, no retries. Preferences and adoption gate on this too. */
   const isOffline = computed(() => mode.value === 'offline')
@@ -413,6 +438,22 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     return hash
   }
 
+  /**
+   * The question this device still owes an answer to, in the shape storage keeps it. An
+   * answer parked behind a load chain counts: it is not on the plan yet, so a restart in
+   * that window has to ask again rather than let the default through unchosen.
+   */
+  const outstandingConflict = (roomId: string): JournalConflict | undefined => {
+    const revision = rooms.value[roomId]?.revision ?? 0
+    const open = conflicts.value[roomId]
+    if (open) return { revision, factoryIds: open.factories.map(row => row.factoryId) }
+
+    const parked = parkedResolutions.get(roomId)
+    if (parked) return { revision, factoryIds: [...parked.askedIds] }
+
+    return pendingConflicts.value[roomId]
+  }
+
   const persistMeta = (roomId: string) => {
     const engine = engines.get(roomId)
     if (!engine) return
@@ -431,7 +472,82 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
       userTouchedFields: [...engine.touchedFields],
       declaredRemovals: [...engine.declaredRemovals],
       baselinePrints,
+      conflict: outstandingConflict(roomId),
     })
+    scheduleJournal(roomId)
+  }
+
+  // ===== The durable journal =====
+
+  /**
+   * `factoryTabs` and `tabMirrorMeta` are shared keys, so a second browser tab of the same
+   * browser replaces both with a generation that never carried this instance's unsent
+   * edits. The journal is partitioned per instance, and each room entry carries the
+   * revision, the intent, the content of the touched records and any unanswered question
+   * in one write — so all four describe the same durable generation.
+   */
+  const journalOf = (roomId: string): JournalRoom | null => {
+    const engine = engines.get(roomId)
+    if (!engine) return null
+
+    const baselinePrints: Record<string, string> = {}
+    for (const id of engine.touchedFactories) {
+      const print = baselineFingerprint(engine, id)
+      if (print !== undefined) baselinePrints[id] = print
+    }
+
+    // Only the records this instance still holds. A touched id with no record here is one
+    // it deleted, which `declaredRemovals` is the statement of.
+    const records: Record<string, string> = {}
+    const tab = getTab(roomId)
+    if (tab) {
+      for (const factory of tab.factories) {
+        if (engine.touchedFactories.has(factory.id)) records[factory.id] = stableStringify(factory)
+      }
+    }
+
+    return {
+      revision: engine.mirroredRevision,
+      appVersion: PROTOCOL_VERSION,
+      userTouchedIds: [...engine.touchedFactories],
+      userTouchedFields: [...engine.touchedFields],
+      declaredRemovals: [...engine.declaredRemovals],
+      baselinePrints,
+      records,
+      conflict: outstandingConflict(roomId),
+    }
+  }
+
+  let journalTimer: ReturnType<typeof setTimeout> | undefined
+  const journalDirty = new Set<string>()
+
+  /** @returns whether the disk took it, which is what stops a caller claiming a revision. */
+  const persistJournalRoom = (roomId: string): boolean => {
+    const room = journalOf(roomId)
+    if (room === null) {
+      journalDirty.delete(roomId)
+      return false
+    }
+
+    if (writeJournalRoom(roomId, room)) {
+      journalDirty.delete(roomId)
+      return true
+    }
+    // Refused, so the edit is still owed. Left dirty and re-armed: a quota that frees up,
+    // or a browser that stops blocking site data, is what makes the next attempt land.
+    scheduleJournal(roomId)
+    return false
+  }
+
+  const persistJournal = () => {
+    clearTimeout(journalTimer)
+    for (const roomId of [...journalDirty]) persistJournalRoom(roomId)
+  }
+
+  const scheduleJournal = (roomId: string) => {
+    journalDirty.add(roomId)
+    clearTimeout(journalTimer)
+    journalTimer = setTimeout(persistJournal, JOURNAL_DEBOUNCE_MS)
   }
 
   /**
@@ -444,10 +560,15 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     const engine = engines.get(roomId)
     if (engine && appStore.persistPlan()) engine.mirroredRevision = engine.acked.revision
     persistMeta(roomId)
+    // Straight through rather than on the debounce: this runs once per op, so it is not
+    // the burst the debounce exists for, and it is the moment the four halves agree.
+    persistJournalRoom(roomId)
   }
 
   const pruneMirrorMeta = () => {
-    pruneTabMirrorMeta(appStore.getTabs().map(tab => tab.id))
+    const known = appStore.getTabs().map(tab => tab.id)
+    pruneTabMirrorMeta(known)
+    prunePlanJournal(known)
   }
 
   // ===== Op builder =====
@@ -466,6 +587,7 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     // guards against is exactly a chain that ran without lowering `isLoaded`.
     if (!appStore.isLoaded || roomIsMidLoad(roomId)) return
 
+    restoreJournalRecords(roomId)
     primeBaseline(roomId)
     if (!engine.seeded && !engine.primed) return
 
@@ -524,8 +646,12 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     if (!appStore.isLoaded) return false
     // An unanswered clash: what this op should carry is the question on screen, and
     // sending our version first would answer it for the user. An answer parked behind a
-    // load chain holds it for the same reason: it is not on the plan yet.
-    if (conflicts.value[roomId] || parkedResolutions.has(roomId)) return false
+    // load chain holds it for the same reason: it is not on the plan yet. A question the
+    // journal remembers holds it too, until a fresh snapshot lets it be put again — a
+    // reload used to drop the barrier with the question and flush "mine" unchosen.
+    if (conflicts.value[roomId] || parkedResolutions.has(roomId) || pendingConflicts.value[roomId]) {
+      return false
+    }
 
     const tab = getTab(roomId)
     if (!tab) return false
@@ -801,6 +927,41 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     else conflict.factories = rows
   }
 
+  /**
+   * A question the journal remembers, put again against the server content that has just
+   * arrived. Deliberately not measured the way a fresh clash is: the baseline moved on when
+   * the question was first raised, so `changedRemotely` would say the records agree and the
+   * decision would be made by nobody. What was recorded is that these ids are undecided,
+   * and the only thing a restart has to re-derive is what each side now says.
+   */
+  const reraisePendingConflict = (roomId: string, server: RoomContent) => {
+    const pending = pendingConflicts.value[roomId]
+    const engine = engines.get(roomId)
+    const tab = getTab(roomId)
+    if (!pending || !engine || !tab) return
+
+    const serverById = new Map(server.factories.map(factory => [factory.id, factory]))
+    const localById = new Map(contentOfTab(tab).factories.map(factory => [factory.id, factory]))
+
+    const rows = pending.factoryIds
+      .filter(id => engine.touchedFactories.has(id))
+      .map(id => describeClash(id, serverById.get(id) ?? null, localById.get(id) ?? null))
+      .filter((row): row is ConflictFactory => row !== null)
+
+    // Asked again, or found to have nothing left to decide. Either way the barrier now
+    // belongs to `conflicts`, or to nobody.
+    delete pendingConflicts.value[roomId]
+
+    const open = conflicts.value[roomId]
+    if (!open) {
+      if (rows.length > 0) conflicts.value[roomId] = { roomId, factories: rows }
+    } else {
+      const known = new Set(open.factories.map(row => row.factoryId))
+      open.factories = [...open.factories, ...rows.filter(row => !known.has(row.factoryId))]
+    }
+    persistMeta(roomId)
+  }
+
   /** Puts the server's copy of each named record back into the tab, absence included. */
   const takeServerCopies = (tab: FactoryTab, engine: RoomEngine, factoryIds: number[]) => {
     const wanted = new Set(factoryIds)
@@ -833,8 +994,16 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     }, { activate: false })
   }
 
-  /** Answers given while a load chain owned the plan, applied when it hands it back. */
-  const parkedResolutions = new Map<string, ResolveConflictOptions>()
+  /**
+   * Answers given while a load chain owned the plan, applied when it hands it back.
+   * `askedIds` rides along so a restart inside that window can put the same question back
+   * rather than let the unapplied answer become a silent "mine wins".
+   */
+  interface ParkedResolution extends ResolveConflictOptions {
+    askedIds: number[]
+  }
+
+  const parkedResolutions = new Map<string, ParkedResolution>()
 
   /**
    * The user's answer. Mine-winners keep the intent they already have, so they leave exactly
@@ -852,12 +1021,20 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     const conflict = conflicts.value[roomId]
     if (!conflict) return false
 
-    const asked = new Set(conflict.factories.map(row => row.factoryId))
-    const answer = { liveWinners: liveWinners.filter(id => asked.has(id)), keepCopy }
+    const asked = [...new Set(conflict.factories.map(row => row.factoryId))]
+    const answer = {
+      liveWinners: liveWinners.filter(id => asked.includes(id)),
+      keepCopy,
+      askedIds: asked,
+    }
     delete conflicts.value[roomId]
+    // Answered, so nothing is owed here any more even if a restore put it back.
+    delete pendingConflicts.value[roomId]
 
     if (roomIsMidLoad(roomId) || !appStore.isLoaded) {
       parkedResolutions.set(roomId, answer)
+      persistMeta(roomId)
+      persistJournalRoom(roomId)
       return true
     }
     return applyResolution(roomId, answer)
@@ -884,6 +1061,7 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     }
 
     persistMeta(roomId)
+    persistJournalRoom(roomId)
     flushRoom(roomId)
     // A staged demo owns no room and has nothing to sync: hand the tab back as a plain
     // local one. A no-op for every real room, which is never in the set.
@@ -953,8 +1131,11 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     if (!demoRooms.delete(roomId)) return
     engines.delete(roomId)
     delete conflicts.value[roomId]
+    delete pendingConflicts.value[roomId]
     parkedResolutions.delete(roomId)
+    journalDirty.delete(roomId)
     removeTabMirrorMeta(roomId)
+    dropJournalRoom(roomId)
   }
 
   // ===== Reducer =====
@@ -1090,6 +1271,7 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
 
     // Before the rebase, which replaces both halves of the comparison: the baseline this
     // client agreed on, and the records it still holds.
+    reraisePendingConflict(roomId, server)
     noteClashes(roomId, server, revision)
     const recalculated = rebase(roomId, server, revision)
     // A clean adopt is proof the room is healthy, so an old streak must not carry into
@@ -1431,29 +1613,111 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     socket?.stop()
   }
 
+  /**
+   * Intent is the only thing that survives a restart; the baseline is not. Both sources are
+   * read: the journal is this browser's per-instance record and the authority on unsent
+   * work, and the shared sidecar covers a browser whose state predates the journal, or whose
+   * journal write the quota refused.
+   */
+  const restoreIntent = (roomId: string, engine: RoomEngine) => {
+    const stored = readTabMirrorMeta()[roomId]
+    const journal = recoverJournalRoom(roomId)
+
+    for (const id of [...stored?.userTouchedIds ?? [], ...journal?.userTouchedIds ?? []]) {
+      engine.touchedFactories.add(id)
+    }
+    for (const field of [...stored?.userTouchedFields ?? [], ...journal?.userTouchedFields ?? []]) {
+      engine.touchedFields.add(field)
+    }
+    for (const id of [...stored?.declaredRemovals ?? [], ...journal?.declaredRemovals ?? []]) {
+      engine.declaredRemovals.add(id)
+    }
+    for (const [id, print] of Object.entries({ ...stored?.baselinePrints, ...journal?.baselinePrints })) {
+      engine.baselinePrints.set(Number(id), print)
+    }
+    // The sidecar's revision describes the shared render mirror, which is what this is
+    // about; the journal answers only when there is no sidecar to ask.
+    engine.mirroredRevision = stored?.revision ?? journal?.revision ?? 0
+
+    // The barrier goes up here, before anything can join or flush, because the whole
+    // failure is a flush that beat the question back onto the screen.
+    const conflict = journal?.conflict ?? stored?.conflict
+    if (conflict) pendingConflicts.value[roomId] = conflict
+  }
+
   const trackRoom = (roomId: string, options: TrackRoomOptions = {}) => {
     if (!rooms.value[roomId]) rooms.value[roomId] = newRoomState(roomId)
 
-    let engine = engines.get(roomId)
+    const engine = engines.get(roomId)
     if (!engine) {
-      engine = newEngine(options)
-      engines.set(roomId, engine)
-
-      // Intent is the only thing that survives a restart; the baseline is not.
-      const stored = readTabMirrorMeta()[roomId]
-      for (const id of stored?.userTouchedIds ?? []) engine.touchedFactories.add(id)
-      for (const field of stored?.userTouchedFields ?? []) engine.touchedFields.add(field)
-      for (const id of stored?.declaredRemovals ?? []) engine.declaredRemovals.add(id)
-      for (const [id, print] of Object.entries(stored?.baselinePrints ?? {})) {
-        engine.baselinePrints.set(Number(id), print)
-      }
-      engine.mirroredRevision = stored?.revision ?? 0
+      const fresh = newEngine(options)
+      engines.set(roomId, fresh)
+      restoreIntent(roomId, fresh)
     } else if (options.visitorToken) {
       engine.visitorToken = options.visitorToken
     }
 
-    if (appStore.isLoaded && !roomIsMidLoad(roomId)) primeBaseline(roomId)
+    if (appStore.isLoaded && !roomIsMidLoad(roomId)) {
+      restoreJournalRecords(roomId)
+      primeBaseline(roomId)
+    }
     if (isConnected.value) join(roomId)
+  }
+
+  /**
+   * Put this browser's unsent records back into the tab. `factoryTabs` is one shared key, so
+   * a sibling browser tab's whole-plan write can be a generation that never carried them —
+   * and the intent alone would then make the rebase push the sibling's stale copy back at
+   * the room as this instance's own edit.
+   *
+   * Only the records still owed: a journal room entry is dropped the moment its intent is
+   * spent, so nothing acknowledged can be written back in from here.
+   */
+  const restoreJournalRecords = (roomId: string) => {
+    const engine = engines.get(roomId)
+    const tab = getTab(roomId)
+    if (!engine || !tab || engine.journalRestored) return
+    engine.journalRestored = true
+
+    const journal = recoverJournalRoom(roomId)
+    if (!journal) return
+
+    const byId = new Map(tab.factories.map(factory => [factory.id, factory]))
+    let changed = false
+
+    for (const [key, print] of Object.entries(journal.records)) {
+      const id = Number(key)
+      if (!engine.touchedFactories.has(id)) continue
+      const mounted = byId.get(id)
+      if (mounted && stableStringify(mounted) === print) continue
+
+      const record = JSON.parse(print) as Factory
+      if (mounted) tab.factories.splice(tab.factories.indexOf(mounted), 1, record)
+      else tab.factories.push(record)
+      changed = true
+    }
+
+    // The mirror image: a record this instance deleted and never sent. It is touched, it is
+    // declared removed, and it has no journal record because this instance does not hold
+    // one. A sibling's write can put it back, and nothing else would take it out again.
+    for (const id of engine.declaredRemovals) {
+      if (!engine.touchedFactories.has(id) || journal.records[id] !== undefined) continue
+      const mounted = byId.get(id)
+      if (!mounted) continue
+      tab.factories.splice(tab.factories.indexOf(mounted), 1)
+      changed = true
+    }
+
+    if (!changed) return
+    tab.factories = inDisplayOrder(tab.factories)
+    // This runs on the boot path, so the game data may not have arrived yet. The records
+    // are the thing being rescued; their derived figures are re-done by the next rebase.
+    try {
+      recalculate(tab)
+    } catch (error) {
+      console.error('roomSyncStore: restored the unsent records but could not recalculate them', error)
+    }
+    appStore.schedulePersist()
   }
 
   /**
@@ -1468,8 +1732,13 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     dropRoomLocks(roomId)
     // A question about a room this browser no longer holds has no answer worth taking.
     delete conflicts.value[roomId]
+    delete pendingConflicts.value[roomId]
     parkedResolutions.delete(roomId)
-    if (!keepMirrorMeta) removeTabMirrorMeta(roomId)
+    journalDirty.delete(roomId)
+    if (!keepMirrorMeta) {
+      removeTabMirrorMeta(roomId)
+      dropJournalRoom(roomId)
+    }
   }
 
   const join = (roomId: string): boolean => {
@@ -1480,7 +1749,13 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     if (room.status === 'revoked' || room.status === 'deleted') return false
 
     const stored = readTabMirrorMeta()[roomId]
-    const lastRevision = engine.seeded ? engine.acked.revision : stored?.revision
+    // A question the journal remembers can only be put again against the live records, and
+    // a join carrying a revision can be answered `up_to_date`, which carries none. So this
+    // one asks for the whole room: the reload used to take that `up_to_date`, seed off its
+    // own mirror and flush, which is how "mine" won without anybody choosing it.
+    const lastRevision = pendingConflicts.value[roomId]
+      ? undefined
+      : engine.seeded ? engine.acked.revision : stored?.revision
     room.status = 'joining'
     return ensureSocket().join(roomId, { lastRevision, visitorToken: engine.visitorToken })
   }
@@ -1511,6 +1786,9 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
   }
 
   const probeTick = () => {
+    // Says this browser tab is still here, so a sweep can tell an abandoned slot from one
+    // whose instance simply has nothing to write.
+    touchJournalSlot()
     // A demo has no room, so the loop below would never reach an answer of its own that
     // parked behind a load chain. Empty in every session that has not staged one.
     for (const roomId of demoRooms) applyParkedResolution(roomId)
@@ -1622,6 +1900,9 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
   const enterOffline = () => {
     // Whatever was edited inside the last debounce window still has to be remembered.
     for (const roomId of Object.keys(rooms.value)) recordIntent(roomId)
+    // Going quiet is exactly when the durable copy has to be up to date: from here on it
+    // is the only record of anything the user changes.
+    persistJournal()
     // While the socket is still up: nobody should be left staring at a field this
     // client walked away from.
     releaseAllFields()
@@ -1698,6 +1979,7 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
    */
   const onLoadingCompleted = () => {
     for (const roomId of Object.keys(rooms.value)) {
+      restoreJournalRecords(roomId)
       primeBaseline(roomId)
       healFromSnapshot(roomId)
     }
@@ -1715,7 +1997,20 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
   eventBus.on('calculationsCompleted', scheduleFlush)
   eventBus.on('loadingCompleted', onLoadingCompleted)
 
-  if (typeof window !== 'undefined') window.addEventListener('offline', onBrowserOffline)
+  /**
+   * The journal is debounced, so a browser closed inside that window would keep the intent
+   * (the sidecar is written straight through) and lose the records it refers to. Both go
+   * out here instead, on the last event a page reliably gets.
+   */
+  const flushJournalOnHide = () => {
+    if (document.visibilityState === 'hidden') persistJournal()
+  }
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('offline', onBrowserOffline)
+    window.addEventListener('pagehide', persistJournal)
+    window.addEventListener('visibilitychange', flushJournalOnHide)
+  }
 
   const probeTimer = setInterval(probeTick, probeIntervalMs())
   if (typeof probeTimer === 'object' && 'unref' in probeTimer) probeTimer.unref()
@@ -1730,8 +2025,14 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     eventBus.off('factoryUpdated', scheduleFlush)
     eventBus.off('calculationsCompleted', scheduleFlush)
     eventBus.off('loadingCompleted', onLoadingCompleted)
-    if (typeof window !== 'undefined') window.removeEventListener('offline', onBrowserOffline)
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('offline', onBrowserOffline)
+      window.removeEventListener('pagehide', persistJournal)
+      window.removeEventListener('visibilitychange', flushJournalOnHide)
+    }
     clearTimeout(debounceTimer)
+    clearTimeout(journalTimer)
+    journalDirty.clear()
     unsubscribeMessage?.()
     unsubscribeStatus?.()
     unsubscribeMessage = null
@@ -1752,6 +2053,7 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
     connectionId,
     fieldLocks,
     conflicts,
+    pendingConflicts,
     isOffline,
     isSuppressed,
     isConnected,
@@ -1797,6 +2099,8 @@ export const useRoomSyncStore = defineStore('roomSync', () => {
 
     // Persistence
     pruneMirrorMeta,
+    // The debounced journal write, forced. The timer is what runs it in the app.
+    persistJournal,
 
     // Reducer, driven by the socket and directly by tests
     handleMessage,

--- a/web/src/sync/plan-journal.spec.ts
+++ b/web/src/sync/plan-journal.spec.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PROTOCOL_VERSION } from 'common'
+import {
+  dropJournalRoom,
+  forgetInstanceId,
+  INSTANCE_ID_KEY,
+  instanceId,
+  JOURNAL_SLOT_TTL_MS,
+  PLAN_JOURNAL_KEY,
+  prunePlanJournal,
+  readPlanJournal,
+  recoverJournalRoom,
+  touchJournalSlot,
+  writeJournalRoom,
+} from '@/sync/plan-journal'
+import type { JournalRoom } from '@/sync/plan-journal'
+import { refuseLocalStorageWrites } from '../../testing/storage'
+import { resetStorageWarning } from '@/utils/safe-storage'
+
+const ROOM = 'room-1'
+
+const entry = (overrides: Partial<JournalRoom> = {}): JournalRoom => ({
+  revision: 4,
+  appVersion: PROTOCOL_VERSION,
+  userTouchedIds: [],
+  userTouchedFields: [],
+  declaredRemovals: [],
+  baselinePrints: {},
+  records: {},
+  ...overrides,
+})
+
+/** A second browser tab is a second instance id over the same localStorage. */
+const asAnotherBrowserTab = (write: () => void) => {
+  const mine = sessionStorage.getItem(INSTANCE_ID_KEY)
+  sessionStorage.removeItem(INSTANCE_ID_KEY)
+  forgetInstanceId()
+
+  write()
+
+  if (mine) sessionStorage.setItem(INSTANCE_ID_KEY, mine)
+  else sessionStorage.removeItem(INSTANCE_ID_KEY)
+  forgetInstanceId()
+}
+
+describe('plan-journal', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    forgetInstanceId()
+    resetStorageWarning()
+  })
+
+  describe('instance identity', () => {
+    it('is stable across a reload of the same browser tab', () => {
+      const first = instanceId()
+      forgetInstanceId()
+
+      expect(instanceId()).toBe(first)
+    })
+
+    it('is a different id in a browser tab that has no session of its own', () => {
+      const first = instanceId()
+      sessionStorage.removeItem(INSTANCE_ID_KEY)
+      forgetInstanceId()
+
+      expect(instanceId()).not.toBe(first)
+    })
+
+    /** Private mode and blocked site data both throw here rather than returning null. */
+    it('still hands out an id when the browser refuses session storage', () => {
+      vi.spyOn(sessionStorage, 'getItem').mockImplementation(() => {
+        throw new DOMException('denied', 'SecurityError')
+      })
+      vi.spyOn(sessionStorage, 'setItem').mockImplementation(() => {
+        throw new DOMException('denied', 'SecurityError')
+      })
+
+      expect(instanceId()).toMatch(/^[0-9a-f-]{36}$/)
+      vi.restoreAllMocks()
+    })
+  })
+
+  describe('recovering what a room still owes', () => {
+    it('reads back what this instance wrote', () => {
+      writeJournalRoom(ROOM, entry({ userTouchedIds: [1], records: { 1: '{"id":1}' } }))
+
+      expect(recoverJournalRoom(ROOM)).toMatchObject({
+        revision: 4,
+        userTouchedIds: [1],
+        records: { 1: '{"id":1}' },
+      })
+    })
+
+    it('has nothing to say about a room nobody has written', () => {
+      expect(recoverJournalRoom('never-seen')).toBeNull()
+    })
+
+    /**
+     * The whole point of the partition. A sibling writing a newer generation is exactly the
+     * case being rescued, so taking the newest slot alone would drop the older tab's edit —
+     * which is the bug this file exists for.
+     */
+    it('unions every instance rather than letting the newest one win', () => {
+      writeJournalRoom(ROOM, entry({ userTouchedIds: [1], records: { 1: '{"id":1,"n":"mine"}' } }))
+      asAnotherBrowserTab(() => {
+        writeJournalRoom(ROOM, entry({ revision: 9, userTouchedIds: [2], records: { 2: '{"id":2}' } }))
+      })
+
+      const recovered = recoverJournalRoom(ROOM)
+      expect(recovered?.userTouchedIds.sort()).toEqual([1, 2])
+      expect(recovered?.records).toEqual({ 1: '{"id":1,"n":"mine"}', 2: '{"id":2}' })
+    })
+
+    it('takes the furthest-along revision, because an older slot has seen less', () => {
+      writeJournalRoom(ROOM, entry({ revision: 4 }))
+      asAnotherBrowserTab(() => writeJournalRoom(ROOM, entry({ revision: 9 })))
+
+      expect(recoverJournalRoom(ROOM)?.revision).toBe(9)
+    })
+
+    it('lets this instance settle a record two slots both hold', () => {
+      asAnotherBrowserTab(() => {
+        writeJournalRoom(ROOM, entry({ userTouchedIds: [1], records: { 1: '{"id":1,"n":"theirs"}' } }))
+      })
+      writeJournalRoom(ROOM, entry({ userTouchedIds: [1], records: { 1: '{"id":1,"n":"mine"}' } }))
+
+      expect(recoverJournalRoom(ROOM)?.records[1]).toBe('{"id":1,"n":"mine"}')
+    })
+
+    it('carries an unanswered question back with the records', () => {
+      writeJournalRoom(ROOM, entry({
+        userTouchedIds: [1],
+        conflict: { revision: 6, factoryIds: [1] },
+      }))
+
+      expect(recoverJournalRoom(ROOM)?.conflict).toEqual({ revision: 6, factoryIds: [1] })
+    })
+
+    it('drops only this instance\'s entry for a room, never a sibling\'s', () => {
+      asAnotherBrowserTab(() => writeJournalRoom(ROOM, entry({ userTouchedIds: [2] })))
+      writeJournalRoom(ROOM, entry({ userTouchedIds: [1] }))
+
+      dropJournalRoom(ROOM)
+
+      expect(recoverJournalRoom(ROOM)?.userTouchedIds).toEqual([2])
+    })
+  })
+
+  describe('what it refuses to believe', () => {
+    it('reads an unparseable key as an empty journal', () => {
+      localStorage.setItem(PLAN_JOURNAL_KEY, '{not json')
+
+      expect(readPlanJournal()).toEqual({})
+    })
+
+    it('skips a room entry with no revision on it', () => {
+      localStorage.setItem(PLAN_JOURNAL_KEY, JSON.stringify({
+        someone: { at: 1, rooms: { [ROOM]: { userTouchedIds: [1] } } },
+      }))
+
+      expect(recoverJournalRoom(ROOM)).toBeNull()
+    })
+
+    it('filters the entries inside a room entry rather than throwing them all away', () => {
+      localStorage.setItem(PLAN_JOURNAL_KEY, JSON.stringify({
+        someone: {
+          at: 1,
+          rooms: {
+            [ROOM]: {
+              revision: 4,
+              userTouchedIds: [1, 'two', 3],
+              records: { 1: '{"id":1}', 2: 17 },
+              conflict: { revision: 6, factoryIds: [] },
+            },
+          },
+        },
+      }))
+
+      const recovered = recoverJournalRoom(ROOM)
+      expect(recovered?.userTouchedIds).toEqual([1, 3])
+      expect(recovered?.records).toEqual({ 1: '{"id":1}' })
+      expect(recovered?.conflict, 'a question about no factories is not a question').toBeUndefined()
+    })
+  })
+
+  describe('a browser that refuses to save', () => {
+    /**
+     * A plan with hundreds of edited records can be what tipped the quota, and the intent
+     * is a fraction of that. Keeping the smaller half is worth more than keeping nothing.
+     */
+    it('falls back to writing the intent without the records', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      // Refuses only the first attempt, which is the one carrying the records.
+      let attempts = 0
+      const restore = refuseLocalStorageWrites(key => key === PLAN_JOURNAL_KEY && attempts++ === 0)
+
+      const written = writeJournalRoom(ROOM, entry({ userTouchedIds: [1], records: { 1: 'x'.repeat(50) } }))
+      restore()
+
+      expect(written).toBe(true)
+      expect(recoverJournalRoom(ROOM)?.userTouchedIds).toEqual([1])
+      expect(recoverJournalRoom(ROOM)?.records).toEqual({})
+      vi.restoreAllMocks()
+    })
+
+    it('says so rather than claiming a write it never made', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const restore = refuseLocalStorageWrites(key => key === PLAN_JOURNAL_KEY)
+
+      expect(writeJournalRoom(ROOM, entry({ userTouchedIds: [1] }))).toBe(false)
+      restore()
+      vi.restoreAllMocks()
+    })
+  })
+
+  describe('sweeping', () => {
+    it('drops room entries for tabs this browser no longer holds', () => {
+      writeJournalRoom(ROOM, entry())
+      writeJournalRoom('closed-tab', entry())
+
+      prunePlanJournal([ROOM])
+
+      expect(recoverJournalRoom('closed-tab')).toBeNull()
+      expect(recoverJournalRoom(ROOM)).not.toBeNull()
+    })
+
+    it('keeps a long-abandoned slot that still owes an edit until it is a month old', () => {
+      asAnotherBrowserTab(() => writeJournalRoom(ROOM, entry({ userTouchedIds: [1] })))
+      instanceId()
+
+      prunePlanJournal([ROOM], Date.now() + JOURNAL_SLOT_TTL_MS - 1_000)
+      expect(recoverJournalRoom(ROOM)?.userTouchedIds).toEqual([1])
+
+      prunePlanJournal([ROOM], Date.now() + JOURNAL_SLOT_TTL_MS + 1_000)
+      expect(recoverJournalRoom(ROOM)).toBeNull()
+    })
+
+    it('never sweeps this instance, however long it has sat still', () => {
+      writeJournalRoom(ROOM, entry({ userTouchedIds: [1] }))
+
+      prunePlanJournal([ROOM], Date.now() + JOURNAL_SLOT_TTL_MS * 12)
+
+      expect(recoverJournalRoom(ROOM)?.userTouchedIds).toEqual([1])
+    })
+
+    it('keeps a slot alive without rewriting what it holds', () => {
+      writeJournalRoom(ROOM, entry({ userTouchedIds: [1] }))
+      const before = readPlanJournal()[instanceId()].at
+
+      vi.useFakeTimers({ now: Date.now() + 60_000 })
+      touchJournalSlot()
+      vi.useRealTimers()
+
+      expect(readPlanJournal()[instanceId()].at).toBeGreaterThan(before)
+      expect(recoverJournalRoom(ROOM)?.userTouchedIds).toEqual([1])
+    })
+  })
+})

--- a/web/src/sync/plan-journal.ts
+++ b/web/src/sync/plan-journal.ts
@@ -1,0 +1,302 @@
+import { PROTOCOL_VERSION } from 'common'
+import type { TabField } from '@/sync/room-state'
+import { writeLocalStorage } from '@/utils/safe-storage'
+
+/**
+ * The durable home for everything one browser instance has NOT yet sent.
+ *
+ * `localStorage.factoryTabs` and `tabMirrorMeta` are both whole-value writes over one
+ * shared key, so a second tab of the same browser replaces them with its own generation.
+ * Its copy of a plan another tab edited offline is stale, and its copy of the sync
+ * metadata never carried the other tab's intent at all — so the edit disappears from the
+ * content and from the record that it was owed.
+ *
+ * This key is partitioned by instance instead: an instance only ever rewrites its own
+ * slot, and boot takes the union of every slot. Each room entry carries the revision, the
+ * intent, the local content of the touched records and any unanswered conflict together,
+ * in one write, so all four describe the same durable generation.
+ */
+export const PLAN_JOURNAL_KEY = 'planSyncJournal'
+
+/** Where this instance's id is kept: per browser tab, and it survives a reload. */
+export const INSTANCE_ID_KEY = 'planInstanceId'
+
+/** A slot nobody has written for this long is a browser tab that is not coming back. */
+export const JOURNAL_SLOT_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+/** A question raised on this device and never answered. */
+export interface JournalConflict {
+  /** The revision of the snapshot that raised it. */
+  revision: number
+  factoryIds: number[]
+}
+
+export interface JournalRoom {
+  revision: number
+  appVersion: string
+  userTouchedIds: number[]
+  userTouchedFields: TabField[]
+  declaredRemovals: number[]
+  baselinePrints: Record<string, string>
+  /**
+   * The unsent edit itself: each touched factory as this instance holds it. Without this
+   * the intent survives a sibling tab's overwrite and the content it refers to does not,
+   * so the rebase would push the sibling's stale copy back at the room as ours.
+   */
+  records: Record<string, string>
+  conflict?: JournalConflict
+}
+
+export interface JournalSlot {
+  instanceId: string
+  /** Last written. Only ever used to order two slots that both hold a record. */
+  at: number
+  rooms: Record<string, JournalRoom>
+}
+
+export type PlanJournal = Record<string, JournalSlot>
+
+const asStringMap = (value: unknown): Record<string, string> => {
+  if (typeof value !== 'object' || value === null) return {}
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter(([, entry]) => typeof entry === 'string'),
+  ) as Record<string, string>
+}
+
+const asNumbers = (value: unknown): number[] =>
+  Array.isArray(value) ? value.filter((entry): entry is number => typeof entry === 'number') : []
+
+const asConflict = (value: unknown): JournalConflict | undefined => {
+  if (typeof value !== 'object' || value === null) return undefined
+  const candidate = value as Partial<JournalConflict>
+  if (typeof candidate.revision !== 'number') return undefined
+  const factoryIds = asNumbers(candidate.factoryIds)
+  if (factoryIds.length === 0) return undefined
+  return { revision: candidate.revision, factoryIds }
+}
+
+/** Repairs whatever it finds rather than throwing: this map is never worth a crash. */
+const asRoom = (value: unknown): JournalRoom | null => {
+  if (typeof value !== 'object' || value === null) return null
+  const candidate = value as Partial<JournalRoom>
+  if (typeof candidate.revision !== 'number') return null
+
+  return {
+    revision: candidate.revision,
+    appVersion: typeof candidate.appVersion === 'string' ? candidate.appVersion : PROTOCOL_VERSION,
+    userTouchedIds: asNumbers(candidate.userTouchedIds),
+    userTouchedFields: Array.isArray(candidate.userTouchedFields) ? candidate.userTouchedFields : [],
+    declaredRemovals: asNumbers(candidate.declaredRemovals),
+    baselinePrints: asStringMap(candidate.baselinePrints),
+    records: asStringMap(candidate.records),
+    conflict: asConflict(candidate.conflict),
+  }
+}
+
+const asSlot = (instanceId: string, value: unknown): JournalSlot | null => {
+  if (typeof value !== 'object' || value === null) return null
+  const candidate = value as Partial<JournalSlot>
+  const rooms: Record<string, JournalRoom> = {}
+
+  for (const [roomId, entry] of Object.entries(candidate.rooms ?? {})) {
+    const room = asRoom(entry)
+    if (room) rooms[roomId] = room
+  }
+  return { instanceId, at: typeof candidate.at === 'number' ? candidate.at : 0, rooms }
+}
+
+/**
+ * Per browser tab and stable across a reload, which is what `sessionStorage` is for. A
+ * browser that refuses it (private mode, blocked site data) still gets an id, just one
+ * that does not outlive the page — the union at boot is what makes that survivable.
+ */
+let cachedInstanceId: string | null = null
+
+export const instanceId = (): string => {
+  if (cachedInstanceId) return cachedInstanceId
+
+  try {
+    const stored = sessionStorage.getItem(INSTANCE_ID_KEY)
+    if (stored) {
+      cachedInstanceId = stored
+      return stored
+    }
+  } catch {
+    // Falls through to a fresh id held in memory.
+  }
+
+  cachedInstanceId = crypto.randomUUID()
+  try {
+    sessionStorage.setItem(INSTANCE_ID_KEY, cachedInstanceId)
+  } catch {
+    // An id nobody can store still partitions this instance from its siblings.
+  }
+  return cachedInstanceId
+}
+
+/** Only for tests: a fresh page load is a fresh read of `sessionStorage`. */
+export const forgetInstanceId = (): void => {
+  cachedInstanceId = null
+}
+
+export const readPlanJournal = (): PlanJournal => {
+  let raw: string | null = null
+  try {
+    raw = localStorage.getItem(PLAN_JOURNAL_KEY)
+  } catch {
+    return {}
+  }
+  if (!raw) return {}
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {}
+  }
+  if (typeof parsed !== 'object' || parsed === null) return {}
+
+  const journal: PlanJournal = {}
+  for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
+    const slot = asSlot(id, value)
+    if (slot) journal[id] = slot
+  }
+  return journal
+}
+
+const writePlanJournal = (journal: PlanJournal): boolean =>
+  writeLocalStorage(PLAN_JOURNAL_KEY, JSON.stringify(journal))
+
+/**
+ * Read, change this instance's slot, write. A sibling writing in the same breath can lose
+ * one heartbeat, and never a room entry it owns: every instance rewrites its own slot on
+ * its next persist, so the loss heals itself within one debounce window.
+ *
+ * @returns whether the disk took it. False is what stops the caller advancing a revision.
+ */
+export const writeJournalRoom = (roomId: string, room: JournalRoom): boolean => {
+  const id = instanceId()
+  const journal = readPlanJournal()
+  const slot = journal[id] ?? { instanceId: id, at: 0, rooms: {} }
+
+  slot.at = Date.now()
+  slot.rooms[roomId] = room
+  journal[id] = slot
+
+  if (writePlanJournal(journal)) return true
+
+  // A plan with hundreds of edited records can be what tipped the quota. The intent alone
+  // is a fraction of the size and is still worth more than nothing, so try again without
+  // the records — the rebase then falls back to today's behaviour for those ids.
+  slot.rooms[roomId] = { ...room, records: {} }
+  return writePlanJournal(journal)
+}
+
+export const dropJournalRoom = (roomId: string): void => {
+  const id = instanceId()
+  const journal = readPlanJournal()
+  const slot = journal[id]
+  if (!slot || !(roomId in slot.rooms)) return
+
+  delete slot.rooms[roomId]
+  slot.at = Date.now()
+  writePlanJournal(journal)
+}
+
+/** Keeps this instance's slot alive so a stale-slot sweep can tell it from an abandoned one. */
+export const touchJournalSlot = (): void => {
+  const id = instanceId()
+  const journal = readPlanJournal()
+  const slot = journal[id]
+  if (!slot) return
+
+  slot.at = Date.now()
+  writePlanJournal(journal)
+}
+
+/**
+ * What this browser still owes for one room, across every instance that has ever written
+ * here. Deliberately a union rather than newest-wins: the bug this exists for is a sibling
+ * tab writing a newer generation that never carried the older tab's edit, so taking the
+ * newest slot alone would drop exactly the thing being rescued.
+ *
+ * Ties on one factory go to this instance, then to the most recently written slot.
+ */
+export const recoverJournalRoom = (roomId: string): JournalRoom | null => {
+  const id = instanceId()
+  const journal = readPlanJournal()
+
+  const slots = Object.values(journal)
+    .filter(slot => slot.rooms[roomId] !== undefined)
+    // Ours last, so its records and prints overwrite everything else's.
+    .sort((left, right) => {
+      if (left.instanceId === id) return 1
+      if (right.instanceId === id) return -1
+      return left.at - right.at
+    })
+  if (slots.length === 0) return null
+
+  const touched = new Set<number>()
+  const fields = new Set<TabField>()
+  const removals = new Set<number>()
+  const baselinePrints: Record<string, string> = {}
+  const records: Record<string, string> = {}
+  let revision = 0
+  let appVersion = PROTOCOL_VERSION
+  let conflict: JournalConflict | undefined
+
+  for (const slot of slots) {
+    const room = slot.rooms[roomId]
+    for (const factoryId of room.userTouchedIds) touched.add(factoryId)
+    for (const field of room.userTouchedFields) fields.add(field)
+    for (const factoryId of room.declaredRemovals) removals.add(factoryId)
+    Object.assign(baselinePrints, room.baselinePrints)
+    Object.assign(records, room.records)
+    // The revision is about the shared mirror, so the furthest-along answer is the truthful
+    // one: a slot left behind at an older revision has not seen what the newer one adopted.
+    if (room.revision >= revision) {
+      revision = room.revision
+      appVersion = room.appVersion
+    }
+    if (room.conflict) conflict = room.conflict
+  }
+
+  return {
+    revision,
+    appVersion,
+    userTouchedIds: [...touched],
+    userTouchedFields: [...fields],
+    declaredRemovals: [...removals],
+    baselinePrints,
+    records,
+    conflict,
+  }
+}
+
+/**
+ * Drops room entries for tabs this browser no longer holds, and whole slots from browser
+ * tabs that are long gone, so the key cannot grow forever. Deliberately generous: a slot
+ * is only swept once it is a month old, because sweeping one that still owes an edit is
+ * the failure this whole module exists to stop.
+ */
+export const prunePlanJournal = (knownTabIds: string[], now = Date.now()): void => {
+  const known = new Set(knownTabIds)
+  const journal = readPlanJournal()
+  const mine = instanceId()
+  let changed = false
+
+  for (const [id, slot] of Object.entries(journal)) {
+    for (const roomId of Object.keys(slot.rooms)) {
+      if (known.has(roomId)) continue
+      delete slot.rooms[roomId]
+      changed = true
+    }
+    const empty = Object.keys(slot.rooms).length === 0
+    if (id !== mine && (empty || now - slot.at > JOURNAL_SLOT_TTL_MS)) {
+      delete journal[id]
+      changed = true
+    }
+  }
+
+  if (changed) writePlanJournal(journal)
+}

--- a/web/src/sync/tab-mirror-meta.ts
+++ b/web/src/sync/tab-mirror-meta.ts
@@ -1,5 +1,6 @@
 import { PROTOCOL_VERSION } from 'common'
 import type { TabField } from '@/sync/room-state'
+import type { JournalConflict } from '@/sync/plan-journal'
 import { writeLocalStorage } from '@/utils/safe-storage'
 
 /**
@@ -28,6 +29,13 @@ export interface TabMirrorMeta {
    * later cannot tell a factory somebody else changed from one only it changed.
    */
   baselinePrints?: Record<string, string>
+  /**
+   * A clash the user was asked about and has not answered. The question itself only ever
+   * lived in memory, so a reload landed on a baseline already advanced to the server's
+   * revision, answered `up_to_date`, and flushed this device's version over the peer's
+   * without anybody choosing it. Persisted, the send barrier and the question both come back.
+   */
+  conflict?: JournalConflict
 }
 
 export type TabMirrorMetaMap = Record<string, TabMirrorMeta>
@@ -37,6 +45,15 @@ const readPrints = (value: unknown): Record<string, string> => {
   return Object.fromEntries(
     Object.entries(value as Record<string, unknown>).filter(([, print]) => typeof print === 'string'),
   ) as Record<string, string>
+}
+
+const readConflict = (value: unknown): JournalConflict | undefined => {
+  if (typeof value !== 'object' || value === null) return undefined
+  const candidate = value as Partial<JournalConflict>
+  if (typeof candidate.revision !== 'number' || !Array.isArray(candidate.factoryIds)) return undefined
+
+  const factoryIds = candidate.factoryIds.filter((id): id is number => typeof id === 'number')
+  return factoryIds.length > 0 ? { revision: candidate.revision, factoryIds } : undefined
 }
 
 const isMeta = (value: unknown): value is TabMirrorMeta =>
@@ -66,6 +83,7 @@ export const readTabMirrorMeta = (): TabMirrorMetaMap => {
         ? value.declaredRemovals.filter(id => typeof id === 'number')
         : [],
       baselinePrints: readPrints(value.baselinePrints),
+      conflict: readConflict(value.conflict),
     }
   }
   return map


### PR DESCRIPTION
No manual steps or intervention required.

## What a user with old browser state sees

Nothing changes for them, and nothing they have saved becomes unreadable. `localStorage.factoryTabs`, `tabMirrorMeta` and `tabSyncStates` all keep exactly the shapes they have now, and every one of them is still read on boot. `tabMirrorMeta` gains one optional field (`conflict`); an entry without it reads as "no question outstanding", which is what an old entry means.

The new durable record (`planSyncJournal`) is additive. A browser that has never written one simply has nothing to recover from it, so the first load after this ships behaves exactly like the load before it: the plan comes off the render mirror and the unsent intent comes off the sidecar, as today. The journal starts filling from the first edit after that. There is no migration, and a rollback to the current build leaves the extra key sitting there being ignored.

## The two bugs

### 1. Reloading with an unanswered conflict silently picked "mine"

`rebase` advances the persisted baseline to the server's revision the moment a conflicting snapshot arrives, and the unanswered `conflicts` state that drives the dialog only ever lived in memory. So reloading the page with the question still on screen found the stored revision already equal to the room's. The join was answered `up_to_date`, `seedFromMirror` marked the touched factory unknown, and with no send barrier restored the flush pushed this device's version straight over the collaborator's. Nobody chose that, and nothing said it had happened. A factory the room had deleted came back the same way.

### 2. A second browser tab erased the only saved copy of offline edits

`persistPlan` writes the whole `factoryTabs` array to one shared key, and `setTabMirrorMeta` replaces the room's sync metadata wholesale. Two browser tabs of the same browser therefore overwrite each other: the second tab's plan is stale for whatever the first edited offline, and its metadata never carried the first tab's intent at all. Closing the first tab did not save it either, because `persistPlan` compared against its own private `lastPersistedPlan` cache and reported success without noticing the stored value was no longer the one it wrote.

## The durable generation map

Every path that writes plan content, the sync revision, or touched-factory intent, and every path that reads them back on boot. "Generation" here means: whose copy is this, and what revision is it relative to.

### Written

| Path | Key | Generation it describes |
| --- | --- | --- |
| `appStore.persistPlan` | `factoryTabs` | Whichever browser instance wrote last. Shared, whole-value, no revision of its own. |
| `appStore.schedulePersist` | `factoryTabs` | Same, 500ms later. |
| the 5s interval, `visibilitychange`, `pagehide` | `factoryTabs` | Same. These exist for mutations that bypass `schedulePersist`. |
| `roomSync.persistMeta` | `tabMirrorMeta[tabId]` | The writing instance's intent, at `engine.mirroredRevision` (what the shared plan on disk is believed to hold, never the live baseline). |
| `roomSync.persistBaseline` | `factoryTabs` then `tabMirrorMeta` then `planSyncJournal` | Content first, so the metadata can never claim a revision the plan on disk is behind. `mirroredRevision` only advances when the content write actually happened. |
| `roomSync.persistJournalRoom` | `planSyncJournal[instanceId][roomId]` | This browser instance alone: revision, intent, declared removals, baseline fingerprints, the content of every touched record, and any unanswered conflict, all in one write. |
| `appStore.setTabState` | `tabSyncStates[tabId]` | Shared, and deliberately not authoritative: the room list overwrites it on every refresh. |

### Read on boot

| Path | Reads | Generation it takes |
| --- | --- | --- |
| `useAppStore` module body | `factoryTabs`, `currentFactoryTabIndex`, `tabSyncStates` | Whatever the last writer left. |
| `roomSync.trackRoom` → `restoreIntent` | `tabMirrorMeta` **and** `planSyncJournal` | The union of every instance's intent, with the sidecar's revision as the answer for the shared mirror. |
| `roomSync.trackRoom` → `restoreJournalRecords` | `planSyncJournal` | This browser's unsent record content, written back into the tab where the shared plan is behind it. |
| `roomSync.primeBaseline` / `seedFromMirror` | the live tab plus restored intent | A provisional baseline: untouched records are the baseline, touched ones are marked unknown. |
| `roomSync.join` | `tabMirrorMeta[roomId].revision` | The revision to ask the server about, unless a question is outstanding, in which case it asks for the whole room. |
| `appStore.canRenderInstantly` | `tabMirrorMeta` | Whether the mirror is at the room's revision and this app version. |

The rule the fix enforces: **content, intent, revision and any unanswered question must describe the same durable generation, and an instance may only ever be told about its own.** The three shared keys still exist and still say what they said; the journal is what makes the four halves agree.

## The fix

**A per-instance journal (`web/src/sync/plan-journal.ts`).** Keyed by a browser-tab instance id kept in `sessionStorage`, so it survives a reload and is not shared between tabs. Each room entry holds the revision, the intent, the declared removals, the baseline fingerprints, the serialized content of every touched record and any unanswered conflict, written together. An instance only ever rewrites its own slot.

Boot takes the **union of every slot**, not the newest. Newest-wins is precisely the bug: the sibling tab's generation is the newer one and it is the one missing the edit. A `sessionStorage` id does not survive a closed browser, so a returning instance recovers through the union rather than by finding "its own" slot.

**The restored send barrier.** `pendingConflicts` is raised in `trackRoom` before anything can join or flush. It makes `join` ask for a whole snapshot rather than a revision check, because an `up_to_date` carries no records to put the question against, and `reraisePendingConflict` asks again against the live copies. `findClashes` cannot re-derive it on its own: the baseline has already moved, so it would find nothing to ask about.

**`persistPlan` asks the disk, not its cache.** It reads the stored string back and takes the shortcut only where the disk agrees with what it last wrote. The `storage` event, which fires in the other tabs of the same origin, makes that prompt; the read-back is what makes it correct with no event at all. That is the degradation story: a browser that never delivers the event loses promptness and nothing else, and there is no leader election to get stuck in.

**Quota failures.** Every write goes through `web/src/utils/safe-storage.ts`. A refused journal write falls back to writing the intent without the records (a fraction of the size, and still worth more than nothing), stays on the dirty list and re-arms, so it lands as soon as there is room. The revision is never advanced on a write that did not happen. The user gets the existing "your browser refused to save" notice and keeps working.

## Tests

Every one of these was written against the current code first and watched fail.

Unit (`pnpm exec vitest run --silent --coverage` in `web`): **3249 passed, 1 skipped, 168 files**, no failures. The 13 new engine tests and 2 new app-store tests failed on the pre-fix source with, among others, `overwrote the other device without anybody choosing it: expected [ { type: 'op' } ] to have a length of +0 but got 1` and `trusted its own cache over the disk`. 19 new tests cover the journal module itself.

Coverage: statements 84.03%, branches 71.79%, functions 75.73%, lines 84.80%.

End-to-end (`pnpm exec playwright test`): **56 passed**, the whole suite. `web/e2e/tests/offline-durability.e2e.ts` is new. It takes the network away with `context.setOffline(true)` rather than severing the socket with `installWsGate`, closes the browser context, and reopens from `storageState` alone. Both of its tests fail on the pre-fix source with `the unsent record never reached browser storage`.

That distinction is the point. The existing offline tests keep the page, the store and everything in memory alive the whole time, so nothing they assert has ever proved that anything reached the disk, which is why this class of bug got through.

`pnpm exec vue-tsc --noEmit` in `web` is clean. `pnpm run lint` from the root is clean (the 64 warnings in `parsing` are pre-existing).

No existing test was weakened or deleted, and none of them was passing only because of the buggy behaviour.

## One thing I scoped rather than fixed

The new end-to-end test settles on the authored content of every factory rather than using `expectQuiesced`, which compares the whole stored record byte for byte. A client booted from disk and a client that only ever took server diffs disagree about the shape of an empty factory's `power` object: one holds `{consumed, produced, difference}` and the other the full set the current engine writes. Neither side authored it, neither side sends it, and it predates this branch. It belongs to the calculation engine rather than to sync, so I have left it alone and said so in the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
