### PR TITLE
fix(backend): stop one client's unblock stranding everyone else's rate limit

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -47,4 +47,4 @@
 - [prom-client is deprecated](prom-client-deprecated-successor.md) — the successor was days old and 0.x, so the metrics endpoint stayed put; what would change that, and the third package name context7 hands out
 - [Verify: hidden-pane menu freeze](verify-hidden-pane-menu-freeze.md) — a hidden browser pane leaves Vuetify menus stuck invisible with inline pointer-events:none; clear the inline props before hit-testing
 - [prom-client label lifecycle](prom-client-label-lifecycle.md) — seed bounded label sets at zero or panels read "No data"; reset ranked ones or dropped labels report forever
-- [Clock step freezes rate limits](clock-step-freezes-rate-limits.md) — a backwards clock step at boot 429'd the API container unhealthy under express-rate-limit; why @nestjs/throttler closed it, and why it looks exactly like prod drift
+- [Clock step freezes rate limits](clock-step-freezes-rate-limits.md) — a backwards clock step at boot 429'd the API container unhealthy under express-rate-limit; why @nestjs/throttler closed it, why we run our own throttler storage instead of its, and why it looks exactly like prod drift

--- a/.claude/memory/clock-step-freezes-rate-limits.md
+++ b/.claude/memory/clock-step-freezes-rate-limits.md
@@ -1,6 +1,6 @@
 ---
 name: clock-step-freezes-rate-limits
-description: "A backwards clock step at boot froze express-rate-limit windows in the future, so the 30s Docker healthcheck alone 429'd the API container unhealthy; @nestjs/throttler closed that path, and the incident is worth keeping because it presents identically to deployment drift"
+description: "A backwards clock step at boot froze express-rate-limit windows in the future, so the 30s Docker healthcheck alone 429'd the API container unhealthy; @nestjs/throttler closed that path and our own storage closed the two defects left in its, and the incident is worth keeping because it presents identically to deployment drift"
 metadata:
   node_type: memory
   type: project
@@ -25,34 +25,45 @@ Two things cleared it, neither of them a code change: the wall clock eventually 
 reset, and a later deploy replaced the container against a corrected clock. Both hide the defect
 without fixing it, which is why "it is healthy now" was never evidence.
 
-## The library rewrite closed it
+## The library rewrite closed it, and our own storage closed what it left
 
 The NestJS rewrite moved rate limiting to `@nestjs/throttler`, and that is what ended this class
 of freeze. Verified against the installed 6.5.0 by driving `ThrottlerStorageService` through a
 faked backwards step of an hour: **it decrements each hit on its own `setTimeout(ttl)`, and Node
 timers are monotonic, so a clock step alone cannot stop the count falling.** Under the healthcheck's
-access pattern the count sits at 2 and never climbs, stepped clock or not. `expiresAt` is still
-wall-clock but only feeds the reported retry-after; it does not gate anything.
+access pattern the count sits at 2 and never climbs, stepped clock or not.
 
-Two paths survive, and the second is the more serious.
+Reading that storage closely turned up two defects of its own, so the app no longer runs on it.
+`src/config/throttler-storage.ts` holds `PerClientThrottlerStorage`, wired in through
+`ThrottlerModule.forRootAsync` so every application instance gets its own, the way `forRoot` gave
+each one its own library storage. Both defects are structural rather than tunable, which is why a
+replacement rather than a setting.
 
-**`blockExpiresAt` is still wall-clock.** Once a key is *actually* blocked, unblocking waits
-on `Date.now()`, so a backwards step extends the block by the offset. Reaching it needs more hits
-inside one ttl than the limit allows, which two probes a minute cannot do, so `/health` is out of
-reach of it.
+**Pending decrements are held per client now, not per bucket.** The library kept one timer list
+per throttler name with no client key in it, and `resetBlockdRequest` cleared the whole list, so
+unblocking any one client cancelled the pending decrements of every other client in that bucket
+and their counts never fell again. That locks strangers out for real: on `login`, `roomAuth`,
+`share` or `slugLookup` someone who spent nothing carries a permanent count and starts collecting
+429s on ordinary requests, `global` can eventually refuse ordinary traffic, and repeated
+block-and-unblock cycles accumulate. Each client owns its own timers here, so an unblock touches
+nobody else.
 
-**Timers are cancelled per bucket, not per client, so a count can stall for a reason that has
-nothing to do with the clock.** `timeoutIds` is keyed by throttler name alone, and
-`resetBlockdRequest` calls `clearExpirationTimes(throttlerName)`, so unblocking any one client
-cancels the pending decrements of every other client in that bucket. Their counts then never
-fall. Repeated block-and-reset cycles accumulate, and the buckets that can strand a real person
-are `login`, `roomAuth`, `share` and `slugLookup`; `global` can eventually refuse ordinary
-traffic. So the statement above is about the clock specifically: a step cannot stall a count, but
-something else can.
+**Every deadline is monotonic.** The library compared `blockExpiresAt` against `Date.now()`, so a
+backwards step extended a live block by the offset; that was the residual this memory used to
+record as known-and-unfixed, and it is closed. `performance.now()` replaces `Date.now()`
+throughout, floored to whole milliseconds because the float residue in `at + ttl - at` was enough
+to round a reported window up by a second.
 
-`backend/test/throttler-clock-step.spec.ts` pins the clock behaviour and is the thing to re-run if
-the throttler is ever upgraded or swapped. It uses one key per bucket, so it cannot see the
-cross-client cancellation on its own.
+**The guarantee now:** a count falls one ttl after the hit that raised it, whatever any other
+client in the same bucket does and whatever the wall clock does, and a block lasts its configured
+duration and no longer. Everything the guard reads is unchanged — `totalHits`, `timeToExpire`,
+`timeToBlockExpire` in whole seconds, `isBlocked`, blocking on the hit that passes the limit.
+
+Two spec files, and both are the thing to re-run if the throttler is upgraded or swapped.
+`backend/test/throttler-storage.spec.ts` pins our storage, and deliberately holds the library to
+the stranding defect, so an upstream fix surfaces as a red test rather than silently.
+`backend/test/throttler-clock-step.spec.ts` pins what the library does under a clock step; it uses
+one key per bucket, which is exactly why the cross-client cancellation was invisible to it.
 
 ## The traps worth keeping
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,7 +9,7 @@ import type { Connection } from 'mongoose'
 import { AuthModule } from './auth/auth.module'
 import { VersionGateGuard } from './common/guards/version-gate.guard'
 import { validateEnv } from './config/env'
-import { THROTTLER_OPTIONS } from './config/throttling'
+import { createThrottlerOptions } from './config/throttling'
 import { EventCountersModule } from './event-counters/event-counters.module'
 import { HealthModule } from './health/health.module'
 import { HttpErrorFilter } from './event-counters/http-error.filter'
@@ -57,7 +57,9 @@ import { VersionModule } from './version/version.module'
         },
       }),
     }),
-    ThrottlerModule.forRoot(THROTTLER_OPTIONS),
+    // Async so the factory runs per application and each gets its own storage, which is what
+    // forRoot does for the library's storage. The storage is ours; see config/throttler-storage.ts.
+    ThrottlerModule.forRootAsync({ useFactory: createThrottlerOptions }),
     // Global, and imported first: everything below may need to report a fault.
     EventCountersModule,
     HealthModule,

--- a/backend/src/config/throttler-storage.ts
+++ b/backend/src/config/throttler-storage.ts
@@ -1,0 +1,131 @@
+import { performance } from 'node:perf_hooks'
+
+import { Injectable } from '@nestjs/common'
+import type { OnApplicationShutdown } from '@nestjs/common'
+import type { ThrottlerStorage } from '@nestjs/throttler'
+
+/** The library does not re-export this from its entrypoint, so take it off the interface. */
+export type ThrottlerRecord = Awaited<ReturnType<ThrottlerStorage['increment']>>
+
+interface ClientRecord {
+  /** Live hits, per bucket. A key only ever carries one bucket under our generateKey. */
+  hits: Map<string, number>
+  /** The pending decrement for each of those hits, held on the client rather than the bucket. */
+  timers: Map<string, NodeJS.Timeout[]>
+  expiresAt: number
+  blockExpiresAt: number
+  isBlocked: boolean
+}
+
+/**
+ * Monotonic, so a wall-clock step cannot move a deadline already set. Floored to whole
+ * milliseconds like Date.now(): performance.now() is fractional, and the float residue in
+ * `at + ttl - at` was enough to round a reported window up by a second.
+ */
+const now = (): number => Math.floor(performance.now())
+
+const toSeconds = (milliseconds: number): number => Math.ceil(milliseconds / 1000)
+
+/**
+ * In-memory throttler storage, replacing @nestjs/throttler 6.5.0's ThrottlerStorageService.
+ *
+ * Two defects in that implementation put real clients at risk, and both are structural rather
+ * than tunable:
+ *
+ * 1. It tracks pending decrements in one list per bucket with no client key, and unblocking any
+ *    one client clears the whole list. Every other client in that bucket then keeps its count
+ *    forever, so repeated block-and-unblock cycles on `login` or `roomAuth` lock out strangers
+ *    who did nothing. Here each client owns its own timers, so an unblock touches nobody else.
+ * 2. Unblocking compared `blockExpiresAt` against `Date.now()`, so a backwards clock step
+ *    extended every live block by the offset. Every deadline here is monotonic instead.
+ *
+ * Everything the guard reads is unchanged: totalHits, timeToExpire and timeToBlockExpire in
+ * whole seconds, isBlocked, blocking on the hit that passes the limit, and the window refreshing
+ * once it has lapsed.
+ */
+@Injectable()
+export class PerClientThrottlerStorage implements ThrottlerStorage, OnApplicationShutdown {
+  private readonly clients = new Map<string, ClientRecord>()
+
+  async increment(
+    key: string,
+    ttl: number,
+    limit: number,
+    blockDuration: number,
+    throttlerName: string,
+  ): Promise<ThrottlerRecord> {
+    const at = now()
+    const client = this.clientFor(key, throttlerName, at, ttl)
+
+    if (client.expiresAt <= at) client.expiresAt = at + ttl
+    const timeToExpire = toSeconds(client.expiresAt - at)
+
+    if (!client.isBlocked) this.countHit(client, throttlerName, ttl)
+
+    if (!client.isBlocked && (client.hits.get(throttlerName) ?? 0) > limit) {
+      client.isBlocked = true
+      client.blockExpiresAt = at + blockDuration
+    }
+
+    // Negative for a client that has never blocked, as in the library. The guard only reads it
+    // to set Retry-After, which it only does while isBlocked.
+    const timeToBlockExpire = toSeconds(client.blockExpiresAt - at)
+    if (client.isBlocked && client.blockExpiresAt <= at) {
+      this.unblock(client, throttlerName)
+      this.countHit(client, throttlerName, ttl)
+    }
+
+    return {
+      totalHits: client.hits.get(throttlerName) ?? 0,
+      timeToExpire,
+      isBlocked: client.isBlocked,
+      timeToBlockExpire,
+    }
+  }
+
+  onApplicationShutdown(): void {
+    for (const client of this.clients.values()) {
+      for (const timers of client.timers.values()) timers.forEach(clearTimeout)
+      client.timers.clear()
+    }
+    this.clients.clear()
+  }
+
+  private clientFor(key: string, throttlerName: string, at: number, ttl: number): ClientRecord {
+    const existing = this.clients.get(key)
+    if (existing) {
+      if (!existing.hits.has(throttlerName)) existing.hits.set(throttlerName, 0)
+      return existing
+    }
+
+    const client: ClientRecord = {
+      hits: new Map([[throttlerName, 0]]),
+      timers: new Map(),
+      expiresAt: at + ttl,
+      blockExpiresAt: 0,
+      isBlocked: false,
+    }
+    this.clients.set(key, client)
+    return client
+  }
+
+  private countHit(client: ClientRecord, throttlerName: string, ttl: number): void {
+    client.hits.set(throttlerName, (client.hits.get(throttlerName) ?? 0) + 1)
+
+    const timer = setTimeout(() => {
+      client.hits.set(throttlerName, Math.max(0, (client.hits.get(throttlerName) ?? 0) - 1))
+      const pending = client.timers.get(throttlerName)
+      if (pending) client.timers.set(throttlerName, pending.filter(id => id !== timer))
+    }, ttl)
+
+    client.timers.set(throttlerName, [...(client.timers.get(throttlerName) ?? []), timer])
+  }
+
+  /** Cancels this client's pending decrements and nobody else's, which is the whole fix. */
+  private unblock(client: ClientRecord, throttlerName: string): void {
+    client.isBlocked = false
+    client.hits.set(throttlerName, 0)
+    client.timers.get(throttlerName)?.forEach(clearTimeout)
+    client.timers.set(throttlerName, [])
+  }
+}

--- a/backend/src/config/throttling.ts
+++ b/backend/src/config/throttling.ts
@@ -2,7 +2,11 @@ import type { ExecutionContext } from '@nestjs/common'
 import type { ThrottlerModuleOptions } from '@nestjs/throttler'
 import type { Request } from 'express'
 
+import { PerClientThrottlerStorage } from './throttler-storage'
 import { isLoopbackRequest } from './loopback'
+
+/** The object form of the module options, as opposed to the bare array of throttlers. */
+type ThrottlerOptions = Extract<ThrottlerModuleOptions, { throttlers: unknown }>
 
 export const HEALTH_PATH = '/health'
 export const VERSION_PATH = '/version'
@@ -117,7 +121,7 @@ const isSlugLookup = (context: ExecutionContext): boolean => {
  * `generateKey` drops the per-handler suffix Nest adds by default, which would otherwise
  * give every route its own allowance instead of one shared allowance per client.
  */
-export const THROTTLER_OPTIONS: ThrottlerModuleOptions = {
+export const THROTTLER_OPTIONS: ThrottlerOptions = {
   throttlers: [
     {
       ...GLOBAL_THROTTLE,
@@ -143,3 +147,16 @@ export const THROTTLER_OPTIONS: ThrottlerModuleOptions = {
   ],
   generateKey: (_context, tracker, throttlerName) => `${throttlerName}-${tracker}`,
 }
+
+/**
+ * The buckets plus our own storage. @nestjs/throttler's in-memory storage holds one list of
+ * pending decrements per bucket with no client key in it, so unblocking one client cancels every
+ * other client's decay in the same bucket and strands their counts; see throttler-storage.ts.
+ *
+ * A factory rather than a constant, because ThrottlerModule.forRoot builds the library's storage
+ * once per application: tests stand several apps up in one process and must not share counts.
+ */
+export const createThrottlerOptions = (): ThrottlerOptions => ({
+  ...THROTTLER_OPTIONS,
+  storage: new PerClientThrottlerStorage(),
+})

--- a/backend/test/throttler-clock-step.spec.ts
+++ b/backend/test/throttler-clock-step.spec.ts
@@ -5,6 +5,10 @@
  * out of reach and the count never fell. @nestjs/throttler drains each hit on a setTimeout
  * instead, and Node timers are monotonic, so the same step cannot stop the count falling. The
  * ttls here are scaled down from the real 60s bucket so the suite can watch it happen.
+ *
+ * This file drives the library's storage, which the app no longer runs on: it runs on
+ * PerClientThrottlerStorage, pinned in throttler-storage.spec.ts. Keeping the library pinned
+ * here is what makes an upgrade's behaviour change visible.
  */
 import { ThrottlerStorageService } from '@nestjs/throttler'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -56,8 +60,9 @@ describe('a backwards clock step against @nestjs/throttler storage', () => {
     storage.onApplicationShutdown()
   })
 
-  // The residual hazard, recorded rather than fixed: unblocking is still wall-clock. Reaching it
-  // needs more hits inside one ttl than the healthcheck can produce, which is why /health is safe.
+  // Why the library's unblocking was not good enough: it waits on Date.now(), so a step
+  // backwards extends a live block by the offset. Our storage does not; see
+  // throttler-storage.spec.ts, 'unblocks on schedule despite a backwards clock step'.
   it('does freeze a key that had already been blocked when the step landed', async () => {
     const storage = new ThrottlerStorageService()
     const limit = 3

--- a/backend/test/throttler-storage.spec.ts
+++ b/backend/test/throttler-storage.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Pins the storage the throttler guard actually runs on.
+ *
+ * @nestjs/throttler 6.5.0's own storage keeps one list of pending decrements per bucket with no
+ * client key in it, and unblocking any client clears the whole list. Every other client in that
+ * bucket then keeps its count for good, so an unrelated person can be 429'd out of signing in or
+ * joining a room. PerClientThrottlerStorage gives each client its own timers and its own
+ * monotonic deadlines; the last describe here holds the library to the behaviour we left behind,
+ * so an upgrade that fixes it upstream is visible rather than silent.
+ */
+import { ThrottlerStorageService } from '@nestjs/throttler'
+import type { ThrottlerStorage } from '@nestjs/throttler'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PerClientThrottlerStorage } from '../src/config/throttler-storage'
+import type { ThrottlerRecord } from '../src/config/throttler-storage'
+
+/** Scaled down from the real buckets so the suite can watch a window open and close. */
+const TTL = 600
+const LIMIT = 2
+const BUCKET = 'login'
+
+const realNow = Date.now.bind(Date)
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+afterEach(() => {
+  Date.now = realNow
+})
+
+/**
+ * Client A blocks and later unblocks. Client B makes two ordinary requests, at its limit but
+ * never over it, while A is blocked. By the time B is measured both of its hits are older than
+ * the ttl, so a storage that decays per client reports one live hit and no block.
+ */
+const oneClientUnblocksWhileAnotherIsCounting = async (
+  storage: ThrottlerStorage,
+): Promise<ThrottlerRecord> => {
+  const hit = (key: string) => storage.increment(key, TTL, LIMIT, TTL, BUCKET)
+
+  await hit('a')
+  await hit('a')
+  expect((await hit('a')).isBlocked).toBe(true)
+
+  await sleep(550)
+  await hit('b')
+  expect((await hit('b')).totalHits).toBe(2)
+
+  await sleep(150)
+  expect((await hit('a')).isBlocked).toBe(false)
+
+  await sleep(600)
+  return hit('b')
+}
+
+describe('PerClientThrottlerStorage', () => {
+  it('leaves another client counting normally when one unblocks', async () => {
+    const storage = new PerClientThrottlerStorage()
+
+    const b = await oneClientUnblocksWhileAnotherIsCounting(storage)
+
+    expect(b.totalHits).toBe(1)
+    expect(b.isBlocked).toBe(false)
+    storage.onApplicationShutdown()
+  })
+
+  it('decays two clients in one bucket independently', async () => {
+    const storage = new PerClientThrottlerStorage()
+    const hit = (key: string) => storage.increment(key, TTL, LIMIT, TTL, BUCKET)
+
+    await hit('a')
+    await hit('a')
+    await hit('b')
+    await sleep(300)
+    // Half a ttl on, both are still holding both hits.
+    expect((await hit('a')).totalHits).toBe(3)
+    expect((await hit('b')).totalHits).toBe(2)
+
+    await sleep(700)
+    // Past the ttl on everything above, so each client is back to just this request.
+    expect((await hit('a')).totalHits).toBe(1)
+    expect((await hit('b')).totalHits).toBe(1)
+    storage.onApplicationShutdown()
+  })
+
+  it('lets a second client spend its whole allowance while the first is blocked', async () => {
+    const storage = new PerClientThrottlerStorage()
+    const hit = (key: string) => storage.increment(key, TTL, LIMIT, TTL, BUCKET)
+
+    await hit('a')
+    await hit('a')
+    expect((await hit('a')).isBlocked).toBe(true)
+
+    for (let attempt = 0; attempt < LIMIT; attempt++) {
+      expect((await hit('b')).isBlocked).toBe(false)
+    }
+    // B blocks on its own hit past its own limit, and on nothing A did.
+    expect((await hit('b')).isBlocked).toBe(true)
+    storage.onApplicationShutdown()
+  })
+
+  it('decays several buckets at once', async () => {
+    const storage = new PerClientThrottlerStorage()
+    // The real generateKey is `${throttlerName}-${tracker}`, so one client holds one key per
+    // bucket it touches.
+    const hit = (bucket: string) => storage.increment(`${bucket}-a`, TTL, LIMIT, TTL, bucket)
+
+    await hit('login')
+    await hit('share')
+    await hit('login')
+    expect((await hit('share')).totalHits).toBe(2)
+
+    await sleep(TTL + 200)
+    expect((await hit('login')).totalHits).toBe(1)
+    expect((await hit('share')).totalHits).toBe(1)
+    storage.onApplicationShutdown()
+  })
+
+  it('reports the record the guard reads, and blocks on the hit past the limit', async () => {
+    const storage = new PerClientThrottlerStorage()
+    const hit = () => storage.increment('k', 1000, LIMIT, 1000, BUCKET)
+
+    const first = await hit()
+    expect(first.totalHits).toBe(1)
+    expect(first.timeToExpire).toBe(1)
+    expect(first.isBlocked).toBe(false)
+
+    expect((await hit()).isBlocked).toBe(false)
+
+    const blocked = await hit()
+    expect(blocked.totalHits).toBe(LIMIT + 1)
+    expect(blocked.isBlocked).toBe(true)
+    // Retry-After comes from this, in whole seconds.
+    expect(blocked.timeToBlockExpire).toBe(1)
+
+    // Still blocked while the block is live, and not counting further hits against itself.
+    const during = await hit()
+    expect(during.isBlocked).toBe(true)
+    expect(during.totalHits).toBe(LIMIT + 1)
+
+    await sleep(1100)
+    const after = await hit()
+    expect(after.isBlocked).toBe(false)
+    expect(after.totalHits).toBe(1)
+    storage.onApplicationShutdown()
+  })
+
+  it('unblocks on schedule despite a backwards clock step', async () => {
+    const storage = new PerClientThrottlerStorage()
+    const hit = () => storage.increment('stepped', TTL, LIMIT, TTL, BUCKET)
+
+    for (let attempt = 0; attempt <= LIMIT; attempt++) await hit()
+    expect((await hit()).isBlocked).toBe(true)
+
+    // The incident: the clock stepped back about an hour, shortly after boot.
+    Date.now = () => realNow() - 60 * 60 * 1000
+    await sleep(TTL + 200)
+
+    expect((await hit()).isBlocked).toBe(false)
+    storage.onApplicationShutdown()
+  })
+
+  it('drops its pending decrements on shutdown', async () => {
+    const storage = new PerClientThrottlerStorage()
+
+    await storage.increment('k', 100, LIMIT, 100, BUCKET)
+    storage.onApplicationShutdown()
+    // Nothing left to fire into a torn-down app, and a second call is safe.
+    await sleep(200)
+    storage.onApplicationShutdown()
+
+    expect((await storage.increment('k', 100, LIMIT, 100, BUCKET)).totalHits).toBe(1)
+    storage.onApplicationShutdown()
+  })
+})
+
+describe('the library storage this replaces', () => {
+  // Held to the defect deliberately. If this ever fails, @nestjs/throttler has fixed the
+  // cross-client cancellation and PerClientThrottlerStorage is worth re-reading against it.
+  it('strands a second client when the first unblocks', async () => {
+    const storage = new ThrottlerStorageService()
+
+    const b = await oneClientUnblocksWhileAnotherIsCounting(storage)
+
+    // Both of B's earlier hits should have decayed. They were cancelled by A's unblock instead,
+    // so an ordinary third request pushes B over a limit it never actually exceeded.
+    expect(b.totalHits).toBe(LIMIT + 1)
+    expect(b.isBlocked).toBe(true)
+    storage.onApplicationShutdown()
+  })
+})


### PR DESCRIPTION
## No manual steps or intervention required.

Stacks on #668 and must merge after it. GitHub will retarget this to `beta7` once #668 lands.

## Who this locks out

Right now, one client hitting a rate limit and later coming off it silently freezes the rate-limit
counts of every other client in the same bucket. Their counts stop falling and never recover, so
somebody who has done nothing wrong accumulates hits forever and eventually gets a 429 on an
ordinary request. That means being unable to sign in, unable to join a room by invite link, and
unable to create a share, for as long as the process stays up rather than for the configured
window. `login`, `roomAuth`, `share` and `slugLookup` are the buckets where that hits a real
person; `global` is the one where it can end up refusing ordinary API traffic. Every
block-and-unblock cycle in a bucket strands a bit more, so it gets worse the longer the container
runs.

## The cause

`@nestjs/throttler` 6.5.0's in-memory storage keeps its pending decrement timers in a single list
per bucket, keyed by throttler name with no client key in it. Each hit schedules a `setTimeout`
that drops that client's count and pushes the id onto that shared list. When any one client comes
off a block, `resetBlockdRequest` calls `clearExpirationTimes` for the whole bucket, which clears
every timer in the list and empties it. The unblocked client is fine, because its count is reset
to zero at the same moment. Everyone else in that bucket keeps whatever count they had, with
nothing left scheduled to take it away.

## What I did

I replaced the storage rather than patching the package. `backend/src/config/throttler-storage.ts`
adds `PerClientThrottlerStorage`, which holds each client's timers on that client's own record, so
an unblock cancels that client's pending decrements and nobody else's. It is registered through
`ThrottlerModule.forRootAsync`, so every application instance gets its own storage exactly as
`forRoot` did with the library's.

I chose the custom storage over a `pnpm patch` on the evidence, not on preference. The defect is
structural, so a patch would have to reimplement the same data structure anyway and would carry no
less code, only less visibility. A patch is invisible in review, silently needs re-applying and
re-reading against every version bump, and fails in the direction of quietly not applying. The
storage is an ordinary file with its own spec, it survives upgrades untouched, and it keeps a test
pointed at the library so an upstream fix is something I find out about.

While I was in there I closed the second problem #668 documented and left open: the library
compared `blockExpiresAt` against `Date.now()`, so a backwards clock step extended a live block by
the offset. Every deadline in the new storage is monotonic, which makes that free rather than a
second piece of work, so it is gone. The reported values are floored to whole milliseconds to
match `Date.now()`'s granularity, because the float residue in `performance.now()` was enough to
round a reported window up by a second.

Nothing the guard reads changed: `totalHits`, `timeToExpire` and `timeToBlockExpire` in whole
seconds, `isBlocked`, blocking on the hit that passes the limit, the window refreshing once it has
lapsed, the `${throttlerName}-${tracker}` key shape, and the per-bucket `skipIf` composition.

## Validation

`backend/test/throttler-storage.spec.ts` is new. Its reproduction drives two clients through one
bucket: A blocks and later unblocks while B makes two ordinary requests inside A's block, and B is
then measured well past the ttl on both. Against the library that reproduction fails, reporting 3
live hits and a block for a client that never went over its limit; against the new storage it
reports 1 and no block. The same scenario is kept pointed at the library in the last describe, held
to the defect deliberately, so an upstream fix shows up as a red test rather than passing unnoticed.

Also covered: two clients decaying independently in one bucket, a second client spending its whole
allowance while the first is blocked, several buckets decaying at once, the full record the guard
reads including Retry-After, unblocking on schedule through a backwards clock step, and shutdown
dropping its pending timers.

Full backend suite: 39 files, 591 tests, all passing. `common`: 7 files, 268 tests, all passing.
`backend` typecheck clean, repo lint clean.

One caveat worth flagging: `backend/test/throttler-clock-step.spec.ts` (from #668, unchanged here
apart from comments) is timing-sensitive and failed about one run in five on an idle machine. It
drives the library storage with a 100ms ttl and 50ms probes, so a timer firing late leaves three
hits alive and trips its `<= 2` assertion. It is unrelated to this change and wants its margins
widened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
