### PR TITLE
test(backend): give the clock-step probe loop a real jitter margin

### DIFF
--- a/backend/test/throttler-clock-step.spec.ts
+++ b/backend/test/throttler-clock-step.spec.ts
@@ -15,14 +15,20 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { HEALTH_THROTTLE } from '../src/config/throttling'
 
+const TTL = 500
 /**
- * Wide on purpose. The shape being pinned is "two hits alive at a time, and the count does not
- * climb", which holds at any scale; what a tight ttl adds is a race against the suite's own
- * scheduler, where one late timer leaves three alive and fails a test that found nothing wrong.
- * A probe interval of 200ms gives a decrement that much slack before it matters.
+ * How late a decrement timer may fire before three hits are alive at once, and the assertion
+ * below fails on the suite's own scheduler rather than on anything the storage did wrong.
  */
-const TTL = 400
-const PROBE = TTL / 2
+const JITTER_MARGIN = 200
+/**
+ * Docker probes at roughly half the ttl, which is what keeps two hits alive at a time. Probing
+ * at *exactly* half leaves no margin at all: hit k's decrement falls due the same instant probe
+ * k+2 lands, at any ttl, so scaling the ttl up on its own buys nothing — measured, the gap sits
+ * at 0ms whether the ttl is 100 or 2000. Probing half the margin later than half the ttl puts
+ * each probe midway between the two deadlines that bracket it, and that gap is the tolerance.
+ */
+const PROBE = (TTL + JITTER_MARGIN) / 2
 /** The incident: the clock was stepped back about an hour shortly after boot. */
 const STEP_BACK = -60 * 60 * 1000
 
@@ -47,7 +53,7 @@ describe('a backwards clock step against @nestjs/throttler storage', () => {
     // ...and only then does the clock get stepped back, which is the ordering that mattered.
     stepClock(STEP_BACK)
 
-    // Docker probes at half the ttl, so two hits are alive at once and no more. More probes
+    // Probing just over half the ttl keeps two hits alive at once and no more. More probes
     // than the bucket's limit, so a count that was climbing would certainly have blocked.
     for (let probe = 0; probe < HEALTH_THROTTLE.limit + 2; probe++) {
       await sleep(PROBE)


### PR DESCRIPTION
No manual steps or intervention required.

Fixes the flake in `backend/test/throttler-clock-step.spec.ts`, "does not stop the hit count falling, so the healthcheck pattern never blocks". The property under test is sound; the test simply had no room.

## Raising the ttl would not have fixed it

The brief was to raise `TTL` and `PROBE` together so the tolerance became a larger absolute number of milliseconds. That does not work, and it is worth saying why before the change makes sense.

The assertion fails when a decrement timer fires late enough that three hits are alive at once. Hit `k`'s timer is due `TTL` after it lands; probe `k+2` lands `2 × PROBE` after it. So the tolerance is exactly `2 × PROBE − TTL` — and with `PROBE = TTL / 2` that is **zero at every scale**, which is why the flake survived the earlier 100 → 400 widening.

Measured against the installed `ThrottlerStorageService` 6.5.0, driving the same loop and recording the real gap between each probe and the timer it races:

| TTL | PROBE | `2·PROBE − TTL` | worst measured gap |
| --- | --- | --- | --- |
| 100 | 50 | 0 | −1ms |
| 400 | 200 (as merged) | 0 | −1ms |
| 1000 | 500 | 0 | 0ms |
| 2000 | 1000 | 0 | 0ms |

The gap does not move with the ttl. It moves with the *ratio*.

## The change

Probe half the margin later than half the ttl, which puts each probe midway between the two deadlines that bracket it:

```ts
const TTL = 500
const JITTER_MARGIN = 200
const PROBE = (TTL + JITTER_MARGIN) / 2   // 350
```

`JITTER_MARGIN` then *is* the tolerance, by construction. Measured gap at this setting: 200ms, on an idle box and under eight spinners on four cores alike.

The other side of the interval cannot fail the assertion, so only the late side needed room: a stalled probe leaves *one* hit alive rather than three, and `Math.max` over the run is still 2 from every other probe. `setTimeout` never fires early, so that side is safe by construction rather than by luck.

## What is unchanged

- **The assertion.** `expect(Math.max(...seen)).toBeLessThanOrEqual(2)` is untouched, and not relaxed.
- **Still two hits alive.** Verified the count reaches 2 on every run — the widening does not turn the test into a vacuous pass at 1.
- **The probe count.** Still `HEALTH_THROTTLE.limit + 2`, so a count that was climbing would certainly have blocked.
- **The block and unblock tests.** Not touched. They pick up the new `TTL` through the shared constant, which only makes their `sleep(TTL * 4)` margin wider.

## Cost

The file goes from 5.6s to 8.2s of test time. Cutting the probe loop would save ~0.35s and weaken the "more probes than the limit" claim, so it is left alone; the rest is the two block tests' `4 × TTL` sleeps.

## Runs

Ten consecutive runs of `cd backend && pnpm exec vitest run test/throttler-clock-step.spec.ts` — 10/10 green, 3 tests each:

```
run  1: PASS | Tests 3 passed (3) | Duration  9.03s (tests 8.22s)
run  2: PASS | Tests 3 passed (3) | Duration  8.85s (tests 8.21s)
run  3: PASS | Tests 3 passed (3) | Duration  8.84s (tests 8.21s)
run  4: PASS | Tests 3 passed (3) | Duration  8.81s (tests 8.22s)
run  5: PASS | Tests 3 passed (3) | Duration  8.85s (tests 8.21s)
run  6: PASS | Tests 3 passed (3) | Duration  8.87s (tests 8.22s)
run  7: PASS | Tests 3 passed (3) | Duration  8.85s (tests 8.22s)
run  8: PASS | Tests 3 passed (3) | Duration  8.85s (tests 8.21s)
run  9: PASS | Tests 3 passed (3) | Duration  8.87s (tests 8.22s)
run 10: PASS | Tests 3 passed (3) | Duration  8.91s (tests 8.21s)
==== 10 passed, 0 failed out of 10 ====
```

Also green: `test/throttler-storage.spec.ts` (8 tests), `pnpm exec eslint` on the file, and `pnpm run typecheck`.

Based on `beta7`, which is where the file lives — it arrived with #668 and was last touched by #669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfPQf4JiMuSUNbUxby54ye

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfPQf4JiMuSUNbUxby54ye)_