### PR TITLE
fix: legacy-import UX issues found during the live v0.7 cutover

### DIFF
--- a/backend/src/rooms/legacy-import.service.ts
+++ b/backend/src/rooms/legacy-import.service.ts
@@ -17,7 +17,7 @@ import { FactoryData } from '../legacy/factory-data.schema'
 import { RoomsService } from './rooms.service'
 import { User } from '../auth/user.schema'
 
-export const LEGACY_ROOM_NAME = 'Recovered plan'
+export const LEGACY_ROOM_NAME = 'Restored from old cloud sync'
 
 /**
  * A v5 UUID over the account id, so the import lands on the same room even if the
@@ -142,12 +142,17 @@ export class LegacyImportService {
     const blob = await this.loadBlob(username)
     if (!blob) return { imported: false, reason: 'no_legacy_data' }
     const { factories, dropped, tab } = blob
+    // A room named only after whatever the old save was called is indistinguishable from
+    // a fresh v0.7 plan of the same name -- say plainly where it came from either way.
     const { name = LEGACY_ROOM_NAME, ...content } = tab
+    const roomName = name === LEGACY_ROOM_NAME
+      ? name
+      : truncateString(`${name} (restored from old cloud sync)`, CAPS.name)
 
     const roomId = legacyImportRoomId(userId)
     const result = await this.roomsService.ensureRoom(
       userId,
-      { roomId, name, factories, ...content },
+      { roomId, name: roomName, factories, ...content },
       'imported',
     )
 

--- a/backend/test/rooms-legacy-import.spec.ts
+++ b/backend/test/rooms-legacy-import.spec.ts
@@ -195,14 +195,14 @@ describe('legacy blob import', () => {
 
       const stored = await connection.collection('rooms').findOne({ roomId: body.room.roomId })
       expect(stored).toMatchObject({
-        name: 'Nuclear megabase',
+        name: 'Nuclear megabase (restored from old cloud sync)',
         powerTarget: 4500,
         depotUploadTier: 2,
         depotExpansionTier: 3,
         plannerVersion: '0.6.2',
         groups: [{ id: 'group-1', name: 'Planned, no members yet', color: '#ff8800' }],
       })
-      expect(body.room.name).toBe('Nuclear megabase')
+      expect(body.room.name).toBe('Nuclear megabase (restored from old cloud sync)')
     })
 
     // Absent is a meaning: the tiers read as fully researched and the version as unanswered.
@@ -216,7 +216,7 @@ describe('legacy blob import', () => {
       const { body } = await post('/rooms/legacy/recover', user).send({})
 
       const stored = await connection.collection('rooms').findOne({ roomId: body.room.roomId })
-      expect(stored?.name).toBe('Early plan')
+      expect(stored?.name).toBe('Early plan (restored from old cloud sync)')
       expect(stored?.powerTarget).toBe(0)
       expect(stored?.groups).toEqual([])
       expect(stored?.depotUploadTier).toBeUndefined()
@@ -408,10 +408,10 @@ describe('legacy blob import', () => {
       const { body } = await autoImport()
 
       expect(body.imported).toBe(true)
-      expect(body.room.name).toBe('Nuclear megabase')
+      expect(body.room.name).toBe('Nuclear megabase (restored from old cloud sync)')
       const stored = await connection.collection('rooms').findOne({ roomId: body.room.roomId })
       expect(stored).toMatchObject({
-        name: 'Nuclear megabase',
+        name: 'Nuclear megabase (restored from old cloud sync)',
         powerTarget: 4500,
         depotUploadTier: 2,
         depotExpansionTier: 3,

--- a/web/src/components/sync/AdoptionDialog.spec.ts
+++ b/web/src/components/sync/AdoptionDialog.spec.ts
@@ -173,6 +173,13 @@ describe('AdoptionDialog', () => {
       expect(body().textContent).toContain('Sync your planner tabs now?')
       expect(body().textContent).toContain('These plans live only in this browser')
     })
+
+    it('points at tab settings for the sign-in sweep too, not the plus button', async () => {
+      await open(['Alpha', 'Beta'])
+
+      expect(body().textContent).toContain('sync them any time from tab settings')
+      expect(body().textContent).not.toContain('the plus button')
+    })
   })
 
   it('leaves every plan local when declined, and remembers the answer', async () => {

--- a/web/src/components/sync/AdoptionDialog.vue
+++ b/web/src/components/sync/AdoptionDialog.vue
@@ -36,9 +36,14 @@
     </div>
 
     <p class="mt-4 text-body-2 text-grey">
-      {{ landed
-        ? 'Say no and it simply stays local. You can send it up any time from tab settings.'
-        : 'Say no and they simply stay local. You can sync them any time from the plus button.' }}
+      <template v-if="landed">
+        Say no and it simply stays local. You can send it up any time from tab settings
+        (<i class="fas fa-pen" />, on the tab).
+      </template>
+      <template v-else>
+        Say no and they simply stay local. You can sync them any time from tab settings
+        (<i class="fas fa-pen" />, on the tab).
+      </template>
     </p>
 
     <template #actions>

--- a/web/src/stores/rooms-store.spec.ts
+++ b/web/src/stores/rooms-store.spec.ts
@@ -460,6 +460,21 @@ describe('rooms-store', () => {
       expect(store.adoptionOpen).toBe(true)
     })
 
+    // The offer dialog sits on top of the loading overlay, and an answer given while
+    // the plan is still being calculated can act on a partial one. A sign-in racing
+    // the boot's own load is the ordinary case this covers, not just a paste.
+    it('waits for the plan to finish loading before offering, on a sign-in too', async () => {
+      appStore.isLoaded = false
+
+      await interactiveLogin([])
+      expect(store.adoptionOpen, 'the plan is still loading').toBe(false)
+
+      eventBus.emit('loadingCompleted')
+      await nextTick()
+
+      expect(store.adoptionOpen).toBe(true)
+    })
+
     // signOut closes the dialog as cleanup; that is not the user answering, so
     // the parked adoption offer is dropped with the session, not shown.
     it('is cleared by a sign-out without counting as an answer', async () => {
@@ -640,6 +655,10 @@ describe('rooms-store', () => {
       expect(toast).toHaveBeenCalledWith('toast', expect.objectContaining({
         message: expect.stringContaining('previously saved to your account'),
         type: 'success',
+        // This fires straight off sign-in, right when the sync offer or a release
+        // splash is likely sat on top of it -- a timed toast nobody saw is the same
+        // as one that never fired.
+        variant: 'permanent',
       }))
       expect(store.legacyOpen).toBe(false)
       toast.mockRestore()

--- a/web/src/stores/rooms-store.ts
+++ b/web/src/stores/rooms-store.ts
@@ -94,6 +94,40 @@ export const useRoomsStore = defineStore('rooms', () => {
   }
 
   /**
+   * The offer dialogs sit on top of the loading overlay, and the overlay is what
+   * stands between a user and a plan still mid-calculation — a dialog answered while
+   * it is up can act on a partial plan. Resolves at once if the app is already
+   * loaded; otherwise waits for whichever load is currently in progress to finish.
+   */
+  const whenAppLoaded = (): Promise<void> => {
+    if (appStore.isLoaded) return Promise.resolve()
+    return new Promise(resolve => {
+      const onLoaded = () => {
+        eventBus.off('loadingCompleted', onLoaded)
+        resolve()
+      }
+      eventBus.on('loadingCompleted', onLoaded)
+    })
+  }
+
+  /** One dialog at a time. The chooser fronts an interactive login and the rest are
+   * parked; every answer releases the next offer that is still due. */
+  const openDueOffers = (
+    rooms: RoomListEntry[],
+    offerChooser: boolean,
+    offerAdoption: boolean,
+    legacy: number | null,
+  ) => {
+    if (offerChooser && openPlanChooser(rooms)) {
+      parked = { adoption: offerAdoption ? rooms : null, legacy }
+    } else if (offerAdoption && openAdoptionOffer(rooms)) {
+      parked = { adoption: null, legacy }
+    } else if (legacy !== null) {
+      openLegacyOffer(legacy)
+    }
+  }
+
+  /**
    * Overlapping callers join the request already in flight instead of being turned
    * away: opening the account tray refreshes the list, and it opens straight after a
    * login, which is the same moment the login sequence asks for the list plus the
@@ -117,14 +151,11 @@ export const useRoomsStore = defineStore('rooms', () => {
       ? await findLegacyPlan()
       : null
 
-    // One dialog at a time. The chooser fronts an interactive login and the rest
-    // are parked; every answer releases the next offer that is still due.
-    if (offerChooser && openPlanChooser(rooms)) {
-      parked = { adoption: offerAdoption ? rooms : null, legacy }
-    } else if (offerAdoption && openAdoptionOffer(rooms)) {
-      parked = { adoption: null, legacy }
-    } else if (legacy !== null) {
-      openLegacyOffer(legacy)
+    // Deliberately not awaited: the list itself, and everything else refresh does,
+    // is due now, regardless of whether the plan is still loading. Only the dialogs
+    // wait.
+    if (offerChooser || offerAdoption || legacy !== null) {
+      void whenAppLoaded().then(() => openDueOffers(rooms, offerChooser, offerAdoption, legacy))
     }
     return true
   }
@@ -468,12 +499,16 @@ export const useRoomsStore = defineStore('rooms', () => {
     // many were left behind is the difference between a partial recovery and a
     // silent one.
     const dropped = result.dropped ?? 0
+    // Permanent regardless of whether anything was dropped: this fires straight off a
+    // sign-in, the exact moment another dialog (the sync offer, a release splash) is
+    // likely to be sat on top of it, and a timed toast that nobody saw is the same as
+    // one that never fired.
     eventBus.emit('toast', {
       message: dropped > 0
         ? `Recovered the plan previously saved to your account. It was too big for a cloud plan, so the last ${dropped} ${dropped === 1 ? 'factory' : 'factories'} could not be brought over.`
         : 'Recovered the plan previously saved to your account.',
       type: dropped > 0 ? 'warning' : 'success',
-      variant: dropped > 0 ? 'permanent' : 'timed',
+      variant: 'permanent',
       timeout: NOTICE_MS,
     })
     await refresh()


### PR DESCRIPTION
No manual steps or intervention required.

Found live, testing an actual pre-v0.7 account save recovering on sign-in right after the v0.7 deploy:

1. **The "sync your tabs?" offer could open before the plan finished loading**, before the calculation pipeline had settled. Answering it there risks syncing a partial plan. Now waits for the load in progress, the same way the existing pasted-tab offer already does.
2. **The recovery toast auto-dismissed on a timer** and was missed live because another dialog landed on top of it at the same moment. Now permanent, matching the toast's own truncation-warning case.
3. **A recovered room kept whatever name the old save happened to have**, indistinguishable from a fresh v0.7 plan of the same name. Now always says where it came from.
4. **The adoption dialog's sign-in-sweep copy pointed at the wrong control** ("the plus button" instead of tab settings), a stale reference from before that control moved. Corrected, with the actual pencil icon named.

All four confirmed against the real, live production database and browser session during the rollout, not just locally.

## Test plan

- [x] Full web test suite: 3,520 tests passing (2 new)
- [x] Full backend test suite: 591 tests passing
- [x] `vue-tsc --noEmit`: clean
- [x] `eslint`: clean on every changed file
- [x] New regression test for the load-timing fix, proven red against the unfixed code and green against the fix
- [x] New regression test for the toast permanence
- [x] New regression test for the dialog copy
- [x] Backend naming tests updated to the new expected name

🤖 Generated with [Claude Code](https://claude.com/claude-code)