### PR TITLE
feat(web): polish the account panel's plan lists

### DIFF
--- a/web/src/components/sync/AccountPanel.spec.ts
+++ b/web/src/components/sync/AccountPanel.spec.ts
@@ -10,6 +10,7 @@ import { useAppStore } from '@/stores/app-store'
 import { useAuthStore } from '@/stores/auth-store'
 import { useRoomSyncStore } from '@/stores/room-sync-store'
 import { useRoomsStore } from '@/stores/rooms-store'
+import { usePlanActivityStore } from '@/stores/plan-activity-store'
 import { LOCAL_TAB_STATE, type TabSyncStateMap } from '@/sync/tab-sync-state'
 
 const entry = (overrides: Partial<RoomListEntry> = {}): RoomListEntry => ({
@@ -34,10 +35,16 @@ describe('AccountPanel', () => {
   let authStore: ReturnType<typeof useAuthStore>
   let roomsStore: ReturnType<typeof useRoomsStore>
   let roomSync: ReturnType<typeof useRoomSyncStore>
+  let planActivity: ReturnType<typeof usePlanActivityStore>
 
   const render = (
     initialState: Record<string, unknown> = {},
-    { open = true, tabs = [] as FactoryTab[], tabStates = {} as TabSyncStateMap } = {},
+    {
+      open = true,
+      tabs = [] as FactoryTab[],
+      tabStates = {} as TabSyncStateMap,
+      stamps = {} as Record<string, number>,
+    } = {},
   ) => {
     const pinia = createTestingPinia({ createSpy: vi.fn, initialState })
     setActivePinia(pinia)
@@ -53,6 +60,10 @@ describe('AccountPanel', () => {
     appStore = useAppStore()
     vi.mocked(appStore.getTabs).mockImplementation(() => tabs)
     vi.mocked(appStore.getTabState).mockImplementation(tabId => tabStates[tabId] ?? LOCAL_TAB_STATE)
+
+    // The per-tab content stamp the tab bar already keeps; the panel reads it for local plans.
+    planActivity = usePlanActivityStore()
+    vi.mocked(planActivity.lastUpdatedAt).mockImplementation(tabId => stamps[tabId] ?? null)
 
     return mount(AccountPanel, { global: { plugins: [vuetify, pinia] }, props: { open } })
   }
@@ -243,16 +254,33 @@ describe('AccountPanel', () => {
       expect(card.find('.plan-action [data-testid="convert-local-plan"]').exists()).toBe(true)
     })
 
-    // A local tab carries no timestamp of its own, so the card says how big the plan is
-    // and stops there rather than repeating app-store's one browser-wide `lastEdit`.
-    it('says how big a local plan is, and claims no last-changed it does not have', () => {
+    const sizedTab = (factories: number) => ([
+      { id: 'local-1', name: 'My Browser Plan', factories: Array.from({ length: factories }, () => ({})) },
+    ] as unknown as FactoryTab[])
+
+    it('says how big a local plan is', () => {
+      const wrapper = render({}, { tabs: sizedTab(3) })
+
+      expect(at(wrapper, 'local-plan-factory-count').text()).toBe('3')
+    })
+
+    // The stamp comes from plan-activity-store, which the tab bar's own last-updated line
+    // already keeps per tab. Nothing new is stored for this.
+    it('says when a local plan last changed, from the per-tab content stamp', () => {
       const wrapper = render({}, {
-        tabs: [{ id: 'local-1', name: 'My Browser Plan', factories: [{}, {}, {}] } as unknown as FactoryTab],
+        tabs: sizedTab(3),
+        stamps: { 'local-1': Date.now() - 5 * 60_000 },
       })
 
-      const card = at(wrapper, 'local-plan')
-      expect(card.find('[data-testid="local-plan-factory-count"]').text()).toBe('3')
-      expect(card.find('[data-testid="plan-last-changed"]').exists()).toBe(false)
+      expect(at(wrapper, 'local-plan-last-changed').text()).toBe('Last updated 5 minutes ago')
+    })
+
+    // Empty stays empty: a plan this browser has not seen change says nothing rather than
+    // inventing a time for it.
+    it('says nothing about a local plan this browser has not seen change', () => {
+      const wrapper = render({}, { tabs: sizedTab(3) })
+
+      expect(at(wrapper, 'local-plan-last-changed').exists()).toBe(false)
     })
 
     it('converts a local tab through the adoption path', async () => {

--- a/web/src/components/sync/AccountPanel.spec.ts
+++ b/web/src/components/sync/AccountPanel.spec.ts
@@ -407,6 +407,24 @@ describe('AccountPanel', () => {
         expect(at(wrapper, testId).classes()).not.toContain('text-body-2')
       }
     })
+
+    // The tab bar names a tab's kind with an icon (TabNavigation.vue: a cloud for a
+    // synced tab, a group of people for a collaborative one). The headings over the
+    // two lists say the same thing with the same glyphs, rather than inventing a pair.
+    it('heads each list with the tab bar\'s icon for that kind of plan', async () => {
+      const wrapper = render({
+        rooms: {
+          entries: {
+            'room-1': entry(),
+            'room-2': entry({ roomId: 'room-2', name: 'Steel', role: 'member', order: 1 }),
+          },
+        },
+      })
+      await openCloud(wrapper)
+
+      expect(at(wrapper, 'my-plans-heading').find('i.fa-cloud').exists()).toBe(true)
+      expect(at(wrapper, 'joined-plans-heading').find('i.fa-users').exists()).toBe(true)
+    })
   })
 
   describe('show and hide', () => {

--- a/web/src/components/sync/AccountPanel.spec.ts
+++ b/web/src/components/sync/AccountPanel.spec.ts
@@ -365,6 +365,30 @@ describe('AccountPanel', () => {
       expect(count.text()).toBe('4')
     })
 
+    // The card's border carries the Show/Hide state: blue while the plan has a tab in
+    // this browser, and otherwise the grey every factory card wears. `plan-open` is what
+    // swaps it, so the class is the contract the scoped rule hangs off.
+    it('marks an open plan\'s card and leaves a hidden one alone', async () => {
+      const wrapper = render({
+        rooms: {
+          entries: {
+            'room-1': entry(),
+            'room-2': entry({ roomId: 'room-2', name: 'Steel', order: 1 }),
+          },
+        },
+      }, {
+        tabs: [tab('room-1', 'Iron Plates')],
+        tabStates: { 'room-1': { kind: 'synced', shared: false, role: 'owner', revision: 3 } },
+      })
+      await openCloud(wrapper)
+
+      const cards = wrapper.findAll('[data-testid="my-plan"]')
+      expect(cards[0].find('[data-testid="hide-plan"]').exists()).toBe(true)
+      expect(cards[0].classes()).toContain('plan-open')
+      expect(cards[1].find('[data-testid="show-plan"]').exists()).toBe(true)
+      expect(cards[1].classes()).not.toContain('plan-open')
+    })
+
     // At text-body-2 the headings were SMALLER than the plan names beneath them, so
     // each one read as one more plan rather than as the heading over the list.
     it('sizes both group headings above the plan names', async () => {

--- a/web/src/components/sync/AccountPanel.spec.ts
+++ b/web/src/components/sync/AccountPanel.spec.ts
@@ -232,15 +232,27 @@ describe('AccountPanel', () => {
       expect(at(wrapper, 'local-plan').exists()).toBe(false)
     })
 
-    // Both tabs are seen together, so a local plan gets the same card a cloud plan does —
-    // header only, as a local plan has no size or last-changed to report.
-    it('draws each local plan as a factory card', () => {
+    // Both tabs are seen together, so a local plan gets the same card and the same
+    // two-row/two-column layout a cloud plan does.
+    it('draws each local plan as a factory card, laid out like a cloud plan', () => {
       const wrapper = render({}, mixedTabs())
 
       const card = at(wrapper, 'local-plan')
       expect(card.classes()).toContain('factory-card')
-      expect(card.find('.header').text()).toContain('My Browser Plan')
-      expect(card.find('.header [data-testid="convert-local-plan"]').exists()).toBe(true)
+      expect(card.find('.plan-title').text()).toContain('My Browser Plan')
+      expect(card.find('.plan-action [data-testid="convert-local-plan"]').exists()).toBe(true)
+    })
+
+    // A local tab carries no timestamp of its own, so the card says how big the plan is
+    // and stops there rather than repeating app-store's one browser-wide `lastEdit`.
+    it('says how big a local plan is, and claims no last-changed it does not have', () => {
+      const wrapper = render({}, {
+        tabs: [{ id: 'local-1', name: 'My Browser Plan', factories: [{}, {}, {}] } as unknown as FactoryTab],
+      })
+
+      const card = at(wrapper, 'local-plan')
+      expect(card.find('[data-testid="local-plan-factory-count"]').text()).toBe('3')
+      expect(card.find('[data-testid="plan-last-changed"]').exists()).toBe(false)
     })
 
     it('converts a local tab through the adoption path', async () => {
@@ -337,19 +349,20 @@ describe('AccountPanel', () => {
 
     // ===== Layout =====
 
-    // Each plan is one of the planner's factory cards — a `.header` naming it over a
-    // body of readouts — so the panel reads as part of the same app. Two bare stacked
-    // lines per plan ran the list together.
-    it('draws each plan as a factory card with a header', async () => {
-      const wrapper = render({ rooms: { entries: { 'room-1': entry() } } })
+    // Two rows, two columns: the name over its readouts in column one, the toggle in
+    // column two spanning both. The toggle answers for the whole plan, so it must NOT
+    // sit inside the title row — that is the arrangement this replaced.
+    it('lays each plan out as a name over its readouts, with the toggle beside both', async () => {
+      const wrapper = render({ rooms: { entries: { 'room-1': entry({ factoryCount: 9 }) } } })
       await openCloud(wrapper)
 
       const card = at(wrapper, 'my-plan')
       expect(card.classes()).toContain('factory-card')
-      expect(card.find('.header').text()).toContain('Iron Plates')
-      // The name and its Show button share the header; the readouts sit below it.
-      expect(card.find('.header [data-testid="show-plan"]').exists()).toBe(true)
-      expect(card.find('.header [data-testid="plan-factory-count"]').exists()).toBe(false)
+      expect(card.find('.plan-title').text()).toContain('Iron Plates')
+      expect(card.find('.plan-meta [data-testid="plan-factory-count"]').text()).toBe('9')
+      expect(card.find('.plan-meta [data-testid="plan-last-changed"]').exists()).toBe(true)
+      expect(card.find('.plan-action [data-testid="show-plan"]').exists()).toBe(true)
+      expect(card.find('.plan-title [data-testid="show-plan"]').exists()).toBe(false)
     })
 
     // Tonal grey on this dark tray read as a disabled control rather than as a count.

--- a/web/src/components/sync/AccountPanel.spec.ts
+++ b/web/src/components/sync/AccountPanel.spec.ts
@@ -163,6 +163,16 @@ describe('AccountPanel', () => {
   })
 
   describe('offline switch', () => {
+    // The chip above it already draws the offline state as a plane; the switch that
+    // causes that state says so with the same icon rather than with words alone.
+    it('wears the same aeroplane the offline connection chip does', () => {
+      const wrapper = render()
+      const label = at(wrapper, 'offline-switch').find('label')
+
+      expect(label.text()).toContain('Offline mode')
+      expect(label.find('i.fa-plane').exists()).toBe(true)
+    })
+
     it('goes silent when switched on', async () => {
       const wrapper = render()
 
@@ -220,6 +230,17 @@ describe('AccountPanel', () => {
 
       expect(at(wrapper, 'no-local-plans').exists()).toBe(true)
       expect(at(wrapper, 'local-plan').exists()).toBe(false)
+    })
+
+    // Both tabs are seen together, so a local plan gets the same card a cloud plan does —
+    // header only, as a local plan has no size or last-changed to report.
+    it('draws each local plan as a factory card', () => {
+      const wrapper = render({}, mixedTabs())
+
+      const card = at(wrapper, 'local-plan')
+      expect(card.classes()).toContain('factory-card')
+      expect(card.find('.header').text()).toContain('My Browser Plan')
+      expect(card.find('.header [data-testid="convert-local-plan"]').exists()).toBe(true)
     })
 
     it('converts a local tab through the adoption path', async () => {
@@ -302,7 +323,7 @@ describe('AccountPanel', () => {
       expect(counts).toEqual(['12', '1'])
     })
 
-    it('gives a joined plan the same two-line row', async () => {
+    it('gives a joined plan the same card', async () => {
       const wrapper = render({
         rooms: { entries: { 'room-2': entry({ roomId: 'room-2', role: 'member', factoryCount: 3 }) } },
       })
@@ -312,6 +333,55 @@ describe('AccountPanel', () => {
       expect(row.find('[data-testid="plan-factory-count"]').text()).toBe('3')
       expect(row.find('[data-testid="plan-last-changed"]').exists()).toBe(true)
       expect(row.find('[data-testid="show-plan"]').exists()).toBe(true)
+    })
+
+    // ===== Layout =====
+
+    // Each plan is one of the planner's factory cards — a `.header` naming it over a
+    // body of readouts — so the panel reads as part of the same app. Two bare stacked
+    // lines per plan ran the list together.
+    it('draws each plan as a factory card with a header', async () => {
+      const wrapper = render({ rooms: { entries: { 'room-1': entry() } } })
+      await openCloud(wrapper)
+
+      const card = at(wrapper, 'my-plan')
+      expect(card.classes()).toContain('factory-card')
+      expect(card.find('.header').text()).toContain('Iron Plates')
+      // The name and its Show button share the header; the readouts sit below it.
+      expect(card.find('.header [data-testid="show-plan"]').exists()).toBe(true)
+      expect(card.find('.header [data-testid="plan-factory-count"]').exists()).toBe(false)
+    })
+
+    // Tonal grey on this dark tray read as a disabled control rather than as a count.
+    // The `factory` token is the one the rest of the app gives a factory reference.
+    it('colours the factory count with the factory token', async () => {
+      const wrapper = render({ rooms: { entries: { 'room-1': entry({ factoryCount: 4 }) } } })
+      await openCloud(wrapper)
+
+      // `.sf-chip.factory` in global.scss carries `!important` colour and border, so it
+      // wins over the chip variant underneath it — the class list is the whole contract.
+      const count = at(wrapper, 'plan-factory-count')
+      expect(count.classes()).toEqual(expect.arrayContaining(['sf-chip', 'factory', 'x-small']))
+      expect(count.text()).toBe('4')
+    })
+
+    // At text-body-2 the headings were SMALLER than the plan names beneath them, so
+    // each one read as one more plan rather than as the heading over the list.
+    it('sizes both group headings above the plan names', async () => {
+      const wrapper = render({
+        rooms: {
+          entries: {
+            'room-1': entry(),
+            'room-2': entry({ roomId: 'room-2', name: 'Steel', role: 'member', order: 1 }),
+          },
+        },
+      })
+      await openCloud(wrapper)
+
+      for (const testId of ['my-plans-heading', 'joined-plans-heading']) {
+        expect(at(wrapper, testId).classes()).toContain('text-h6')
+        expect(at(wrapper, testId).classes()).not.toContain('text-body-2')
+      }
     })
   })
 

--- a/web/src/components/sync/AccountPanel.vue
+++ b/web/src/components/sync/AccountPanel.vue
@@ -26,10 +26,15 @@
       data-testid="offline-switch"
       density="compact"
       hide-details
-      label="Offline mode"
       :model-value="roomSync.isOffline"
       @update:model-value="toggleOffline"
-    />
+    >
+      <!-- The same fa-plane the connection chip above wears for the offline state:
+           the switch that causes that state carries the icon it puts you in. -->
+      <template #label>
+        <span class="mr-2"><i class="fas fa-plane" /></span>Offline mode
+      </template>
+    </v-switch>
     <p class="text-body-2 mb-4 text-grey">
       Offline mode stops all contact with the server. Your edits are kept and sent when you
       switch it back off.
@@ -60,29 +65,34 @@
       >
         Every plan in your tab bar is already on the cloud.
       </p>
-      <div
+      <!-- The same card a cloud plan gets in CloudPlanRow, minus the body: a local plan
+           has no size or last-changed to report. One tab away from a list of cards, so
+           bare rows here would read as the unfinished half of the same panel. -->
+      <v-card
         v-for="tab in localTabs"
         :key="tab.id"
-        class="align-center d-flex ga-2 mb-2"
+        class="factory-card plan-card mb-2"
         data-testid="local-plan"
       >
-        <span class="flex-grow-1 text-truncate">{{ tab.name }}</span>
-        <v-tooltip location="top">
-          <template #activator="{ props: convertProps }">
-            <v-btn
-              color="green"
-              data-testid="convert-local-plan"
-              icon="fas fa-cloud-upload-alt"
-              :loading="convertingId === tab.id"
-              size="x-small"
-              variant="flat"
-              v-bind="convertProps"
-              @click="convert(tab.id)"
-            />
-          </template>
-          <span>Send this plan to the cloud</span>
-        </v-tooltip>
-      </div>
+        <div class="header align-center d-flex ga-2">
+          <span class="flex-grow-1 text-truncate">{{ tab.name }}</span>
+          <v-tooltip location="top">
+            <template #activator="{ props: convertProps }">
+              <v-btn
+                color="green"
+                data-testid="convert-local-plan"
+                icon="fas fa-cloud-upload-alt"
+                :loading="convertingId === tab.id"
+                size="x-small"
+                variant="flat"
+                v-bind="convertProps"
+                @click="convert(tab.id)"
+              />
+            </template>
+            <span>Send this plan to the cloud</span>
+          </v-tooltip>
+        </div>
+      </v-card>
       <p v-if="localTabs.length > 0" class="text-body-2 mt-1 text-grey">
         A local plan lives in this browser only. Send it to the cloud and it follows your
         account to every device you sign in on.
@@ -91,7 +101,9 @@
 
     <div v-else data-testid="cloud-pane">
       <div data-testid="my-plans">
-        <p class="text-body-2 font-weight-bold mb-2">My Plans</p>
+        <!-- A heading has to outrank the plan names under it. At text-body-2 it was
+             SMALLER than they are, and read as one more plan in the list. -->
+        <p class="text-h6 mb-2 plans-heading" data-testid="my-plans-heading">My Plans</p>
         <p
           v-if="ownedRooms.length === 0"
           class="text-body-2 text-grey mb-3"
@@ -113,7 +125,7 @@
       </div>
 
       <div v-if="joinedRooms.length > 0" class="mt-3" data-testid="joined-plans">
-        <p class="text-body-2 font-weight-bold mb-2">Joined Plans</p>
+        <p class="text-h6 mb-2 plans-heading" data-testid="joined-plans-heading">Joined Plans</p>
         <cloud-plan-row
           v-for="room in joinedRooms"
           :key="room.roomId"
@@ -330,3 +342,18 @@
     roomsStore.signOut()
   }
 </script>
+
+<style lang="scss" scoped>
+  // `text-h6` carries its own `font-weight: 400 !important`, which beats the
+  // `font-weight-bold` utility — a class that reads as bold and silently is not. The
+  // weight is set here instead, where it actually lands.
+  .plans-heading {
+    font-weight: 700 !important;
+  }
+
+  // Matches CloudPlanRow's card: `.factory-card .header` in global.scss is padded for a
+  // full-width planner card (12px 16px 0), which is too generous for a ~370px tray.
+  .plan-card .header {
+    padding: 6px 10px !important;
+  }
+</style>

--- a/web/src/components/sync/AccountPanel.vue
+++ b/web/src/components/sync/AccountPanel.vue
@@ -66,32 +66,54 @@
       >
         Every plan in your tab bar is already on the cloud.
       </p>
-      <!-- The same card a cloud plan gets in CloudPlanRow, minus the body: a local plan
-           has no size or last-changed to report. One tab away from a list of cards, so
-           bare rows here would read as the unfinished half of the same panel. -->
+      <!-- The same card, and the same two-row/two-column layout, a cloud plan gets in
+           CloudPlanRow. No last-changed line: a local tab carries no timestamp of its
+           own (app-store's `lastEdit` is one stamp for the whole browser, not per plan),
+           and repeating that one value on every card would say they were all edited at
+           the same moment. -->
       <v-card
         v-for="tab in localTabs"
         :key="tab.id"
         class="factory-card plan-card mb-2"
         data-testid="local-plan"
       >
-        <div class="header align-center d-flex ga-2">
-          <span class="flex-grow-1 text-truncate">{{ tab.name }}</span>
-          <v-tooltip location="top">
-            <template #activator="{ props: convertProps }">
-              <v-btn
-                color="green"
-                data-testid="convert-local-plan"
-                icon="fas fa-cloud-upload-alt"
-                :loading="convertingId === tab.id"
-                size="x-small"
-                variant="flat"
-                v-bind="convertProps"
-                @click="convert(tab.id)"
-              />
-            </template>
-            <span>Send this plan to the cloud</span>
-          </v-tooltip>
+        <div class="plan-grid">
+          <div class="align-center d-flex ga-2 plan-title">
+            <span class="flex-grow-1 plan-name text-truncate">{{ tab.name }}</span>
+          </div>
+
+          <div class="align-center d-flex ga-2 plan-meta text-caption text-grey">
+            <v-tooltip location="top">
+              <template #activator="{ props: countProps }">
+                <v-chip
+                  class="sf-chip factory x-small no-margin"
+                  data-testid="local-plan-factory-count"
+                  v-bind="countProps"
+                >
+                  <i class="fas fa-industry mr-1" />{{ tab.factories.length }}
+                </v-chip>
+              </template>
+              <span>{{ factoryCountLabel(tab.factories.length) }} in this plan</span>
+            </v-tooltip>
+          </div>
+
+          <div class="align-center d-flex plan-action">
+            <v-tooltip location="top">
+              <template #activator="{ props: convertProps }">
+                <v-btn
+                  color="green"
+                  data-testid="convert-local-plan"
+                  icon="fas fa-cloud-upload-alt"
+                  :loading="convertingId === tab.id"
+                  size="x-small"
+                  variant="flat"
+                  v-bind="convertProps"
+                  @click="convert(tab.id)"
+                />
+              </template>
+              <span>Send this plan to the cloud</span>
+            </v-tooltip>
+          </div>
         </div>
       </v-card>
       <p v-if="localTabs.length > 0" class="text-body-2 mt-1 text-grey">
@@ -226,6 +248,10 @@
   const localTabs = computed(() =>
     appStore.getTabs().filter(tab => appStore.getTabState(tab.id).kind === 'local')
   )
+
+  /** Spelled out for the tooltip; the chip itself is the icon and the number. */
+  const factoryCountLabel = (count: number) =>
+    `${count} ${count === 1 ? 'factory' : 'factories'}`
 
   const rooms = computed(() =>
     Object.values(roomsStore.entries).sort((a, b) => a.order - b.order)
@@ -370,9 +396,43 @@
     margin-left: 6px;
   }
 
-  // Matches CloudPlanRow's card: `.factory-card .header` in global.scss is padded for a
-  // full-width planner card (12px 16px 0), which is too generous for a ~370px tray.
-  .plan-card .header {
-    padding: 8px 10px !important;
+  // The same two-row/two-column grid CloudPlanRow lays its cards out on, so the two
+  // tabs of this panel agree. Kept in step by hand: scoped styles cannot be shared, and
+  // one small grid in two files beat a third component for a purely visual layout.
+  .plan-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    column-gap: 8px;
+    row-gap: 2px;
+    padding: 8px 10px;
+  }
+
+  .plan-title {
+    grid-column: 1;
+    grid-row: 1;
+    min-width: 0;
+  }
+
+  .plan-meta {
+    grid-column: 1;
+    grid-row: 2;
+    min-width: 0;
+  }
+
+  .plan-action {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+  }
+
+  // The square-ish corner the planner gives every button in a factory card, which the
+  // dropped `.header` rule used to supply. Without it Vuetify's `.v-btn--icon` rounds
+  // this one to a circle while the Show/Hide buttons opposite stay square.
+  .plan-action .v-btn {
+    border-radius: 4px;
+  }
+
+  .plan-name {
+    line-height: 1.25;
   }
 </style>

--- a/web/src/components/sync/AccountPanel.vue
+++ b/web/src/components/sync/AccountPanel.vue
@@ -95,6 +95,16 @@
               </template>
               <span>{{ factoryCountLabel(tab.factories.length) }} in this plan</span>
             </v-tooltip>
+            <v-tooltip v-if="localLastChanged(tab.id)" location="top">
+              <template #activator="{ props: timeProps }">
+                <span
+                  class="text-no-wrap text-truncate"
+                  data-testid="local-plan-last-changed"
+                  v-bind="timeProps"
+                >{{ localLastChanged(tab.id) }}</span>
+              </template>
+              <span>Last changed {{ localLastChangedExact(tab.id) }}</span>
+            </v-tooltip>
           </div>
 
           <div class="align-center d-flex plan-action">
@@ -228,6 +238,8 @@
   import { useAuthStore } from '@/stores/auth-store'
   import { useRoomSyncStore } from '@/stores/room-sync-store'
   import { OFFLINE_MESSAGE, useRoomsStore } from '@/stores/rooms-store'
+  import { usePlanActivityStore } from '@/stores/plan-activity-store'
+  import { absoluteTime, relativeTimeLong } from '@/utils/relative-time'
 
   const props = withDefaults(defineProps<{
     /** True while the account tray is showing this panel. */
@@ -238,6 +250,7 @@
   const authStore = useAuthStore()
   const roomsStore = useRoomsStore()
   const roomSync = useRoomSyncStore()
+  const planActivity = usePlanActivityStore()
 
   const username = computed(() => authStore.loggedInUser)
 
@@ -252,6 +265,31 @@
   /** Spelled out for the tooltip; the chip itself is the icon and the number. */
   const factoryCountLabel = (count: number) =>
     `${count} ${count === 1 ? 'factory' : 'factories'}`
+
+  /**
+   * When this browser last saw a local plan's CONTENT change. plan-activity-store already
+   * keeps one stamp per tab for the tab bar's own last-updated line — renames and reorders
+   * deliberately excluded — so a local plan says the same thing a cloud plan does without
+   * anything new being stored. A cloud plan keeps using the server's `lastActivityAt`
+   * instead: that one is stamped by the server's clock and follows the plan across devices,
+   * where this is only what this browser has seen.
+   *
+   * Empty until this browser has seen the plan change, and empty stays empty — the same
+   * rule CloudPlanRow follows for an unreadable stamp.
+   */
+  const localStamp = (tabId: string): string | null => {
+    const at = planActivity.lastUpdatedAt(tabId)
+    return at ? new Date(at).toISOString() : null
+  }
+
+  const localLastChanged = (tabId: string) => {
+    const at = localStamp(tabId)
+    if (at === null) return ''
+    const elapsed = relativeTimeLong(at, now.value)
+    return elapsed === '' ? '' : `Last updated ${elapsed}`
+  }
+
+  const localLastChangedExact = (tabId: string) => absoluteTime(localStamp(tabId) ?? undefined)
 
   const rooms = computed(() =>
     Object.values(roomsStore.entries).sort((a, b) => a.order - b.order)

--- a/web/src/components/sync/AccountPanel.vue
+++ b/web/src/components/sync/AccountPanel.vue
@@ -354,6 +354,6 @@
   // Matches CloudPlanRow's card: `.factory-card .header` in global.scss is padded for a
   // full-width planner card (12px 16px 0), which is too generous for a ~370px tray.
   .plan-card .header {
-    padding: 6px 10px !important;
+    padding: 8px 10px !important;
   }
 </style>

--- a/web/src/components/sync/AccountPanel.vue
+++ b/web/src/components/sync/AccountPanel.vue
@@ -22,6 +22,7 @@
     </v-chip>
 
     <v-switch
+      class="offline-switch"
       color="orange"
       data-testid="offline-switch"
       density="compact"
@@ -102,8 +103,15 @@
     <div v-else data-testid="cloud-pane">
       <div data-testid="my-plans">
         <!-- A heading has to outrank the plan names under it. At text-body-2 it was
-             SMALLER than they are, and read as one more plan in the list. -->
-        <p class="text-h6 mb-2 plans-heading" data-testid="my-plans-heading">My Plans</p>
+             SMALLER than they are, and read as one more plan in the list.
+
+             The icons are the tab bar's own vocabulary for what a tab is, from
+             TabNavigation.vue: a cloud for a synced tab, a group of people for a
+             collaborative one. Fixed-width so both headings start their text at the
+             same x despite the two glyphs being different widths. -->
+        <p class="text-h6 mb-2 plans-heading" data-testid="my-plans-heading">
+          <i class="fas fa-cloud fa-fw mr-2" />My Plans
+        </p>
         <p
           v-if="ownedRooms.length === 0"
           class="text-body-2 text-grey mb-3"
@@ -125,7 +133,9 @@
       </div>
 
       <div v-if="joinedRooms.length > 0" class="mt-3" data-testid="joined-plans">
-        <p class="text-h6 mb-2 plans-heading" data-testid="joined-plans-heading">Joined Plans</p>
+        <p class="text-h6 mb-2 plans-heading" data-testid="joined-plans-heading">
+          <i class="fas fa-users fa-fw mr-2" />Joined Plans
+        </p>
         <cloud-plan-row
           v-for="room in joinedRooms"
           :key="room.roomId"
@@ -349,6 +359,15 @@
   // weight is set here instead, where it actually lands.
   .plans-heading {
     font-weight: 700 !important;
+  }
+
+  // Vuetify draws the switch's thumb 6px to the LEFT of the control's own box (and the
+  // track 4px), so the thumb is free to overhang as it slides. Everything else in this
+  // tray — the username, the connection chip, the tabs, the body copy — starts at one x,
+  // and the switch alone poked out of that column. Nudged back by the thumb's overhang
+  // rather than the track's: the thumb is the high-contrast edge the eye lines up on.
+  .offline-switch {
+    margin-left: 6px;
   }
 
   // Matches CloudPlanRow's card: `.factory-card .header` in global.scss is padded for a

--- a/web/src/components/sync/CloudPlanRow.vue
+++ b/web/src/components/sync/CloudPlanRow.vue
@@ -1,6 +1,9 @@
 <template>
-  <div class="mb-2">
-    <div class="align-center d-flex ga-2">
+  <!-- Drawn as one of the planner's factory cards: a `.header` naming the thing and
+       carrying its controls, over a body of readouts. A bare pair of stacked lines read
+       as loose text running into the next plan's; a card says where one plan ends. -->
+  <v-card class="factory-card plan-card mb-2">
+    <div class="header align-center d-flex ga-2">
       <span class="flex-grow-1 text-truncate">{{ room.name }}</span>
       <v-chip v-if="room.shared" color="green" size="x-small" variant="flat">Shared</v-chip>
       <v-tooltip location="top">
@@ -21,16 +24,20 @@
           : 'Open this plan in your tab bar.' }}</span>
       </v-tooltip>
     </div>
-    <div class="align-center d-flex ga-2 text-caption text-grey">
+    <!-- A v-card-text rather than a plain div on purpose: `.factory-card .header` drops
+         its bottom border when no `.v-card-text` follows it, so the divider that makes
+         this read as a header only exists if the body below is one. -->
+    <v-card-text class="align-center d-flex ga-2 plan-meta text-caption text-grey">
       <!-- The plan's size, drawn the way the sidebar's Global Factories Summary draws
-           it: the icon carries the meaning and the tooltip spells it out. -->
+           it: the icon carries the meaning and the tooltip spells it out. Wears the
+           `factory` token rather than a tonal grey, which on this dark tray read as a
+           disabled control rather than as a count. -->
       <v-tooltip location="top">
         <template #activator="{ props: countProps }">
           <v-chip
+            class="sf-chip factory x-small no-margin"
             data-testid="plan-factory-count"
-            size="small"
             v-bind="countProps"
-            variant="tonal"
           >
             <i class="fas fa-industry mr-1" />{{ room.factoryCount }}
           </v-chip>
@@ -47,8 +54,8 @@
         </template>
         <span>Last changed {{ absoluteTime(room.lastActivityAt) }}</span>
       </v-tooltip>
-    </div>
-  </div>
+    </v-card-text>
+  </v-card>
 </template>
 
 <script setup lang="ts">
@@ -57,9 +64,9 @@
   import { absoluteTime, relativeTimeLong } from '@/utils/relative-time'
 
   /**
-   * One two-line row of the account panel's plan lists. Line one names the plan
-   * and toggles whether it is open (has a tab) in this browser; line two says
-   * how big it is and when it last changed. Owned and joined plans share it.
+   * One plan's card in the account panel's plan lists. The header names the plan
+   * and toggles whether it is open (has a tab) in this browser; the body says how
+   * big it is and when it last changed. Owned and joined plans share it.
    */
   const props = withDefaults(defineProps<{
     room: RoomListEntry
@@ -88,3 +95,18 @@
     return elapsed === '' ? '' : `Last updated ${elapsed}`
   })
 </script>
+
+<style lang="scss" scoped>
+  // `.factory-card .header` in global.scss is padded for a full-width planner card
+  // (12px 16px 0). These sit in a ~370px account tray as well as in a dialog, so the
+  // padding comes in and the header gets a bottom of its own — the planner's card has
+  // a chips bar to fill that space, and this one does not. Two classes plus the scope
+  // attribute to outrank the global rule's `!important`.
+  .plan-card .header {
+    padding: 6px 10px !important;
+  }
+
+  .plan-card .plan-meta {
+    padding: 6px 10px;
+  }
+</style>

--- a/web/src/components/sync/CloudPlanRow.vue
+++ b/web/src/components/sync/CloudPlanRow.vue
@@ -5,8 +5,17 @@
   <v-card class="factory-card plan-card mb-2" :class="{ 'plan-open': open }">
     <div class="plan-grid">
       <div class="align-center d-flex ga-2 plan-title">
-        <span class="flex-grow-1 plan-name text-truncate">{{ room.name }}</span>
-        <v-chip v-if="room.shared" color="green" size="x-small" variant="flat">Shared</v-chip>
+        <!-- The chip qualifies the name, so it sits against it rather than being pushed to
+             the far side of the column, where it lined up with nothing and shifted with
+             the width of the button opposite. -->
+        <span class="plan-name text-truncate">{{ room.name }}</span>
+        <v-chip
+          v-if="room.shared"
+          class="flex-shrink-0"
+          color="green"
+          size="x-small"
+          variant="flat"
+        >Shared</v-chip>
       </div>
 
       <div class="align-center d-flex ga-2 plan-meta text-caption text-grey">
@@ -141,6 +150,9 @@
   // glyphs so the two rows sit evenly either side of the card's middle.
   .plan-name {
     line-height: 1.25;
+    // A flex item will not shrink below its content without this, so `text-truncate`
+    // would never get to truncate — the name would push the Shared chip out of the card.
+    min-width: 0;
   }
 
   // The border says whether this plan has a tab in this browser: the product blue when

--- a/web/src/components/sync/CloudPlanRow.vue
+++ b/web/src/components/sync/CloudPlanRow.vue
@@ -2,9 +2,9 @@
   <!-- Drawn as one of the planner's factory cards: a `.header` naming the thing and
        carrying its controls, over a body of readouts. A bare pair of stacked lines read
        as loose text running into the next plan's; a card says where one plan ends. -->
-  <v-card class="factory-card plan-card mb-2">
+  <v-card class="factory-card plan-card mb-2" :class="{ 'plan-open': open }">
     <div class="header align-center d-flex ga-2">
-      <span class="flex-grow-1 text-truncate">{{ room.name }}</span>
+      <span class="flex-grow-1 plan-name text-truncate">{{ room.name }}</span>
       <v-chip v-if="room.shared" color="green" size="x-small" variant="flat">Shared</v-chip>
       <v-tooltip location="top">
         <template #activator="{ props: toggleProps }">
@@ -102,11 +102,30 @@
   // padding comes in and the header gets a bottom of its own — the planner's card has
   // a chips bar to fill that space, and this one does not. Two classes plus the scope
   // attribute to outrank the global rule's `!important`.
+  //
+  // The header is deliberately the TALLER of the two bands. Matched padding left the
+  // 12px readouts below in a roomier strip than the 16px name above them, which read as
+  // the title being squeezed rather than as the heading of the card.
   .plan-card .header {
-    padding: 6px 10px !important;
+    padding: 8px 10px !important;
   }
 
   .plan-card .plan-meta {
-    padding: 6px 10px;
+    padding: 4px 10px;
+  }
+
+  // The name sets the header's height through its line box, and at the inherited 1.43
+  // that box carries far more air below the baseline than above the cap, which sits the
+  // name visibly high in the band. Tightened to hug the glyphs so centring them centres
+  // what you actually see.
+  .plan-name {
+    line-height: 1.25;
+  }
+
+  // The border says whether this plan has a tab in this browser: the product blue when
+  // it is open, and otherwise the grey every factory card wears, straight from
+  // `.factory-card`. Outranks that rule's `!important` shorthand on specificity.
+  .plan-card.plan-open {
+    border-color: var(--sf-product) !important;
   }
 </style>

--- a/web/src/components/sync/CloudPlanRow.vue
+++ b/web/src/components/sync/CloudPlanRow.vue
@@ -1,60 +1,63 @@
 <template>
-  <!-- Drawn as one of the planner's factory cards: a `.header` naming the thing and
-       carrying its controls, over a body of readouts. A bare pair of stacked lines read
-       as loose text running into the next plan's; a card says where one plan ends. -->
+  <!-- Two rows, two columns: the name over its readouts in column one, the toggle in
+       column two spanning both. Deliberately looser than the planner's factory card,
+       whose tinted header band and divider cannot survive a control that crosses them. -->
   <v-card class="factory-card plan-card mb-2" :class="{ 'plan-open': open }">
-    <div class="header align-center d-flex ga-2">
-      <span class="flex-grow-1 plan-name text-truncate">{{ room.name }}</span>
-      <v-chip v-if="room.shared" color="green" size="x-small" variant="flat">Shared</v-chip>
-      <v-tooltip location="top">
-        <template #activator="{ props: toggleProps }">
-          <v-btn
-            :color="open ? undefined : 'primary'"
-            :data-room-id="room.roomId"
-            :data-testid="open ? 'hide-plan' : 'show-plan'"
-            :loading="loading"
-            :size="size"
-            variant="tonal"
-            v-bind="toggleProps"
-            @click="emit('toggle', room.roomId)"
-          >{{ open ? 'Hide' : 'Show' }}</v-btn>
-        </template>
-        <span>{{ open
-          ? 'Close this plan\'s tab in this browser. It stays on your account.'
-          : 'Open this plan in your tab bar.' }}</span>
-      </v-tooltip>
+    <div class="plan-grid">
+      <div class="align-center d-flex ga-2 plan-title">
+        <span class="flex-grow-1 plan-name text-truncate">{{ room.name }}</span>
+        <v-chip v-if="room.shared" color="green" size="x-small" variant="flat">Shared</v-chip>
+      </div>
+
+      <div class="align-center d-flex ga-2 plan-meta text-caption text-grey">
+        <!-- The plan's size, drawn the way the sidebar's Global Factories Summary draws
+             it: the icon carries the meaning and the tooltip spells it out. Wears the
+             `factory` token rather than a tonal grey, which on this dark tray read as a
+             disabled control rather than as a count. -->
+        <v-tooltip location="top">
+          <template #activator="{ props: countProps }">
+            <v-chip
+              class="sf-chip factory x-small no-margin"
+              data-testid="plan-factory-count"
+              v-bind="countProps"
+            >
+              <i class="fas fa-industry mr-1" />{{ room.factoryCount }}
+            </v-chip>
+          </template>
+          <span>{{ factoryCountLabel }} in this plan</span>
+        </v-tooltip>
+        <v-tooltip location="top">
+          <template #activator="{ props: timeProps }">
+            <span
+              class="text-no-wrap text-truncate"
+              data-testid="plan-last-changed"
+              v-bind="timeProps"
+            >{{ lastChanged }}</span>
+          </template>
+          <span>Last changed {{ absoluteTime(room.lastActivityAt) }}</span>
+        </v-tooltip>
+      </div>
+
+      <div class="align-center d-flex plan-action">
+        <v-tooltip location="top">
+          <template #activator="{ props: toggleProps }">
+            <v-btn
+              :color="open ? undefined : 'primary'"
+              :data-room-id="room.roomId"
+              :data-testid="open ? 'hide-plan' : 'show-plan'"
+              :loading="loading"
+              :size="size"
+              variant="tonal"
+              v-bind="toggleProps"
+              @click="emit('toggle', room.roomId)"
+            >{{ open ? 'Hide' : 'Show' }}</v-btn>
+          </template>
+          <span>{{ open
+            ? 'Close this plan\'s tab in this browser. It stays on your account.'
+            : 'Open this plan in your tab bar.' }}</span>
+        </v-tooltip>
+      </div>
     </div>
-    <!-- A v-card-text rather than a plain div on purpose: `.factory-card .header` drops
-         its bottom border when no `.v-card-text` follows it, so the divider that makes
-         this read as a header only exists if the body below is one. -->
-    <v-card-text class="align-center d-flex ga-2 plan-meta text-caption text-grey">
-      <!-- The plan's size, drawn the way the sidebar's Global Factories Summary draws
-           it: the icon carries the meaning and the tooltip spells it out. Wears the
-           `factory` token rather than a tonal grey, which on this dark tray read as a
-           disabled control rather than as a count. -->
-      <v-tooltip location="top">
-        <template #activator="{ props: countProps }">
-          <v-chip
-            class="sf-chip factory x-small no-margin"
-            data-testid="plan-factory-count"
-            v-bind="countProps"
-          >
-            <i class="fas fa-industry mr-1" />{{ room.factoryCount }}
-          </v-chip>
-        </template>
-        <span>{{ factoryCountLabel }} in this plan</span>
-      </v-tooltip>
-      <v-tooltip location="top">
-        <template #activator="{ props: timeProps }">
-          <span
-            class="text-no-wrap"
-            data-testid="plan-last-changed"
-            v-bind="timeProps"
-          >{{ lastChanged }}</span>
-        </template>
-        <span>Last changed {{ absoluteTime(room.lastActivityAt) }}</span>
-      </v-tooltip>
-    </v-card-text>
   </v-card>
 </template>
 
@@ -64,9 +67,9 @@
   import { absoluteTime, relativeTimeLong } from '@/utils/relative-time'
 
   /**
-   * One plan's card in the account panel's plan lists. The header names the plan
-   * and toggles whether it is open (has a tab) in this browser; the body says how
-   * big it is and when it last changed. Owned and joined plans share it.
+   * One plan's card in the account panel's plan lists. Column one names the plan and
+   * says how big it is and when it last changed; column two toggles whether it is open
+   * (has a tab) in this browser. Owned and joined plans share it.
    */
   const props = withDefaults(defineProps<{
     room: RoomListEntry
@@ -97,27 +100,45 @@
 </script>
 
 <style lang="scss" scoped>
-  // `.factory-card .header` in global.scss is padded for a full-width planner card
-  // (12px 16px 0). These sit in a ~370px account tray as well as in a dialog, so the
-  // padding comes in and the header gets a bottom of its own — the planner's card has
-  // a chips bar to fill that space, and this one does not. Two classes plus the scope
-  // attribute to outrank the global rule's `!important`.
-  //
-  // The header is deliberately the TALLER of the two bands. Matched padding left the
-  // 12px readouts below in a roomier strip than the 16px name above them, which read as
-  // the title being squeezed rather than as the heading of the card.
-  .plan-card .header {
-    padding: 8px 10px !important;
+  // Column one takes what is left after the button; `minmax(0, 1fr)` rather than `1fr`
+  // so a long plan name truncates instead of forcing the card wider than the tray.
+  .plan-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    column-gap: 8px;
+    row-gap: 2px;
+    padding: 8px 10px;
   }
 
-  .plan-card .plan-meta {
-    padding: 4px 10px;
+  .plan-title {
+    grid-column: 1;
+    grid-row: 1;
+    min-width: 0;
   }
 
-  // The name sets the header's height through its line box, and at the inherited 1.43
-  // that box carries far more air below the baseline than above the cap, which sits the
-  // name visibly high in the band. Tightened to hug the glyphs so centring them centres
-  // what you actually see.
+  .plan-meta {
+    grid-column: 1;
+    grid-row: 2;
+    min-width: 0;
+  }
+
+  // Spans both rows and centres against them, which is the whole point of the grid:
+  // one control answering for the plan rather than one sitting on its title.
+  .plan-action {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+  }
+
+  // The square-ish corner the planner gives every button in a factory card's header.
+  // That rule keyed off `.header`, which this layout no longer has.
+  .plan-action .v-btn {
+    border-radius: 4px;
+  }
+
+  // The name sets row one's height through its line box, and at the inherited 1.43 that
+  // box carries far more air below the baseline than above the cap. Tightened to hug the
+  // glyphs so the two rows sit evenly either side of the card's middle.
   .plan-name {
     line-height: 1.25;
   }


### PR DESCRIPTION
Presentation polish on the account panel, ahead of the Beta v0.7 "What's new" deck screenshotting it. Nothing about what the panel does, what it fetches, or the Show/Hide behaviour has changed, and no new data is stored.

## The plan cards

Every plan — local and cloud — is now one of the planner's factory cards, laid out as **two rows by two columns**: column one carries the plan's name with its readouts underneath, column two carries the button, spanning both rows and centred against them so one control answers for the whole plan rather than sitting on its title. This drops the planner's tinted header band and divider, which cannot survive a control that crosses them.

- **The border says whether the plan has a tab in this browser** — the product blue (`--sf-product`) when open, otherwise the grey every factory card already wears. Local plans keep the grey: they are always open, so the cue would say nothing there.
- **The factory-count chip wears the `factory` semantic token** (`sf-chip factory x-small no-margin`) instead of `variant="tonal"`, which on the dark tray read as a disabled control rather than as a plan's size.
- **The name's line box is tightened to 1.25.** At the inherited 1.43 it carried far more air below the baseline than above the cap, which sat it visibly high in a row that is busy centring it.
- **Local plans now show their factory count and when they last changed**, in the same format as cloud plans. The count is `tab.factories.length`; the stamp is the per-tab content stamp `plan-activity-store` already keeps for the tab bar's own last-updated line — renames and reorders deliberately excluded, so dragging a card does not make a plan look edited. Nothing new is stored for this, and `Factory` is untouched. Cloud plans keep using the server's `lastActivityAt` instead: that one is stamped by the server's clock and follows the plan across devices, where this is only what this browser has seen. Empty stays empty — a plan this browser has not seen change says nothing rather than inventing a time for it.

## The panel around them

- **The Offline mode switch carries the `fa-plane`** the connection chip directly above it already wears for that state, so the toggle and the state it causes match. The label moves from the `label` prop to the `#label` slot, the pattern `PlanChooserDialog.vue` already uses.
- **The switch is back in the tray's left column.** Vuetify draws its thumb 6px left of the control's own box so the thumb can overhang as it slides, which left it as the one thing in the panel poking out of the column every other element starts at (measured: everything at x=42, the thumb at 36).
- **My Plans / Joined Plans were `text-body-2` (14px)** — *smaller* than the 16px plan names beneath them, so each heading read as one more plan in the list. They are `text-h6` (20px) now. The weight is set in a scoped rule rather than by `font-weight-bold`: `text-h6` carries its own `font-weight: 400 !important`, which beats the utility class, so the old markup's `font-weight-bold` was silently doing nothing.
- **Each heading wears the tab bar's own icon for that kind of plan** — a cloud for synced, a group of people for collaborative, taken from `TabNavigation.vue` rather than invented here. Fixed-width, so both headings start their text at the same x.

Every colour resolves through `--sf-*` from `web/src/utils/colors.ts`; no new literal hex.

## Verification

- `cd web && pnpm exec vitest run sync/` — **26 files, 600 tests passing**. `AccountPanel.spec.ts` gains assertions for the switch's icon, both headings' size and icons, the card layout (title over readouts, toggle beside both), the count chip's token, the open/hidden border state, and the local last-changed line in both its states.
- `pnpm lint` clean, `vue-tsc --noEmit` clean.
- Both tabs and both of `CloudPlanRow`'s sizes were rendered in a real browser and **measured**, not eyeballed: the toggle's centre sits on the card's centre; open cards compute `rgb(33, 150, 243)` and hidden ones `rgb(108, 108, 108)`; no card overflows at either the ~370px tray width or the 560px dialog width.

E2E (`pnpm test:e2e`) was not run locally. It touches this markup only through the `offline-switch` and `account-panel` test IDs, both unchanged.

## A note on CI

`Build & Test Web` has gone red on several commits here with **every test passing** — vitest exits 1 on one unhandled error thrown outside any test. That is a pre-existing flake, not this PR's: the same check is red the same way on `main` at `8651b8c`, the commit this branch is based on ([run #1463](https://github.com/satisfactory-factories/application/actions/runs/34392596316)), and each occurrence names a different "last documented test" inside `TabSettingsDialog.spec.ts` — which is what a race looks like rather than a failing assertion. Full diagnosis in [this comment](https://github.com/satisfactory-factories/application/pull/680#issuecomment-5608488372); it wants its own PR against `main` rather than widening this one.

No `CHANGELOG.md` entry: the account panel is described there under the in-development Beta v0.7 section, and nothing in that description is contradicted by a cosmetic change to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLWMwZj5gBFtviE5qEthuV