### PR TITLE
test(web): drive the raw-migration harness through RawMigrationPrompt

### DIFF
--- a/web/testing/browser/migration.e2e.mjs
+++ b/web/testing/browser/migration.e2e.mjs
@@ -1,10 +1,22 @@
 // The pre-v0.6 migration, end to end and in a real browser: a returning user with a plan built
-// before extraction existed is met by the v0.6 deck, runs the wizard from it, and comes back to
-// the deck with a plan that is actually fixed. Run the dev server first, then:
-//   node testing/browser/migration.e2e.mjs
+// before extraction existed is met by the raw-resources notice, runs the wizard from it, and is
+// left with a plan that is actually fixed.
+//
+// The notice is `components/planner/RawMigrationPrompt.vue`, raised off `showRawBreakingNotice`
+// in the app store and answered — either way — by `dismissRawBreakingNotice()`, which stamps
+// `plannerVersion` on the tab. Answering therefore belongs to the PLAN, not to the browser, so
+// every scenario here re-arms by seeding an unstamped plan rather than by clearing a flag.
+//
+// The v0.6 deck still takes the notice over on the one load where it auto-shows (see the last
+// scenario); everywhere else `seenV6Splash` is seeded so the notice speaks for itself.
+//
+// Run the dev server first, then:
+//   cd web && VITE_ENV=dev pnpm exec vite --port 3005 --strictPort
+//   PORT=3005 node testing/browser/migration.e2e.mjs
 import puppeteer from 'puppeteer-core'
 
 const BASE = `http://localhost:${process.env.PORT || 3000}`
+const CHROMIUM = process.env.CHROMIUM || '/usr/bin/chromium'
 const results = []
 const check = (name, pass, detail = '') => {
   results.push({ name, pass, detail })
@@ -12,22 +24,33 @@ const check = (name, pass, detail = '') => {
 }
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
+// Fixed sleeps went stale as the load got slower: poll instead, so a busy machine costs time
+// rather than a false failure.
+const waitFor = async (predicate, timeout = 20000) => {
+  const deadline = Date.now() + timeout
+  for (;;) {
+    if (await predicate()) return true
+    if (Date.now() > deadline) return false
+    await sleep(250)
+  }
+}
+
 const browser = await puppeteer.launch({
-  executablePath: process.env.CHROMIUM || '/usr/bin/chromium',
+  executablePath: CHROMIUM,
   headless: 'new',
-  args: ['--disable-background-timer-throttling', '--window-size=1600,1200'],
+  args: [
+    '--no-sandbox',
+    '--disable-background-timer-throttling',
+    '--disable-renderer-backgrounding',
+    '--disable-backgrounding-occluded-windows',
+    '--window-size=1600,1200',
+  ],
   defaultViewport: { width: 1600, height: 1200 },
 })
-const page = await browser.newPage()
-const errors = []
-page.on('pageerror', e => errors.push(String(e)))
-page.on('console', m => { if (m.type() === 'error' && !m.text().includes('Failed to load resource')) errors.push(m.text()) })
-const notFound = []
-page.on('response', r => { if (r.status() === 404) notFound.push(r.url()) })
 
 // Clicked in-page rather than through the mouse: dialogs scroll their own container, so a real
 // mouse click misses anything below the fold.
-const clickByText = async (selector, text) => page.evaluate((sel, t) => {
+const click = (p, selector, text) => p.evaluate((sel, t) => {
   const el = [...document.querySelectorAll(sel)].find(e =>
     e.textContent.trim().includes(t) && e.offsetParent !== null)
   if (!el) return false
@@ -35,94 +58,154 @@ const clickByText = async (selector, text) => page.evaluate((sel, t) => {
   return true
 }, selector, text)
 
-const closeAnyOverlay = async () => {
-  await page.evaluate(() => {
-    const btn = [...document.querySelectorAll('.v-overlay__content .v-card-title .v-btn')].pop()
-    btn?.click()
-  })
-  await sleep(400)
-}
-
-const splashState = () => page.evaluate(() => {
-  const dialogs = [...document.querySelectorAll('.v-overlay__content .v-card')]
-  const splash = dialogs.find(d => d.textContent.includes("What's new in Beta v0.6"))
-  if (!splash) return { open: false }
-  const counter = splash.querySelector('.slide-counter')?.textContent?.trim() ?? ''
+// Everything the notice puts in front of the user. Matched on its own heading rather than on
+// "Action needed", which is only the kicker above it and is a phrase the v0.6 deck uses too.
+const promptStateOf = p => p.evaluate(() => {
+  const card = [...document.querySelectorAll('.v-overlay__content .v-card')]
+    .find(d => d.textContent.includes('Raw resource migration required'))
+  if (!card || card.offsetParent === null) return { open: false }
+  const label = el => el.textContent.replace(/\s+/g, ' ').trim()
   return {
     open: true,
-    slide: counter,
-    hasClose: !!splash.querySelector('.v-card-title .v-btn'),
-    banner: splash.textContent.includes('Action needed'),
-    wizardBtn: splash.textContent.includes('Run the wizard'),
-    scrollTop: splash.querySelector('.v-card-text')?.scrollTop ?? -1,
+    headline: label(card.querySelector('.action-headline') ?? card),
+    heading: label(card.querySelector('h3') ?? card),
+    wizardBtn: !!card.querySelector('#raw-notice-wizard'),
+    dismissBtn: !!card.querySelector('#raw-notice-dismiss'),
+    // The notice is deliberately not persistent: closing it has to leave a usable plan.
+    closable: !!card.querySelector('.v-card-title .app-dialog-close'),
+    examples: [...card.querySelectorAll('.v-btn')].map(label)
+      .filter(t => ['Miners', 'Resource wells', 'Water'].includes(t)),
+    image: card.querySelector('img')?.getAttribute('src') ?? '',
   }
 })
 
-// Matched on the dialog's own title, not anywhere in its text: slide 1 of the deck names the
-// wizard too, so a body-text match reports the deck as the wizard.
-const wizardOpen = () => page.evaluate(() =>
+// Matched on the dialog's own title, not anywhere in its text: the notice names the wizard too,
+// so a body-text match reports the notice as the wizard.
+const wizardOpenOn = p => p.evaluate(() =>
   [...document.querySelectorAll('.v-overlay__content .v-card .v-card-title')].some(t =>
     t.textContent.includes('Raw Resources Wizard') && t.offsetParent !== null))
 
-// --- 1. Put a pre-v0.6 plan in local storage, the way a returning user already has one. The
-// template is loaded first and left unanswered, then the deck is re-armed and the page reloaded:
-// that is the real entry point, a legacy plan present before the app boots.
-await page.goto(BASE, { waitUntil: 'networkidle2' })
-await page.evaluate(() => {
+const deckOpenOn = p => p.evaluate(() =>
+  [...document.querySelectorAll('.v-overlay__content .v-card')].some(d =>
+    d.querySelector('.v-card-title')?.textContent.includes("What's new in Beta v0.6") &&
+    d.offsetParent !== null))
+
+const tabsOf = p => p.evaluate(() => {
+  const tabs = JSON.parse(localStorage.getItem('factoryTabs') || '[]')
+  return tabs.map(t => ({
+    name: t.name,
+    plannerVersion: t.plannerVersion ?? null,
+    factories: (t.factories ?? []).length,
+  }))
+})
+
+// --- The plan under test: the #503 template, loaded once through the UI the way it ships, then
+// stripped of its stamp. Every scenario below is booted from this rather than re-driving the
+// sidebar, so each one starts from an identical pre-v0.6 plan.
+const capturePage = await browser.newPage()
+await capturePage.goto(BASE, { waitUntil: 'networkidle2' })
+await capturePage.evaluate(() => {
+  localStorage.clear()
   localStorage.setItem('dismissed-introduction', 'true')
-  localStorage.removeItem('seenV6Splash')
+  localStorage.setItem('seenV51Splash', 'true')
+  localStorage.setItem('seenV6Splash', 'true')
 })
-await page.goto(BASE, { waitUntil: 'networkidle2' })
-await sleep(2500)
-if ((await splashState()).open) await closeAnyOverlay()
-
-await clickByText('.v-btn', 'Templates')
+await capturePage.goto(BASE, { waitUntil: 'networkidle2' })
+await waitFor(() => capturePage.evaluate(() => !!document.querySelector('.v-btn')))
+await click(capturePage, '.v-btn', 'Templates')
 await sleep(700)
-const loaded = await clickByText('.v-btn', '#503: Pre-mining plan')
+const loaded = await click(capturePage, '.v-btn', '#503: Pre-mining plan')
 check('the #503 template button is reachable', loaded)
-await sleep(4000)
-await page.evaluate(() => localStorage.removeItem('seenV6Splash'))
+await waitFor(() => capturePage.evaluate(() =>
+  (JSON.parse(localStorage.getItem('factoryTabs') || '[]')[0]?.factories ?? []).length > 0))
+const captured = await capturePage.evaluate(() =>
+  JSON.parse(localStorage.getItem('factoryTabs') || '[]')[0] ?? null)
+check('the template is a plan the change can have broken',
+  (captured?.factories?.length ?? 0) > 0 && !captured?.plannerVersion,
+  JSON.stringify({ factories: captured?.factories?.length, plannerVersion: captured?.plannerVersion ?? null }))
+await capturePage.close()
 
-const stored = await page.evaluate(() => {
-  const raw = JSON.parse(localStorage.getItem('factoryTabs') || '{}')
-  const tab = Object.values(raw.tabs ?? raw)[0] ?? {}
-  return { plannerVersion: tab.plannerVersion ?? null, factories: (tab.factories ?? []).length }
-})
-check('the stored plan is unstamped, as a pre-v0.6 plan is', stored.plannerVersion === null, JSON.stringify(stored))
+const legacyTab = JSON.parse(JSON.stringify(captured))
+delete legacyTab.plannerVersion
 
-// --- 2. Boot with that plan present: this is what a returning user gets.
+// Seeded before the app boots rather than written into a live page: the planner persists its
+// in-memory plan on `pagehide`, so anything written to local storage from a loaded page is
+// clobbered by the navigation that was meant to pick it up.
+const newPage = async ({ tabs = [legacyTab], index = 0, deckSeen = true } = {}) => {
+  const p = await browser.newPage()
+  p.on('dialog', d => { console.log('   DIALOG', d.type(), d.message().slice(0, 100)); d.accept().catch(() => {}) })
+  p.on('pageerror', e => console.log('   PAGEERROR', String(e).slice(0, 160)))
+  await p.evaluateOnNewDocument((seed, i, seen) => {
+    // Fires on every navigation, and a reload here is a scenario in its own right — a second
+    // seeding would answer the question the reload is asking. Sentinel in sessionStorage, which
+    // survives the reload but not the tab.
+    if (sessionStorage.getItem('migration-e2e-seeded')) return
+    sessionStorage.setItem('migration-e2e-seeded', 'true')
+    localStorage.setItem('dismissed-introduction', 'true')
+    localStorage.setItem('seenV51Splash', 'true')
+    if (seen) localStorage.setItem('seenV6Splash', 'true')
+    else localStorage.removeItem('seenV6Splash')
+    localStorage.setItem('factoryTabs', JSON.stringify(seed))
+    localStorage.setItem('currentFactoryTabIndex', String(i))
+  }, tabs, index, deckSeen)
+  return p
+}
+
+const bootLegacyPlan = async (options = {}) => {
+  const p = await newPage(options)
+  await p.goto(BASE + (options.path ?? '/'), { waitUntil: 'networkidle2' })
+  return p
+}
+
+// ============================================================================
+// 1. A returning user opens the planner with a pre-v0.6 plan already in local storage.
+const page = await bootLegacyPlan()
+const errors = []
+page.on('pageerror', e => errors.push(String(e)))
+page.on('console', m => { if (m.type() === 'error' && !m.text().includes('Failed to load resource')) errors.push(m.text()) })
+const notFound = []
+page.on('response', r => { if (r.status() === 404) notFound.push(r.url()) })
+
+check('the notice speaks for a plan built before extraction existed',
+  await waitFor(async () => (await promptStateOf(page)).open))
+const state = await promptStateOf(page)
+check('it leads on the action needed, about this plan', state.headline === 'Action needed', state.headline)
+check('and names the migration', state.heading === 'Raw resource migration required', state.heading)
+check('it offers the wizard', state.wizardBtn)
+check('and the answer that is not the wizard', state.dismissBtn)
+check('it can be closed, since dismissing leaves a usable plan', state.closable)
+check('it shows what extraction looks like', state.examples.join(', ') === 'Miners, Resource wells, Water', state.examples.join(', '))
+check('it opens on the miners example', state.image.includes('miners'), state.image)
+
+// The examples are the notice's one moving part.
+await click(page, '.v-btn', 'Resource wells')
+await sleep(400)
+check('picking another example swaps the picture',
+  (await promptStateOf(page)).image.includes('resource-well'), (await promptStateOf(page)).image)
+
+// The deck is spent, so nothing is stacked in front of the notice.
+check('the deck is not stacked over it', (await deckOpenOn(page)) === false)
+
+// --- 2. Leaving without answering asks again on the next load: the plan is still unanswered.
 await page.reload({ waitUntil: 'networkidle2' })
-await sleep(4000)
+check('leaving without answering asks again next load',
+  await waitFor(async () => (await promptStateOf(page)).open))
 
-// --- 3. The deck should take over, locked, with the banner and the wizard offer.
-let state = await splashState()
-check('the v6 deck opens after the legacy plan loads', state.open, JSON.stringify(state))
-check('it opens on slide 1', state.slide === '1 / 7', state.slide)
-check('it carries the action-needed banner', !!state.banner)
-check('it offers the wizard', !!state.wizardBtn)
-check('it has no close button while unanswered', state.hasClose === false)
-
-// The migration prompt must not be stacked behind it.
-const promptToo = await page.evaluate(() =>
-  [...document.querySelectorAll('.v-overlay__content .v-card')].filter(d =>
-    d.textContent.includes('Raw resource migration required')).length)
-check('the notice is not stacked behind the deck', promptToo === 0, `${promptToo} notices`)
-
-// --- 4. Run the wizard from the deck.
-const ranWizard = await clickByText('.v-btn', 'Run the wizard')
+// --- 3. Run the wizard from the notice.
+const ranWizard = await click(page, '.v-btn', 'Run the wizard')
 check('the Run the wizard button clicks', ranWizard)
-await sleep(2500)
-check('the deck steps aside', (await splashState()).open === false)
-check('the wizard opens', await wizardOpen())
+check('the notice steps aside', await waitFor(async () => (await promptStateOf(page)).open === false))
+check('the wizard opens', await waitFor(() => wizardOpenOn(page)))
 
-// --- 5. Apply it.
+// --- 4. Apply it.
 const rowInfo = await page.evaluate(() => {
-  const card = [...document.querySelectorAll('.v-overlay__content .v-card')].find(d => d.querySelector('.v-card-title')?.textContent.includes('Raw Resources Wizard'))
+  const card = [...document.querySelectorAll('.v-overlay__content .v-card')]
+    .find(d => d.querySelector('.v-card-title')?.textContent.includes('Raw Resources Wizard'))
   return { rows: card?.querySelectorAll('tbody tr').length ?? 0, nothingToFix: !!card?.textContent.includes('Nothing to fix') }
 })
 check('the wizard has rows to fix', rowInfo.rows > 0 && !rowInfo.nothingToFix, JSON.stringify(rowInfo))
 
-const reviewed = await clickByText('.v-card-actions .v-btn', 'Review')
+const reviewed = await click(page, '.v-card-actions .v-btn', 'Review')
 check('Review clicks', reviewed)
 await sleep(1500)
 const summary = await page.evaluate(() => {
@@ -130,49 +213,15 @@ const summary = await page.evaluate(() => {
   return (card?.textContent || '').replace(/\s+/g, ' ').match(/This will:.{0,200}/)?.[0] ?? ''
 })
 console.log('      summary:', summary)
-const applied = await clickByText('.v-card-actions .v-btn', 'Apply')
+const applied = await click(page, '.v-card-actions .v-btn', 'Apply')
 check('Apply clicks', applied)
-await sleep(8000)
+check('the wizard closes once applied', await waitFor(async () => (await wizardOpenOn(page)) === false, 30000))
+await sleep(3000)
 
-// --- 6. The deck comes back where it left off, now closable.
-state = await splashState()
-check('the deck returns after the wizard closes', state.open, JSON.stringify(state))
-check('it returns to the slide it left', state.slide === '1 / 7', state.slide)
-check('it is closable now the question is answered', state.hasClose === true)
-check('the wizard is gone', (await wizardOpen()) === false)
-
-// --- 7. Walk the deck: scroll resets between slides, and it ends on Got it!
-await page.evaluate(() => {
-  const body = [...document.querySelectorAll('.v-overlay__content .v-card')]
-    .find(d => d.textContent.includes("What's new in Beta v0.6"))?.querySelector('.v-card-text')
-  if (body) body.scrollTop = body.scrollHeight
-})
-await sleep(300)
-const scrolledBefore = (await splashState()).scrollTop
-await clickByText('.v-card-actions .v-btn', 'Mining')
-await sleep(600)
-state = await splashState()
-check('the next slide opens at the top', state.scrollTop === 0, `was ${scrolledBefore}, now ${state.scrollTop}`)
-
-// The Next / Got it! button is the last action on every slide.
-const slidesSeen = []
-for (let i = 0; i < 8 && (await splashState()).open; i++) {
-  slidesSeen.push((await splashState()).slide)
-  await page.evaluate(() => {
-    const card = [...document.querySelectorAll('.v-overlay__content .v-card')]
-      .find(d => d.textContent.includes("What's new in Beta v0.6"))
-    const btns = [...(card?.querySelectorAll('.v-card-actions .v-btn') ?? [])]
-    btns[btns.length - 1]?.click()
-  })
-  await sleep(600)
-}
-console.log('      slides walked:', slidesSeen.join(' -> '))
-check('the deck can be walked to the end and closed', (await splashState()).open === false)
-
-// --- 8. The plan is actually fixed.
+// --- 5. The plan is actually fixed.
 const planState = await page.evaluate(() => {
-  const raw = JSON.parse(localStorage.getItem('factoryTabs') || '{}')
-  const tab = Object.values(raw.tabs ?? raw)[0] ?? {}
+  const tabs = JSON.parse(localStorage.getItem('factoryTabs') || '[]')
+  const tab = tabs[Number(localStorage.getItem('currentFactoryTabIndex') ?? 0)] ?? {}
   const factories = tab.factories ?? []
   return {
     plannerVersion: tab.plannerVersion ?? null,
@@ -184,187 +233,117 @@ const planState = await page.evaluate(() => {
   }
 })
 check('the plan is stamped as answered', planState.plannerVersion !== null, String(planState.plannerVersion))
+check('the wizard built the mines it promised', planState.factories > (captured.factories?.length ?? 0),
+  `${captured.factories?.length} -> ${planState.factories}`)
 check('no factory is left with a problem', planState.problems.length === 0, planState.problems.join(', '))
 check('nothing is still supplied out of thin air', planState.rawSupplied.length === 0, planState.rawSupplied.join(', '))
 
-// --- 9. A reload does not re-open the deck or the notice.
+// --- 6. A reload does not raise it again.
 await page.reload({ waitUntil: 'networkidle2' })
-await sleep(3500)
-check('the deck stays shut on the next load', (await splashState()).open === false)
-const noticeBack = await page.evaluate(() =>
-  [...document.querySelectorAll('.v-overlay__content .v-card')].some(d => d.textContent.includes('Raw resource migration required')))
-check('the notice does not come back', noticeBack === false)
+await sleep(4000)
+check('the notice does not come back', (await promptStateOf(page)).open === false)
 
 check('no page errors', errors.length === 0, errors.slice(0, 3).join(' | '))
 const missing = [...new Set(notFound)].filter(u => !u.includes(':3001'))
 check('nothing 404s', missing.length === 0, missing.slice(0, 5).join(' | '))
+await page.close()
 
-// ---- Edge cases, each on its own page so one cannot leave state for the next.
-const newPage = async () => {
-  const p = await browser.newPage()
-  p.on('pageerror', e => console.log('   PAGEERROR', String(e).slice(0, 160)))
-  return p
-}
-const click = (p, sel, text) => p.evaluate((s, t) => {
-  const el = [...document.querySelectorAll(s)].find(e => e.textContent.trim().includes(t) && e.offsetParent !== null)
-  if (!el) return false
-  el.click()
-  return true
-}, sel, text)
-const splashStateOf = p => p.evaluate(() => {
-  const splash = [...document.querySelectorAll('.v-overlay__content .v-card')]
-    .find(d => d.querySelector('.v-card-title')?.textContent.includes("What's new in Beta v0.6"))
-  if (!splash || splash.offsetParent === null) return { open: false }
-  return {
-    open: true,
-    slide: splash.querySelector('.slide-counter')?.textContent?.trim() ?? '',
-    hasClose: !!splash.querySelector('.v-card-title .v-btn'),
-    banner: splash.textContent.includes('Action needed'),
-  }
-})
-const wizardOpenOn = p => p.evaluate(() =>
-  [...document.querySelectorAll('.v-overlay__content .v-card .v-card-title')]
-    .some(t => t.textContent.includes('Raw Resources Wizard') && t.offsetParent !== null))
+// ============================================================================
+// Each scenario below boots its own page, so one cannot leave state for the next.
 
-// Puts an unanswered pre-v0.6 plan in local storage and boots the app with it present.
-const seedLegacyPlan = async (p, startPath = '/') => {
-  await p.goto(BASE, { waitUntil: 'networkidle2' })
-  await p.evaluate(() => {
-    localStorage.clear()
-    localStorage.setItem('dismissed-introduction', 'true')
-  })
-  await p.goto(BASE, { waitUntil: 'networkidle2' })
-  await sleep(2500)
-  await p.evaluate(() => {
-    const b = [...document.querySelectorAll('.v-overlay__content .v-card-title .v-btn')].pop()
-    b?.click()
-  })
-  await sleep(500)
-  await click(p, '.v-btn', 'Templates')
-  await sleep(700)
-  await click(p, '.v-btn', '#503: Pre-mining plan')
-  await sleep(4000)
-  await p.evaluate(() => localStorage.removeItem('seenV6Splash'))
-  await p.goto(BASE + startPath, { waitUntil: 'networkidle2' })
-  await sleep(4000)
-}
-
-// --- Edge 1: the deck locks on a page that does not mount the wizard.
+// --- "I'll sort it myself": an answer, not a fix.
 {
-  const page = await newPage()
-  await seedLegacyPlan(page, '/changelog')
-  const state = await splashStateOf(page)
-  console.log('      deck on /changelog:', JSON.stringify(state))
-  // Landing straight on another page must not spend the one-time showing.
-  check('[changelog] nothing is marked seen off the planner',
-    (await page.evaluate(() => localStorage.getItem('seenV6Splash'))) === null)
-  await page.evaluate(() => {
+  const p = await bootLegacyPlan()
+  await waitFor(async () => (await promptStateOf(p)).open)
+  await click(p, '.v-btn', "I'll sort it myself")
+  check('[decline] the notice closes', await waitFor(async () => (await promptStateOf(p)).open === false))
+  await sleep(1500)
+  const tabs = await tabsOf(p)
+  check('[decline] the plan counts as answered', tabs[0]?.plannerVersion !== null, JSON.stringify(tabs))
+  check('[decline] but is left exactly as it was, unfixed',
+    tabs[0]?.factories === legacyTab.factories.length, `${tabs[0]?.factories} factories`)
+  await p.reload({ waitUntil: 'networkidle2' })
+  await sleep(4000)
+  check('[decline] and is not nagged about again', (await promptStateOf(p)).open === false)
+  await p.close()
+}
+
+// --- Closing it in the corner is the same answer as saying so.
+{
+  const p = await bootLegacyPlan()
+  await waitFor(async () => (await promptStateOf(p)).open)
+  await p.evaluate(() => {
+    const card = [...document.querySelectorAll('.v-overlay__content .v-card')]
+      .find(d => d.textContent.includes('Raw resource migration required'))
+    card?.querySelector('.v-card-title .app-dialog-close')?.click()
+  })
+  check('[close] the X closes it', await waitFor(async () => (await promptStateOf(p)).open === false))
+  await sleep(1500)
+  check('[close] and answers for the plan', (await tabsOf(p))[0]?.plannerVersion !== null,
+    JSON.stringify(await tabsOf(p)))
+  await p.close()
+}
+
+// --- Cancelling the wizard rather than applying. Opening it was already the answer, so the plan
+// is stamped either way — the notice must not come back to ask a question it has been given.
+{
+  const p = await bootLegacyPlan()
+  await waitFor(async () => (await promptStateOf(p)).open)
+  await click(p, '.v-btn', 'Run the wizard')
+  check('[cancel] the wizard is open', await waitFor(() => wizardOpenOn(p)))
+  await click(p, '.v-card-actions .v-btn', 'Cancel')
+  check('[cancel] the wizard closes', await waitFor(async () => (await wizardOpenOn(p)) === false))
+  await sleep(1500)
+  check('[cancel] the notice does not reappear behind it', (await promptStateOf(p)).open === false)
+  check('[cancel] the plan counts as answered, not as fixed', (await tabsOf(p))[0]?.plannerVersion !== null,
+    JSON.stringify(await tabsOf(p)))
+  await p.close()
+}
+
+// --- Landing somewhere other than the planner. The notice is mounted by the planner's tab bar,
+// so it has nothing to say on /changelog — and, because the answer lives on the plan rather than
+// in a one-time flag, nothing is spent by not saying it. The warning still finds them.
+{
+  const p = await bootLegacyPlan({ path: '/changelog' })
+  await sleep(4000)
+  check('[changelog] the notice holds off away from the planner', (await promptStateOf(p)).open === false)
+  check('[changelog] and nothing is answered on the plan\'s behalf',
+    (await tabsOf(p))[0]?.plannerVersion === null, JSON.stringify(await tabsOf(p)))
+  await p.evaluate(() => {
     const link = [...document.querySelectorAll('a')].find(a => a.getAttribute('href') === '/')
     if (link) link.click()
     else window.location.href = '/'
   })
-  await sleep(5000)
-  const onPlanner = await splashStateOf(page)
-  check('[changelog] the warning still finds them on the planner', onPlanner.open && onPlanner.banner, JSON.stringify(onPlanner))
-  await page.close()
+  check('[changelog] the warning still finds them on the planner',
+    await waitFor(async () => (await promptStateOf(p)).open))
+  await p.close()
 }
 
-// --- Edge 2: the tab is closed on the locked slide without answering.
+// --- A second pre-v0.6 plan in another tab, after the first has been answered. The answer belongs
+// to the plan, so the one that has not been asked about still gets its warning.
 {
-  const page = await newPage()
-  await seedLegacyPlan(page)
-  check('[reload] the deck is locked to begin with', (await splashStateOf(page)).hasClose === false)
-  await page.reload({ waitUntil: 'networkidle2' })
-  await sleep(4500)
-  const state = await splashStateOf(page)
-  check('[reload] leaving without answering asks again next load', state.open && state.banner && state.hasClose === false, JSON.stringify(state))
-  await page.close()
+  const answered = JSON.parse(JSON.stringify(legacyTab))
+  answered.plannerVersion = '0.6'
+  const second = JSON.parse(JSON.stringify(legacyTab))
+  second.id = 'second-tab'
+  second.name = 'Second legacy plan'
+  const p = await bootLegacyPlan({ tabs: [answered, second], index: 1 })
+  check('[second plan] the notice speaks for a plan that was never asked about',
+    await waitFor(async () => (await promptStateOf(p)).open), JSON.stringify(await tabsOf(p)))
+  await p.close()
 }
 
-// --- Edge 3: cancelling the wizard rather than applying.
+// --- The one load the notice does not own. The v0.6 deck still auto-shows for a user who has not
+// seen it, and takes the warning over rather than queueing behind it — slide 1 IS this warning,
+// with the wizard attached. The notice must not be stacked underneath.
 {
-  const page = await newPage()
-  await seedLegacyPlan(page)
-  await click(page, '.v-btn', 'Run the wizard')
-  await sleep(2500)
-  check('[cancel] the wizard is open', await wizardOpenOn(page))
-  await click(page, '.v-card-actions .v-btn', 'Cancel')
-  await sleep(2000)
-  const state = await splashStateOf(page)
-  check('[cancel] the deck still comes back', state.open, JSON.stringify(state))
-  check('[cancel] and is closable, the question having been answered', state.hasClose === true)
-  const stamped = await page.evaluate(() => {
-    const raw = JSON.parse(localStorage.getItem('factoryTabs') || '{}')
-    const tab = Object.values(raw.tabs ?? raw)[0] ?? {}
-    return tab.plannerVersion ?? null
-  })
-  check('[cancel] the plan counts as answered, not as fixed', stamped !== null, String(stamped))
-  await page.close()
-}
-
-// --- Edge 4: "I'll sort it myself".
-{
-  const page = await newPage()
-  await seedLegacyPlan(page)
-  await click(page, '.v-btn', "I'll sort it myself")
-  await sleep(1000)
-  const state = await splashStateOf(page)
-  check('[decline] the deck stays open, and unlocks', state.open && state.hasClose === true, JSON.stringify(state))
-  for (let i = 0; i < 8 && (await splashStateOf(page)).open; i++) {
-    await page.evaluate(() => {
-      const card = [...document.querySelectorAll('.v-overlay__content .v-card')]
-        .find(d => d.querySelector('.v-card-title')?.textContent.includes("What's new in Beta v0.6"))
-      const btns = [...(card?.querySelectorAll('.v-card-actions .v-btn') ?? [])]
-      btns[btns.length - 1]?.click()
-    })
-    await sleep(500)
-  }
-  check('[decline] the tour can be walked out of', (await splashStateOf(page)).open === false)
-  await page.reload({ waitUntil: 'networkidle2' })
-  await sleep(4500)
-  const back = await splashStateOf(page)
-  const noticeBack = await page.evaluate(() =>
-    [...document.querySelectorAll('.v-overlay__content .v-card')].some(d =>
-      d.textContent.includes('Raw resource migration required') && d.offsetParent !== null))
-  check('[decline] neither the deck nor the notice nags again', back.open === false && !noticeBack,
-    `deck ${back.open}, notice ${noticeBack}`)
-  await page.close()
-}
-
-// --- Edge 5: a second legacy plan in another tab, after the deck has been seen.
-{
-  const page = await newPage()
-  await seedLegacyPlan(page)
-  await click(page, '.v-btn', "I'll sort it myself")
-  await sleep(800)
-  await page.evaluate(() => {
-    const b = [...document.querySelectorAll('.v-overlay__content .v-card-title .v-btn')].pop()
-    b?.click()
-  })
-  await sleep(800)
-  // A fresh tab carrying another pre-v0.6 plan: the deck is spent, so the notice must speak.
-  await page.evaluate(() => {
-    const tabs = JSON.parse(localStorage.getItem('factoryTabs') || '[]')
-    const copy = JSON.parse(JSON.stringify(tabs[0]))
-    copy.id = 'second-tab'
-    copy.name = 'Second legacy plan'
-    delete copy.plannerVersion
-    tabs.push(copy)
-    localStorage.setItem('factoryTabs', JSON.stringify(tabs))
-    localStorage.setItem('currentFactoryTabIndex', String(tabs.length - 1))
-  })
-  await page.reload({ waitUntil: 'networkidle2' })
-  await sleep(4500)
-  const noticeShown = await page.evaluate(() =>
-    [...document.querySelectorAll('.v-overlay__content .v-card')].some(d =>
-      d.textContent.includes('Raw resource migration required') && d.offsetParent !== null))
-  const tabInfo = await page.evaluate(() => {
-    const tabs = JSON.parse(localStorage.getItem('factoryTabs') || '[]')
-    const i = Number(localStorage.getItem('currentFactoryTabIndex') ?? 0)
-    return { tabs: tabs.length, current: i, name: tabs[i]?.name, version: tabs[i]?.plannerVersion ?? null }
-  })
-  check('[second plan] the notice speaks for a plan the deck never covered', noticeShown, JSON.stringify(tabInfo))
-  await page.close()
+  const p = await bootLegacyPlan({ deckSeen: false })
+  check('[deck] the v0.6 deck takes the warning over on its one showing',
+    await waitFor(() => deckOpenOn(p)))
+  check('[deck] and the notice is not stacked behind it', (await promptStateOf(p)).open === false)
+  check('[deck] the plan is left unanswered until the deck is answered',
+    (await tabsOf(p))[0]?.plannerVersion === null, JSON.stringify(await tabsOf(p)))
+  await p.close()
 }
 
 await browser.close()

--- a/web/testing/browser/migration.e2e.mjs
+++ b/web/testing/browser/migration.e2e.mjs
@@ -7,8 +7,9 @@
 // `plannerVersion` on the tab. Answering therefore belongs to the PLAN, not to the browser, so
 // every scenario here re-arms by seeding an unstamped plan rather than by clearing a flag.
 //
-// The v0.6 deck still takes the notice over on the one load where it auto-shows (see the last
-// scenario); everywhere else `seenV6Splash` is seeded so the notice speaks for itself.
+// On the one load where the v0.6 release deck auto-shows it takes the notice over, so the last
+// scenario asserts only what holds whichever of the two speaks; everywhere else `seenV6Splash`
+// is seeded so the notice speaks for itself.
 //
 // Run the dev server first, then:
 //   cd web && VITE_ENV=dev pnpm exec vite --port 3005 --strictPort
@@ -333,15 +334,22 @@ await page.close()
   await p.close()
 }
 
-// --- The one load the notice does not own. The v0.6 deck still auto-shows for a user who has not
-// seen it, and takes the warning over rather than queueing behind it — slide 1 IS this warning,
-// with the wizard attached. The notice must not be stacked underneath.
+// --- The first load, before the release deck has been seen. The v0.6 deck currently auto-shows
+// here and takes the warning over rather than queueing behind it — slide 1 IS this warning, with
+// the wizard attached — so the notice must not be stacked underneath. Once the deck becomes
+// manual-only the notice speaks here itself. Asserted as the invariant that holds either way:
+// exactly one of the two puts the warning in front of the user, and whichever it is, the plan is
+// left unanswered until it is answered.
 {
   const p = await bootLegacyPlan({ deckSeen: false })
-  check('[deck] the v0.6 deck takes the warning over on its one showing',
-    await waitFor(() => deckOpenOn(p)))
-  check('[deck] and the notice is not stacked behind it', (await promptStateOf(p)).open === false)
-  check('[deck] the plan is left unanswered until the deck is answered',
+  check('[first load] the warning is raised',
+    await waitFor(async () => (await deckOpenOn(p)) || (await promptStateOf(p)).open))
+  const byDeck = await deckOpenOn(p)
+  const byNotice = (await promptStateOf(p)).open
+  console.log(`      raised by: ${byDeck ? 'the v0.6 deck, which still takes it over' : 'RawMigrationPrompt'}`)
+  check('[first load] by one of the deck and the notice, never both', byDeck !== byNotice,
+    `deck ${byDeck}, notice ${byNotice}`)
+  check('[first load] and the plan is left unanswered until it is answered',
     (await tabsOf(p))[0]?.plannerVersion === null, JSON.stringify(await tabsOf(p)))
   await p.close()
 }


### PR DESCRIPTION
## What

`web/testing/browser/migration.e2e.mjs` asserted the pre-v0.6 raw-resources migration entirely through the v0.6 release deck. The deck only carries that warning on the one load where it auto-shows; every other route to it is `RawMigrationPrompt.vue`, which is what the app store's `showRawBreakingNotice` actually raises. This rewrites the harness around the prompt.

- **`promptState()` replaces `splashState()`**, reading what the prompt genuinely renders: the "Action needed" kicker, the "Raw resource migration required" heading, `#raw-notice-wizard` / `#raw-notice-dismiss`, the close button, the three extraction examples, and the picture swapping when one is picked.
- **Re-arming is per plan, not per browser.** `dismissRawBreakingNotice()` stamps `plannerVersion` on the tab, so every scenario now boots from an unstamped plan seeded with `page.evaluateOnNewDocument()` rather than clearing `seenV6Splash`. The `#503: Pre-mining plan` template is still the vehicle — it is loaded once through the sidebar and captured, then each scenario boots from that same plan.
- **Polled waits replace fixed sleeps**, so a slow template load costs time rather than failing the run.
- **The wizard half is kept end to end**: run it from the notice, review, apply, and confirm the plan is stamped, has grown its mine factories, has no factory left with a problem, and nothing still supplied out of thin air.
- `--no-sandbox` plus the anti-throttling flags, matching the other harnesses in this directory.

## Two real defects fixed along the way

- **The second-plan case hung the run.** It wrote `factoryTabs` into a live page and reloaded; the planner persists its in-memory plan on `pagehide`, so the write was clobbered and the reload landed on `currentFactoryTabIndex` pointing past the end — the SAFE MODE `alert()`, which blocks navigation and timed the harness out at 30s. Seeding before boot fixes it. The seed is one-shot (sessionStorage sentinel) so a reload is still a reload.
- **The "leaving without answering" case was flaky**, because the fixed sleep after the template load was sometimes short and the plan arrived already stamped.

## A note on scope

The brief for this change said the deck's takeover was removed in v0.7 — that `SplashV6.vue` is now manual-only, with no banner and no lock, opening only on a `splashShowV6` event from a v0.7 deck. That is not the case on `main` as of 8651b8c: `SplashV6.vue` still auto-shows on `loadingCompleted`, still answers `splashShow`, still renders "Action needed" behind `:persistent="awaitingAnswer"`, and calls `deferRawBreakingNotice()`; there is no v0.7 deck and no `splashShowV6` event anywhere in `src/`. Confirmed in a real browser, not just by reading.

So the harness keeps one scenario for the deck takeover, since it is behaviour the app still has. If the v0.7 deck work lands later, that scenario is the only thing here that needs revisiting — everything else is asserted against `RawMigrationPrompt` and is independent of it.

The `/changelog` case is kept but reframed: the prompt has no one-time showing to spend, so what is worth asserting is that landing away from the planner answers nothing on the plan's behalf and the warning still finds them when they arrive.

## Testing

Not run by CI (CI's Playwright suite is `web/e2e/`). Run by hand:

```
cd web && VITE_ENV=dev pnpm exec vite --port 3005 --strictPort
PORT=3005 node testing/browser/migration.e2e.mjs
```

**44/44 checks passed**, twice in a row. `pnpm exec eslint testing/browser/migration.e2e.mjs` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6cDqyaQcYrKYN3VgC4jkP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6cDqyaQcYrKYN3VgC4jkP)_