### PR TITLE
fix(web): stop the unit run failing with every test green

### DIFF
--- a/web/src/setup-vitest.ts
+++ b/web/src/setup-vitest.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { afterAll, vi } from 'vitest'
 import path from 'node:path'
 import { readFileSync } from 'node:fs'
 import { config } from '@/config/config'
@@ -82,6 +82,65 @@ if (typeof globalThis.ResizeObserver === 'undefined') {
   }
 }
 
+// jsdom's WebSocket is a thin wrapper around undici's, and undici builds its `open` event
+// with the realm's `Event` — jsdom's — then dispatches it through Node's own `EventTarget`,
+// whose `instanceof Event` check is against Node's class. Hence the nonsense error, `The
+// "event" argument must be an instance of Event. Received an instance of Event`. Nothing
+// awaits it, so it escapes as an uncaught exception that Vitest counts and exits 1 on, on a
+// run where every test passed. It fires only once a socket actually connects, which is what
+// made it intermittent.
+//
+// No unit test should be opening a real connection in the first place: the specs that drive
+// the sync client inject their own socket (`SyncSocketOptions.socketFactory`), and everything
+// else reaching `new WebSocket()` — `roomSync.start()` by way of `roomsStore.begin()` — is
+// doing so incidentally, at the live API's URL. So this one is installed unconditionally
+// rather than behind the `typeof … === 'undefined'` guard the stubs above use: a real
+// implementation being present is precisely the problem. It connects to nothing and fires
+// no handler, which is the honest stand-in for a socket a test never meant to open.
+class InertWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  readonly CONNECTING = 0
+  readonly OPEN = 1
+  readonly CLOSING = 2
+  readonly CLOSED = 3
+
+  readyState = InertWebSocket.CONNECTING
+  binaryType = 'blob'
+  bufferedAmount = 0
+  extensions = ''
+  protocol = ''
+  readonly url: string
+
+  onopen: unknown = null
+  onmessage: unknown = null
+  onclose: unknown = null
+  onerror: unknown = null
+
+  constructor (url: string | URL) {
+    this.url = String(url)
+  }
+
+  send (): void {}
+
+  close (): void {
+    this.readyState = InertWebSocket.CLOSED
+  }
+
+  addEventListener (): void {}
+  removeEventListener (): void {}
+  dispatchEvent (): boolean {
+    return true
+  }
+}
+
+for (const target of [globalThis, window]) {
+  Object.defineProperty(target, 'WebSocket', { value: InertWebSocket, writable: true, configurable: true })
+}
+
 // jsdom never loads images, so an <img> stays `complete: false` with a zero natural
 // size forever — and Vuetify's VImg keeps re-arming its 100ms size poll to wait for
 // one. Nothing unmounts those components, so the timers outlive the jsdom teardown
@@ -90,6 +149,33 @@ if (typeof globalThis.ResizeObserver === 'undefined') {
 for (const prop of ['naturalWidth', 'naturalHeight'] as const) {
   Object.defineProperty(HTMLImageElement.prototype, prop, { configurable: true, get: () => 1 })
 }
+
+// Vitest's worker console buffers what is logged and ships it to the reporter over the worker's
+// rpc channel. That channel is closed the moment the file's tests are over, and any call still
+// in flight is rejected with `Closing rpc while "onUserConsoleLog" was pending` — an unhandled
+// rejection Vitest counts as an error and exits 1 on. One more red run with every test green.
+//
+// What it catches is the app's own logging, arriving late: the store's load chain and its 500ms
+// persist debounce both keep going after the test that started them returned, and both log
+// generously on the way. `afterPaint` and `loadPause` in `app-store.ts` already close the two
+// widest gaps at the source, and a full run still leaves around seventy lines landing after the
+// test that caused them — each one a chance to be the call that teardown rejects. Rather than
+// ask every future spec to await a chain it never started on purpose, stop logging once the
+// tests are over. Nothing readable is lost: Vitest keeps a passing test's console output to
+// itself, `pnpm test` passes `--silent` on top of that, and a line logged after the last test
+// belongs to no test to be printed under in any case.
+//
+// Scoped to the file, and only the file: `pool: 'forks'` gives each spec file its own process,
+// so this console dies with it. Registered from a setup file, so it is the first `afterAll` on
+// the root suite — and hooks running in reverse (`sequence.hooks: 'stack'`), the last to run.
+afterAll(() => {
+  const quietened = ['log', 'info', 'debug', 'dir', 'table', 'trace', 'warn', 'error'] as const
+  const quiet = Object.fromEntries(quietened.map(method => [method, () => {}]))
+  // One object under jsdom, but a Set keeps this honest if the two ever differ.
+  for (const target of new Set([globalThis.console, window.console])) {
+    Object.assign(target, quiet)
+  }
+})
 
 let gameData: any = null
 let gameDataVersion: string | null = null


### PR DESCRIPTION
`Build & Test Web` has been going red intermittently on `main` and on PRs with every test passing, on errors thrown outside any test that Vitest counts and exits 1 on. There turned out to be **two** of them, both fixed here in `web/src/setup-vitest.ts`, beside the environment's existing stand-ins.

## 1. A unit test was opening a real WebSocket

```
TypeError: The "event" argument must be an instance of Event. Received an instance of Event
 ❯ WebSocket.dispatchEvent node:internal/event_target:784:13
 ❯ fireEvent undici/lib/web/websocket/util.js:69:10
```

jsdom 30's `WebSocket` is a wrapper around **undici's**. Undici builds the `open` event with the realm's `Event` — jsdom's — and dispatches it through Node's own `EventTarget`, whose `instanceof Event` check is against Node's class: hence two `Event`s that are not the same `Event`. Nothing awaits it, and it only fires once a socket gets far enough to connect, which is what made it intermittent.

Traced to its source rather than guessed at (an `fs`-based stack probe in jsdom's `WebSocketImpl`, since Vitest keeps a passing test's console output to itself):

```
at SyncSocket.defaultSocketFactory (web/src/sync/ws-client.ts:65)
at SyncSocket.connect      (web/src/sync/ws-client.ts:125)
at Proxy.start             (web/src/stores/room-sync-store.ts:1621)
at begin                   (web/src/stores/rooms-store.ts:952)
```

Worth flagging on its own: the URL it opened was `wss://api.satisfactory-factories.app/ws` — the **live API**, from a unit test. Not the port-3001 gameData server that the brief suspected.

An inert `WebSocket` on `globalThis` and `window` ends it. It is installed unconditionally rather than behind the `typeof … === 'undefined'` guard the neighbouring stubs use, because here a real implementation being present is precisely the problem. Nothing that means to exercise the client is weakened by it: `ws-client.spec.ts` and `room-sync-store.spec.ts` both inject their own socket through `SyncSocketOptions.socketFactory`, and both still pass.

## 2. Vitest's console channel closing on a log still in flight

Six runs of the suite with only the fix above still failed once:

```
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
This error originated in "src/components/sync/AdoptionDialog.spec.ts"
```

The worker buffers each logged line and ships it to the reporter over its rpc; when the file's tests are over the channel is closed and every call still pending is rejected — unhandled, so it lands as an error on a run where every test passed, exactly like the first.

What it catches is the app's own logging arriving late. The store's load chain and its 500ms persist debounce both keep running after the test that started them returned, and both log generously on the way. `afterPaint` and `loadPause` in `app-store.ts` already close the two widest gaps at the source; a probe over a full run showed **~70 lines still landing after the test that caused them**, from `rooms-store.spec.ts`, `room-sync-store.spec.ts` and `TabNavigation.spec.ts` — each one a chance to be the call teardown rejects.

Rather than ask every future spec to await a chain it never started on purpose, the console is quietened from `afterAll`. The same probe after the change records **none**. Nothing readable is lost: Vitest keeps a passing test's console output to itself, `pnpm test` passes `--silent` on top of that, and a line logged after the last test has no test to be printed under. It is scoped to the file — `pool: 'forks'` gives each spec file its own process — and being registered from a setup file it is the first `afterAll` on the root suite, so with hooks running in reverse it is the last to run.

## Verification

Run on Node 24.20.0, matching CI.

- `cd web && pnpm test` — **six consecutive runs on this commit, all 172 files / 3520 tests green, all exit 0, no errors.** Six runs with only the WebSocket fix failed once, on the console race; the previous commit's failure reproduced locally on the first try.
- `pnpm lint`, `pnpm lint-check` and `pnpm exec vue-tsc --noEmit` clean.
- No test skipped, disabled or quarantined; no spec touched.

No `CHANGELOG.md` entry: this is test infrastructure with no user-visible effect. Say the word if you would rather it were noted under Under the hood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7j7xhNv8yFtDZqJy1tCMo

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7j7xhNv8yFtDZqJy1tCMo)_