### PR TITLE
fix(web): keep the unit suite off the network entirely

### DIFF
--- a/web/src/config/config.ts
+++ b/web/src/config/config.ts
@@ -1,7 +1,22 @@
+// Under Vitest neither of the two defaults below will do. `VITE_ENV` is unset there, so every
+// unit test resolved to the live API — and one of them opened a real socket to it, until the
+// inert `WebSocket` in `setup-vitest.ts` stopped that. No unit test has business reaching a
+// server, the preview API included: that one is a single shared instance, and a suite that
+// talks to it is both slower and able to disturb whatever else is pointed at it. Real requests
+// belong in the e2e suite, which builds with `VITE_ENV=dev` and boots its own API on 3001.
+//
+// So the test URL is a port nothing listens on: whatever slips past the mocks fails at once,
+// on this machine, rather than travelling. `setup-vitest.ts` refuses the request before it gets
+// even that far — this is what that refusal falls back on, and what a spec asserting on a
+// request's URL builds from.
+const TEST_API_URL = 'http://127.0.0.1:1'
+
 // VITE_API_URL overrides everything, and is how a build is pointed somewhere other than the
 // two defaults. Vercel sets it to the preview API for the Preview environment, so no preview
 // deployment can read or write live plans; production leaves it unset. See docs/deployment.md.
-const apiUrl = import.meta.env.VITE_API_URL ||
+const apiUrl = import.meta.env.MODE === 'test'
+  ? TEST_API_URL
+  : import.meta.env.VITE_API_URL ||
   (import.meta.env.VITE_ENV === 'dev' ? 'http://localhost:3001' : 'https://api.satisfactory-factories.app')
 
 export const config = {

--- a/web/src/setup-vitest.spec.ts
+++ b/web/src/setup-vitest.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+import { config } from '@/config/config'
+import { SyncSocket } from '@/sync/ws-client'
+
+/**
+ * The guarantees `setup-vitest.ts` installs, rather than the app code that leans on them.
+ * They are invisible when they hold and expensive when they stop: a unit run that reaches the
+ * live API fails on whatever the network did that minute, and it fails with every test passing,
+ * because what breaks is thrown outside the tests entirely. Nothing else in the suite would
+ * notice these being deleted.
+ */
+describe('the unit test environment', () => {
+  describe('the API URL', () => {
+    it('is a port on this machine, so nothing can travel', () => {
+      expect(config.apiUrl).toBe('http://127.0.0.1:1')
+    })
+
+    it('is not the live API, whatever else it becomes', () => {
+      expect(config.apiUrl).not.toContain('satisfactory-factories.app')
+    })
+  })
+
+  describe('fetch', () => {
+    /** The refusal announces itself on stderr; silence it here rather than in the reporter. */
+    const captureStderr = () => vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+
+    it('refuses the request instead of making it', async () => {
+      const stderr = captureStderr()
+      try {
+        await expect(fetch('http://127.0.0.1:1/rooms')).rejects.toThrow(/tried to reach the network/)
+      } finally {
+        stderr.mockRestore()
+      }
+    })
+
+    it('says on stderr what to mock, because the caller may swallow the rejection', async () => {
+      const stderr = captureStderr()
+      try {
+        await fetch('http://127.0.0.1:1/telemetry').catch(() => {})
+        expect(stderr).toHaveBeenCalledOnce()
+        expect(stderr.mock.calls[0][0]).toContain('@/api/client')
+      } finally {
+        stderr.mockRestore()
+      }
+    })
+
+    it('says it once per URL, so a retrying caller cannot bury the run in it', async () => {
+      const stderr = captureStderr()
+      try {
+        for (let attempt = 0; attempt < 3; attempt++) {
+          await fetch('http://127.0.0.1:1/rooms/retried').catch(() => {})
+        }
+        expect(stderr).toHaveBeenCalledOnce()
+      } finally {
+        stderr.mockRestore()
+      }
+    })
+  })
+
+  describe('WebSocket', () => {
+    it('leaves a socket the sync client opens unconnected', async () => {
+      const client = new SyncSocket()
+      client.connect()
+
+      // Long enough that a real socket to a live API would have handshaken.
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(client.status).toBe('connecting')
+      expect(client.isConnected).toBe(false)
+      client.stop()
+    })
+
+    it('never hands a handler an event, so no realm mismatch can reach the run', async () => {
+      const socket = new WebSocket('wss://example.invalid/ws') as unknown as Record<string, unknown>
+      const fired: string[] = []
+      for (const handler of ['onopen', 'onmessage', 'onclose', 'onerror'] as const) {
+        socket[handler] = () => fired.push(handler)
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(fired).toEqual([])
+      expect(socket.readyState).toBe(0)
+    })
+  })
+})

--- a/web/src/setup-vitest.ts
+++ b/web/src/setup-vitest.ts
@@ -141,6 +141,40 @@ for (const target of [globalThis, window]) {
   Object.defineProperty(target, 'WebSocket', { value: InertWebSocket, writable: true, configurable: true })
 }
 
+// Nothing in a unit test may reach the network. `config.apiUrl` points at a dead port under
+// Vitest, so a stray request cannot travel — but a request that fails at the socket is still a
+// request, and this app reads a network failure as its offline path: a spec that forgot to mock
+// the API would quietly exercise offline behaviour and pass, which is how the sync stores would
+// come to be tested against the wrong thing. Refuse it outright instead, and say what to mock.
+//
+// It rejects rather than throwing, because that is what `fetch` does and what the callers are
+// written for: `api/client.ts` wraps a failure in `ApiNetworkError`, and the telemetry beacon
+// swallows one on purpose. Which is also why the refusal is announced on the process's own
+// stderr — a swallowed rejection would be exactly as silent as the request it replaced, and the
+// reporter keeps a passing test's console to itself.
+const refusedUrls = new Set<string>()
+
+const refuseNetwork = (input: unknown): Promise<never> => {
+  const url = typeof input === 'string'
+    ? input
+    : String((input as { url?: unknown })?.url ?? input)
+  const message = `A unit test tried to reach the network: fetch(${url}). Mock the module that ` +
+    'calls it — `@/api/client` for the planner\'s API — rather than letting the request out.'
+
+  if (!refusedUrls.has(url)) {
+    refusedUrls.add(url)
+    process.stderr.write(`${message}\n`)
+  }
+
+  return Promise.reject(new TypeError(message))
+}
+
+// `writable`/`configurable`, so a spec's own `vi.stubGlobal('fetch', …)` still replaces it — and
+// is put back to this, rather than to the real thing, by `vi.unstubAllGlobals()`.
+for (const target of [globalThis, window]) {
+  Object.defineProperty(target, 'fetch', { value: refuseNetwork, writable: true, configurable: true })
+}
+
 // jsdom never loads images, so an <img> stays `complete: false` with a zero natural
 // size forever — and Vuetify's VImg keeps re-arming its 100ms size poll to wait for
 // one. Nothing unmounts those components, so the timers outlive the jsdom teardown

--- a/web/vite.config.mts
+++ b/web/vite.config.mts
@@ -41,6 +41,39 @@ process.env.VITE_APP_VERSION = JSON.parse(
 process.env.VITE_GIT_SHA =
   (process.env.VERCEL_GIT_COMMIT_SHA || process.env.GIT_SHA || '').slice(0, 12)
 
+// The Vitest API URL must never reach a bundle. `config.ts` only picks it when `MODE` is
+// `test`, and only Vitest sets that, so today it cannot happen by accident — but "cannot
+// happen" is what every shipped mistake was, and this one ships an app that talks to a port
+// on the user's own machine. `vite build --mode test`, or an edit that inverts the condition,
+// is all it would take.
+//
+// It is asserted here rather than as a CI step because CI is not on the path of the build
+// that ships: Vercel builds the web app itself, from the repository, and never runs the
+// workflow. A plugin runs wherever `vite build` does — Vercel, CI and a laptop alike.
+//
+// The literal is repeated from `config.ts` on purpose: a guard that imports the value it
+// guards agrees with itself no matter what that value becomes. `setup-vitest.spec.ts` asserts
+// the same string from the other side, so changing it in `config.ts` alone fails the suite.
+const TEST_API_URL = 'http://127.0.0.1:1'
+
+const refuseTestApiUrl = () => ({
+  name: 'refuse-test-api-url',
+  apply: 'build' as const,
+  generateBundle (_options: unknown, bundle: Record<string, { type: string, code?: string, source?: unknown }>) {
+    for (const [fileName, emitted] of Object.entries(bundle)) {
+      const contents = emitted.type === 'chunk' ? emitted.code ?? '' : String(emitted.source ?? '')
+      if (!contents.includes(TEST_API_URL)) continue
+
+      throw new Error(
+        `${fileName} carries the Vitest API URL (${TEST_API_URL}). That is the address a unit ` +
+        'run points at so nothing can reach a real server, and a build that ships it is a ' +
+        'planner that talks to the reader\'s own machine. Check the `MODE` branch in ' +
+        'src/config/config.ts, and the mode this build ran in.',
+      )
+    }
+  },
+})
+
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
   build: {
@@ -52,6 +85,7 @@ export default defineConfig(() => ({
     },
   },
   plugins: [
+    refuseTestApiUrl(),
     VueRouter({
       dts: 'src/typed-router.d.ts',
     }),


### PR DESCRIPTION
Follow-up to [#683](https://github.com/satisfactory-factories/application/pull/683). That PR stopped a unit test opening a socket to the live API; this one removes the reason it could, and stops the next one.

## The state of things

Under Vitest `VITE_ENV` is unset, so `config.apiUrl` fell through to `https://api.satisfactory-factories.app`. Every unit test resolved the live API as its base URL.

The good news, measured rather than assumed — a probe wrapping `globalThis.fetch` over a full run recorded **zero** real requests. Every spec that touches the API mocks `@/api/client`, or the store above it. So this is preventative: nothing leaks today, but nothing stopped it either, and the WebSocket in #683 is what happens when something does.

## What changed

**`config.apiUrl` is `http://127.0.0.1:1` under Vitest** — a port nothing listens on, so anything past the mocks fails at once and on the machine it started on. Deliberately *not* the preview API: that is one shared instance, and a unit suite pointed at it is both slower and able to disturb whatever else is using it. Real requests belong in the e2e suite, which already builds with `VITE_ENV=dev` against its own API on 3001.

The branch is `import.meta.env.MODE === 'test'`, matching the guards already in `app-store.ts`. It sits in `config.ts` on purpose — that file is where the URL is decided and documented, so that is where a reader should find the test case. The e2e build is `MODE=production`, so it is untouched.

**`fetch` is refused in the vitest setup**, because failing at the socket is not the same as never asking. This app reads a network failure as its *offline path*: a spec that forgot to mock would quietly exercise offline behaviour and pass, which is how the sync stores would end up tested against the wrong thing. Details that matter:

- It **rejects** rather than throwing — that is what `fetch` does, and the callers are written for it (`api/client.ts` wraps a rejection in `ApiNetworkError`; the telemetry beacon swallows one deliberately). A synchronous throw would sail straight past a `.catch()` and become the sort of uncaught error #683 was about.
- It **announces itself once per URL on stderr**, precisely because a swallowed rejection is as silent as the request it replaced. Once per URL, so a retrying caller cannot bury the run in it.
- It stays `writable`/`configurable`, so a spec's own `vi.stubGlobal('fetch', …)` still replaces it, and `vi.unstubAllGlobals()` restores it to the refusal rather than to the real thing.

**`src/setup-vitest.spec.ts`** locks all of it in, including #683's inert `WebSocket`, which shipped without a test. These guarantees are invisible while they hold, and nothing else in the suite would notice them being deleted — which is exactly the kind of thing that rots.

## Verification

Node 24.20.0, matching CI.

- **Each of the seven new tests confirmed to fail with its guard removed** — 5 with this PR's changes stashed, and the 2 WebSocket ones with #683's stub deleted. Not decorative.
- `pnpm test` ×3: **173 files, 3537 tests green, exit 0 every time, zero requests refused in any run.**
- `pnpm lint`, `pnpm lint-check`, `pnpm exec vue-tsc --noEmit` clean.
- No test skipped, disabled or quarantined.

No `CHANGELOG.md` entry, on the same reasoning as #683 — test infrastructure, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7j7xhNv8yFtDZqJy1tCMo

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7j7xhNv8yFtDZqJy1tCMo)_