### PR TITLE
feat(backend): name plans in sf_room_factories and export plans per owner

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -48,3 +48,4 @@
 - [Verify: hidden-pane menu freeze](verify-hidden-pane-menu-freeze.md) — a hidden browser pane leaves Vuetify menus stuck invisible with inline pointer-events:none; clear the inline props before hit-testing
 - [prom-client label lifecycle](prom-client-label-lifecycle.md) — seed bounded label sets at zero or panels read "No data"; reset ranked ones or dropped labels report forever
 - [Clock step freezes rate limits](clock-step-freezes-rate-limits.md) — a backwards clock step at boot 429'd the API container unhealthy under express-rate-limit; why @nestjs/throttler closed it, why we run our own throttler storage instead of its, and why it looks exactly like prod drift
+- [Grafana dashboard via API](grafana-dashboard-via-api.md) — edit Planner Metrics through the API on the Grafana box with the on-box token, never the browser; ask for SSH first

--- a/.claude/memory/grafana-dashboard-via-api.md
+++ b/.claude/memory/grafana-dashboard-via-api.md
@@ -1,0 +1,44 @@
+---
+name: grafana-dashboard-via-api
+description: "Edit the Planner Metrics Grafana dashboard through its HTTP API from the Grafana box, never by driving the browser; where the token lives and the traps"
+metadata: 
+  node_type: memory
+  type: project
+  volatility: normal
+  lastVerified: 2026-09-12
+  originSessionId: f918c7e6-a8d3-4cdc-8406-cd3a9c367aad
+  modified: 2026-09-11T23:35:10.521Z
+---
+
+**Dashboard edits go through the Grafana API, run on the Grafana box itself.** Driving the
+Grafana UI through the in-app browser prompts for permission on every click (the port cannot
+be allowlisted), so that route is out. The way that works:
+
+1. **Ask for explicit permission to SSH to the Grafana host before the first connection.**
+   Once given, that yes covers the whole task: go on the box freely and use the token below.
+   The host is not the `sf` API box; ask which host if the session does not already know.
+2. The service-account token is the file `~/claude-token` in root's home on that box
+   (service account "Claude", Editor). **Never `cat` it into the conversation.** Use it in
+   place: `T=$(tr -d "\n" < ~/claude-token); curl -H "Authorization: Bearer $T" http://localhost:3000/api/...`.
+3. `GET /api/dashboards/uid/satisfactory-factories-metrics` → edit the JSON locally with a
+   script → `POST /api/dashboards/db` with `{"dashboard": ..., "overwrite": false, "message": "..."}`.
+   Keep `version` as fetched so a concurrent UI save conflicts instead of being clobbered.
+   `scp` the body to `/tmp` on the box and `-d @file`; inline quoting through ssh breaks.
+4. Re-fetch and diff against the original before reporting: every untouched panel must be
+   byte-identical apart from the `gridPos.y` shifts the new panel forced.
+
+**Traps.** Panels reference the datasource as `{"uid":"prometheus"}`, which the frontend
+resolves by name, but `POST /api/ds/query` needs the real uid from `GET /api/datasources`
+(it was `ffp7m9lxm8jr4b`); "Data source not found" means this. Check a new metric has data
+and which labels it carries before mirroring a sibling's `sum by (label)`: the per-room
+totals have no `shared` label, so a copied `{{shared}}` legend renders blank. Rows are flat
+in `panels[]` with rows as separators, so inserting a panel means bumping `y` on everything
+below it by its height, exactly as the UI would.
+
+**Why:** two sessions burned out on browser permission prompts before this; the API route
+finished the same job with a verifiable diff. Keeping the token on the box means no session
+ever holds it and nothing needs rotating afterwards.
+
+**How to apply:** metric definitions live in `backend/src/metrics/metrics.service.ts`; a
+panel that needs a label the exporter does not emit is a backend change first, and the
+dashboard reads "No data" until that deploys. Related: [[backend-deploy-and-prod-drift]].

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -6,6 +6,7 @@ import { AccountTokenService } from './account-token.service'
 import { AuthTokenPayload, isAccountTokenPayload } from './auth-token'
 import { AuthService } from './auth.service'
 import { CurrentUser, JwtAuthGuard } from './jwt-auth.guard'
+import { UserActivityService } from '../user-activity/user-activity.service'
 
 interface CredentialsBody { username?: string, password?: string }
 interface TokenBody { token?: string }
@@ -21,6 +22,7 @@ export class AuthController {
     private readonly authService: AuthService,
     private readonly jwtService: JwtService,
     private readonly accounts: AccountTokenService,
+    private readonly userActivity: UserActivityService,
   ) {}
 
   @Post('register')
@@ -59,12 +61,22 @@ export class AuthController {
       // A token the account has since superseded is as invalid as an expired one, and the
       // client reads this route's answer to decide whether it is still signed in.
       if (!await this.accounts.isCurrent(payload)) throw new Error('token superseded')
+      await this.stampSessionResumed(payload.id)
       return { valid: true, decoded: payload }
     } catch {
       throw new HttpException(
         { valid: false, message: 'Invalid or expired token' },
         HttpStatus.UNAUTHORIZED,
       )
+    }
+  }
+
+  /** Allowed to fail: a metrics write must never be the reason a session looks signed out. */
+  private async stampSessionResumed (userId: string): Promise<void> {
+    try {
+      await this.userActivity.recordSessionResumed(userId, new Date())
+    } catch (cause) {
+      console.error(`Failed to stamp the resumed session for ${userId}`, cause)
     }
   }
 

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -39,7 +39,7 @@ interface CheapCounts {
 }
 
 interface OwnedTotal { name: string, value: number }
-interface RoomTotal { roomId: string, owner: string, factories: number }
+interface RoomTotal { roomId: string, name: string, owner: string, factories: number }
 interface ShareTotal { shareId: string, opens: number }
 
 /** The slow numbers: five window counts and three top-N aggregations. */
@@ -50,6 +50,7 @@ interface SlowStats {
   topRooms: RoomTotal[]
   topEditors: OwnedTotal[]
   topOwners: OwnedTotal[]
+  topRoomOwners: OwnedTotal[]
   newShares: Array<readonly [string, number]>
   topShares: ShareTotal[]
   newRooms: Array<readonly [string, number]>
@@ -90,9 +91,10 @@ export class MetricsService {
   private readonly newAccounts: Gauge<'window'>
   private readonly signedInAccounts: Gauge<'window'>
   private readonly signInsTotal: Gauge<string>
-  private readonly roomFactories: Gauge<'room_id' | 'owner'>
+  private readonly roomFactories: Gauge<'room_id' | 'name' | 'owner'>
   private readonly userEdits: Gauge<'username'>
   private readonly userFactories: Gauge<'username'>
+  private readonly userRooms: Gauge<'username'>
 
   private readonly sharesTotal: Gauge<string>
   private readonly shareOpensTotal: Gauge<string>
@@ -213,7 +215,7 @@ export class MetricsService {
     this.roomFactories = new Gauge({
       name: 'sf_room_factories',
       help: `The ${METRICS_TOP_N} largest synced tabs by factory count.`,
-      labelNames: ['room_id', 'owner'],
+      labelNames: ['room_id', 'name', 'owner'],
       registers,
     })
     this.userEdits = new Gauge({
@@ -225,6 +227,12 @@ export class MetricsService {
     this.userFactories = new Gauge({
       name: 'sf_user_factories',
       help: `The ${METRICS_TOP_N} accounts owning the most factories, summed over the synced tabs they created.`,
+      labelNames: ['username'],
+      registers,
+    })
+    this.userRooms = new Gauge({
+      name: 'sf_user_rooms',
+      help: `The ${METRICS_TOP_N} accounts that created the most synced tabs.`,
       labelNames: ['username'],
       registers,
     })
@@ -380,7 +388,7 @@ export class MetricsService {
 
     this.roomFactories.reset()
     for (const room of stats.topRooms) {
-      this.roomFactories.set({ room_id: room.roomId, owner: room.owner }, room.factories)
+      this.roomFactories.set({ room_id: room.roomId, name: room.name, owner: room.owner }, room.factories)
     }
 
     this.userEdits.reset()
@@ -391,6 +399,11 @@ export class MetricsService {
     this.userFactories.reset()
     for (const owner of stats.topOwners) {
       this.userFactories.set({ username: owner.name }, owner.value)
+    }
+
+    this.userRooms.reset()
+    for (const owner of stats.topRoomOwners) {
+      this.userRooms.set({ username: owner.name }, owner.value)
     }
 
     for (const [window, shares] of stats.newShares) {
@@ -434,8 +447,8 @@ export class MetricsService {
   private async loadSlow (): Promise<SlowStats> {
     const now = this.clock.now()
     const [
-      activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners, newShares, topShares,
-      newRooms, newMemberships,
+      activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners, topRoomOwners, newShares,
+      topShares, newRooms, newMemberships,
     ] =
       await Promise.all([
         this.countByWindow(now, since => this.users.countDocuments({ lastActiveAt: { $gt: since } })),
@@ -444,6 +457,7 @@ export class MetricsService {
         this.findLargestRooms(),
         this.findBusiestEditors(),
         this.findLargestOwners(),
+        this.findMostProlificOwners(),
         this.countByWindow(now, since => this.shares.countDocuments({ created: { $gt: since } })),
         this.findMostOpenedShares(),
         this.countByWindow(now, since => this.rooms.countDocuments({ createdAt: { $gt: since } })),
@@ -454,8 +468,8 @@ export class MetricsService {
       ])
 
     return {
-      activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners, newShares, topShares,
-      newRooms, newMemberships,
+      activeAccounts, newAccounts, signedInAccounts, topRooms, topEditors, topOwners, topRoomOwners, newShares,
+      topShares, newRooms, newMemberships,
     }
   }
 
@@ -522,11 +536,12 @@ export class MetricsService {
 
   /** Sorted by size then by id, so equal-sized rooms do not swap places between scrapes. */
   private async findLargestRooms (): Promise<RoomTotal[]> {
-    const rows = await this.rooms.aggregate<{ roomId: string, createdBy: string, factories: number }>([
+    const rows = await this.rooms.aggregate<{ roomId: string, name: string, createdBy: string, factories: number }>([
       { $match: { deletedAt: null } },
       {
         $project: {
           roomId: 1,
+          name: 1,
           createdBy: 1,
           factories: { $size: { $ifNull: ['$factories', []] } },
         },
@@ -538,6 +553,7 @@ export class MetricsService {
     const owners = await this.resolveUsernames(rows.map(row => row.createdBy))
     return rows.map(row => ({
       roomId: row.roomId,
+      name: row.name,
       owner: owners.get(row.createdBy) ?? DELETED_OWNER,
       factories: row.factories,
     }))
@@ -563,6 +579,18 @@ export class MetricsService {
 
     const owners = await this.resolveUsernames(rows.map(row => row._id))
     return rows.map(row => ({ name: owners.get(row._id) ?? DELETED_OWNER, value: row.factories }))
+  }
+
+  private async findMostProlificOwners (): Promise<OwnedTotal[]> {
+    const rows = await this.rooms.aggregate<{ _id: string, rooms: number }>([
+      { $match: { deletedAt: null } },
+      { $group: { _id: '$createdBy', rooms: { $sum: 1 } } },
+      { $sort: { rooms: -1, _id: 1 } },
+      { $limit: METRICS_TOP_N },
+    ])
+
+    const owners = await this.resolveUsernames(rows.map(row => row._id))
+    return rows.map(row => ({ name: owners.get(row._id) ?? DELETED_OWNER, value: row.rooms }))
   }
 
   /**

--- a/backend/src/user-activity/user-activity.service.ts
+++ b/backend/src/user-activity/user-activity.service.ts
@@ -39,10 +39,20 @@ export class UserActivityService {
   async recordEdit (userId: string, at: Date): Promise<void> {
     if (userId === ANONYMOUS_ACTOR) return
 
+    // An accepted edit proves the account was signed in, whether or not it typed a password
+    // today, so the signed-in window always contains the active one.
     await this.users.updateOne(
       { _id: userId },
-      { $max: { lastActiveAt: at }, $inc: { editCount: 1 } },
+      { $max: { lastActiveAt: at, lastSignInAt: at }, $inc: { editCount: 1 } },
     )
+  }
+
+  /**
+   * A stored token resumed without a password is still a sign-in as far as the windows
+   * are concerned, but not a sign-in event: `signInCount` is left alone.
+   */
+  async recordSessionResumed (userId: string, at: Date): Promise<void> {
+    await this.users.updateOne({ _id: userId }, { $max: { lastSignInAt: at } })
   }
 
   /**

--- a/backend/test/auth.spec.ts
+++ b/backend/test/auth.spec.ts
@@ -151,6 +151,21 @@ describe('auth', () => {
       expect(response.body.decoded.username).toBe(CREDENTIALS.username)
     })
 
+    it('stamps the account as signed in, without counting another sign-in', async () => {
+      await post('/register').send(CREDENTIALS)
+      const { body } = await post('/login').send(CREDENTIALS)
+      await connection.collection('users').updateOne(
+        { username: CREDENTIALS.username },
+        { $set: { lastSignInAt: new Date('2026-01-01T00:00:00Z') } },
+      )
+
+      await post('/validate-token').send({ token: body.token })
+
+      const stored = await connection.collection('users').findOne({ username: CREDENTIALS.username })
+      expect(stored?.lastSignInAt.getTime()).toBeGreaterThan(new Date('2026-01-01T00:00:00Z').getTime())
+      expect(stored?.signInCount).toBe(1)
+    })
+
     it('answers 401 for a token signed with another secret', async () => {
       const foreign = jwt.sign({ id: 'x', username: 'x' }, 'not-the-secret')
 

--- a/backend/test/metrics-usage.spec.ts
+++ b/backend/test/metrics-usage.spec.ts
@@ -214,7 +214,15 @@ describe('the database-backed usage metrics', () => {
 
       const body = await scrape()
 
-      expect(sample(body, 'sf_room_factories', `room_id="${big.roomId}",owner="mael"`)).toBe(40)
+      expect(sample(body, 'sf_room_factories', `room_id="${big.roomId}",name="Iron Line",owner="mael"`)).toBe(40)
+    })
+
+    it('carries the plan name so the panel can show more than an id', async () => {
+      const room = await seedRoom(12, { name: 'Nuclear "Mk2"' })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_room_factories', `room_id="${room.roomId}",name="Nuclear \\"Mk2\\"",owner="${DELETED_OWNER}"`)).toBe(12)
     })
 
     it('labels an owner who no longer exists rather than dropping the room', async () => {
@@ -222,7 +230,7 @@ describe('the database-backed usage metrics', () => {
 
       const body = await scrape()
 
-      expect(sample(body, 'sf_room_factories', `room_id="${room.roomId}",owner="${DELETED_OWNER}"`)).toBe(9)
+      expect(sample(body, 'sf_room_factories', `room_id="${room.roomId}",name="Iron Line",owner="${DELETED_OWNER}"`)).toBe(9)
     })
 
     // A cast error on one bad row must not take the whole scrape down.
@@ -231,7 +239,7 @@ describe('the database-backed usage metrics', () => {
 
       const body = await scrape()
 
-      expect(sample(body, 'sf_room_factories', `room_id="${room.roomId}",owner="${DELETED_OWNER}"`)).toBe(4)
+      expect(sample(body, 'sf_room_factories', `room_id="${room.roomId}",name="Iron Line",owner="${DELETED_OWNER}"`)).toBe(4)
     })
 
     it(`exports at most ${METRICS_TOP_N} rooms however many exist`, async () => {
@@ -244,12 +252,12 @@ describe('the database-backed usage metrics', () => {
 
     it('drops a room that has fallen out of the top N', async () => {
       const small = await seedRoom(1)
-      expect(sample(await scrape(), 'sf_room_factories', `room_id="${small.roomId}",owner="${DELETED_OWNER}"`)).toBe(1)
+      expect(sample(await scrape(), 'sf_room_factories', `room_id="${small.roomId}",name="Iron Line",owner="${DELETED_OWNER}"`)).toBe(1)
 
       for (let index = 0; index < METRICS_TOP_N; index++) await seedRoom(50 + index)
 
       const body = await scrape()
-      expect(sample(body, 'sf_room_factories', `room_id="${small.roomId}",owner="${DELETED_OWNER}"`)).toBeUndefined()
+      expect(sample(body, 'sf_room_factories', `room_id="${small.roomId}",name="Iron Line",owner="${DELETED_OWNER}"`)).toBeUndefined()
     })
 
     it('breaks ties on room id, so equal rooms keep their order between scrapes', async () => {
@@ -538,6 +546,38 @@ describe('the database-backed usage metrics', () => {
       const body = await scrape()
       expect(sample(body, 'sf_share_opens', 'share_id="opened-for-real"')).toBe(2)
       expect(sample(body, 'sf_share_opens_total')).toBe(2)
+    })
+  })
+
+  describe('sf_user_rooms, the accounts with the most plans', () => {
+    it('counts the live rooms each account created', async () => {
+      const prolific = await seedUser('prolific')
+      const once = await seedUser('once')
+      await seedRoom(1, { createdBy: String(prolific._id) })
+      await seedRoom(1, { createdBy: String(prolific._id) })
+      await seedRoom(30, { createdBy: String(prolific._id), deletedAt: new Date() })
+      await seedRoom(50, { createdBy: String(once._id) })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_user_rooms', 'username="prolific"')).toBe(2)
+      expect(sample(body, 'sf_user_rooms', 'username="once"')).toBe(1)
+    })
+
+    it(`caps at ${METRICS_TOP_N} and drops an owner who has fallen out`, async () => {
+      const early = await seedUser('early')
+      await seedRoom(1, { createdBy: String(early._id) })
+      expect(sample(await scrape(), 'sf_user_rooms', 'username="early"')).toBe(1)
+
+      for (let index = 0; index < METRICS_TOP_N; index++) {
+        const owner = await seedUser(`owner-${index}`)
+        await seedRoom(1, { createdBy: String(owner._id) })
+        await seedRoom(1, { createdBy: String(owner._id) })
+      }
+
+      const body = await scrape()
+      expect(labelValues(body, 'sf_user_rooms', 'username').length).toBe(METRICS_TOP_N)
+      expect(sample(body, 'sf_user_rooms', 'username="early"')).toBeUndefined()
     })
   })
 

--- a/backend/test/metrics-usage.spec.ts
+++ b/backend/test/metrics-usage.spec.ts
@@ -204,6 +204,19 @@ describe('the database-backed usage metrics', () => {
       expect(sample(body, 'sf_signed_in_accounts', 'window="24h"')).toBe(2)
       expect(sample(body, 'sf_active_accounts', 'window="24h"')).toBe(1)
     })
+
+    // A resumed session edits without ever hitting /login. Left out of the signed-in
+    // window, the "of those who signed in, how many edited" ratio climbed past 100%.
+    it('counts an editor as signed in even without a password login', async () => {
+      const user = await seedUser('resumed')
+      await context.app.get(UserActivityService).recordEdit(String(user._id), clock.now())
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_active_accounts', 'window="24h"')).toBe(1)
+      expect(sample(body, 'sf_signed_in_accounts', 'window="24h"')).toBe(1)
+      expect(sample(body, 'sf_signins_total')).toBe(0)
+    })
   })
 
   describe('sf_room_factories, the largest plans', () => {
@@ -663,6 +676,7 @@ describe('UserActivityService', () => {
 
       const stored = await reload(user._id)
       expect(stored?.lastActiveAt?.toISOString()).toBe(at.toISOString())
+      expect(stored?.lastSignInAt?.toISOString()).toBe(at.toISOString())
       expect(stored?.editCount).toBe(1)
     })
 
@@ -686,6 +700,19 @@ describe('UserActivityService', () => {
 
     it('ignores anonymous visitors, who have no account to stamp', async () => {
       await expect(service().recordEdit(ANONYMOUS_ACTOR, new Date())).resolves.toBeUndefined()
+    })
+  })
+
+  describe('recordSessionResumed', () => {
+    it('moves the sign-in window forward without counting a sign-in', async () => {
+      const user = await seedUser('resumed', { lastSignInAt: new Date('2026-09-01T00:00:00Z'), signInCount: 4 })
+      const at = new Date('2026-09-02T10:00:00Z')
+
+      await service().recordSessionResumed(String(user._id), at)
+
+      const stored = await reload(user._id)
+      expect(stored?.lastSignInAt?.toISOString()).toBe(at.toISOString())
+      expect(stored?.signInCount).toBe(4)
     })
   })
 


### PR DESCRIPTION
No manual steps or intervention required. The new series appear on the next scrape after the API deploys.

## What changes

- `sf_room_factories` gains a `name` label (the tab's name) alongside `room_id` and `owner`, so the Biggest Plans panel can show the plan rather than a bare id.
- New gauge `sf_user_rooms{username}`: the top 20 accounts by number of live synced tabs they created. Deleted rooms are excluded, same as the other top-N gauges.
- `lastSignInAt` is now also stamped by a successful `validate-token` and by an accepted edit. It was only ever stamped by a password login, so a browser resuming a stored token counted as active but never as signed in, and the "Of Those Who Signed In, How Many Edited" stat read 194%. `signInCount` is untouched, so "Sign-ins, All Time" still means password logins.
- Memory file describing how the dashboard is edited through the Grafana API.

## Dashboard

Already saved (v14): "Biggest Plans" legend is `{{owner}} · {{name}}` and a new "Accounts With the Most Plans" bar gauge reads `sort_desc(sf_user_rooms{job="satisfactory-factories"})`. Both show no data until this deploys.

## Validation done

- `pnpm exec vitest run` in `backend/`: 39 files, 597 tests passed, including new cases for the `name` label (with a quoted name), `sf_user_rooms` (counting, cap at top N, dropping an owner who falls out), the resumed-session stamp on `validate-token`, and an editor landing in the signed-in window with `sf_signins_total` still 0.
- `pnpm exec tsc --noEmit` and `pnpm run lint-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)