### PR TITLE
fix(repo): keep the release summary out of the release title

### DIFF
--- a/.github/scripts/changelog-release-notes.mjs
+++ b/.github/scripts/changelog-release-notes.mjs
@@ -13,10 +13,17 @@
 //
 // A release is an `<h1>` naming its version, e.g.
 //
-//   <h1>Beta v0.6 - The "Groundwork" Update <span class="release-date">19/Aug/2026</span></h1>
+//   <h1>Beta v0.6 - The "Groundwork" Update <span class="release-date">19/Aug/2026</span>
+//   <span class="release-summary">Raw resources, mines, resource wells and factory groups</span></h1>
 //
 // and runs until the next `<h1>`. A heading naming the exact version wins;
 // failing that, the version's major.minor does, so `0.6.0` finds `v0.6`.
+//
+// The heading carries two asides that are not part of its title: the date, which
+// becomes the "_Released …_" line, and the one-line summary the page's contents
+// list shows under each entry. Neither reaches the title, and the summary is
+// dropped from the body too, because the release's own opening paragraph already
+// says the same thing at more length.
 //
 // Usage:
 //   node .github/scripts/changelog-release-notes.mjs --version 0.6.0 [--out notes.md]
@@ -302,6 +309,10 @@ function list (node, indent) {
   }).join('\n')
 }
 
+// Spans a release heading carries beside its title. Each has its own home, so
+// none of them is part of the name of the release.
+const ASIDE = /\b(?:release-date|release-summary)\b/
+
 // Splits the page into releases: each <h1> that names one, plus everything up to
 // the next <h1>. The "Change Log" heading is the page title, not a release.
 export function parseReleases (source) {
@@ -318,11 +329,14 @@ export function parseReleases (source) {
   const releases = []
   for (const node of flatten(tree.children)) {
     if (node.tag === 'h1') {
-      const dateNode = node.children.find(child => child.attrs?.class?.includes('release-date'))
+      const asides = node.children.filter(child => ASIDE.test(child.attrs?.class ?? ''))
+      const dateNode = asides.find(child => child.attrs.class.includes('release-date'))
+      const summaryNode = asides.find(child => child.attrs.class.includes('release-summary'))
       const date = dateNode ? inline(dateNode.children).trim() : ''
-      const title = inline(node.children.filter(child => child !== dateNode)).replace(/\s+/g, ' ').trim()
+      const summary = summaryNode ? inline(summaryNode.children).trim() : ''
+      const title = inline(node.children.filter(child => !asides.includes(child))).replace(/\s+/g, ' ').trim()
       if (!title || title === 'Change Log') { releases.push(null); continue }
-      releases.push({ title, date, nodes: [] })
+      releases.push({ title, date, summary, nodes: [] })
       continue
     }
     releases.at(-1)?.nodes?.push(node)

--- a/web/src/pages/changelog.vue
+++ b/web/src/pages/changelog.vue
@@ -1025,11 +1025,19 @@ h1,h2,h3,h4,h5,h6 {
   margin-top: 0.25rem;
 }
 
+// Directly under the release it belongs to, aligned with it rather than stepped in: it is that
+// entry's second line, not a level below it.
 .toc-summary {
   color: #bdbdbd;
   font-size: 0.9rem;
   list-style: none;
-  padding-left: 1rem;
+  padding-left: 0;
+
+  // The app's list styling indents every item by 16px for its marker. This one has no marker,
+  // so that indent would step the summary in from the release it sits under.
+  li {
+    margin-left: 0;
+  }
 }
 
 .toc {


### PR DESCRIPTION
Two things about the `.release-summary` span #690 added to each release heading. A regression it caused in the release notes generator, caught before cutting the 0.7.1 release, and where it sits in the page's contents list.

## 1. The summary was being published as part of the release title

`changelog-release-notes.mjs` builds the release title from the heading's text with only `.release-date` filtered out, so the new summary came along with it:

```
$ node .github/scripts/changelog-release-notes.mjs --list
Beta v0.7 - The "SINKronisation" Update Realtime sync, rooms and offline mode  (09/Sep/2026)
Beta v0.6 - The "Groundwork" Update Raw resources, mines, resource wells and factory groups  (19/Aug/2026)
Beta v0.5 - The "Overclocked" Update Overclocking, Somersloops, building groups and power  (21/Jul/2026)
Alpha v0.4 Export Calculator v2 and a new loading sequence  (25/Jan/2025)
```

Every one of those would have been published as the release's name.

Both spans are asides on the heading, so they are matched by class and filtered together. The date still becomes the `_Released …_` line; the summary is dropped rather than repeated into the body, because the release's own opening paragraph already says the same thing at more length. That duplication is exactly why the page carries both: the contents list needs one line, the release itself has room for a paragraph.

`parseReleases` now also returns `summary` alongside `title` and `date`, so it is there if a use for it turns up.

After:

```
$ node .github/scripts/changelog-release-notes.mjs --list
Beta v0.7 - The "SINKronisation" Update  (09/Sep/2026)
Beta v0.6 - The "Groundwork" Update  (19/Aug/2026)
Beta v0.5 - The "Overclocked" Update  (21/Jul/2026)
Alpha v0.4  (25/Jan/2025)
```

All four match the names the already-published releases use, so a re-run with `overwrite` would not rename anything.

## 2. The contents summary sits flush under its release

In "Jump to an update" it was stepped in from the release name it belongs to, which read as a level below rather than as that entry's second line.

Two indents to clear: the `1rem` the list carried, and the 16px the app's list styling gives every item to make room for its marker, which this list does not have (`list-style: none`). Measured in the browser afterwards, the link and the summary share a left edge at 198px.

## Testing

Ran the generator for every version the page holds, checking both the title and that the body still converts:

| Version | Title | Body |
| --- | --- | --- |
| 0.7.1 | `Beta v0.7 - The "SINKronisation" Update` | 33,756 chars |
| 0.6.0 | `Beta v0.6 - The "Groundwork" Update` | 18,840 chars |
| 0.5.0 | `Beta v0.5 - The "Overclocked" Update` | 9,540 chars |
| 0.4.0 | `Alpha v0.4` | 7,383 chars |

All under the 125,000 character cap, and all pass the script's own leftover-markup check.

The contents list was checked in Chromium against a production `pnpm build` served through `vite preview`, with the left edges measured from the live DOM rather than eyeballed. `pnpm lint` clean.

The 0.7.1 release was cut from this branch with the fix in place, using the repo's own `Release: Publish` workflow: https://github.com/satisfactory-factories/application/releases/tag/0.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PTSRZn8YB7LHuoRHXo3Tt