### PR TITLE
feat(backend): feature utilisation over synced plans, and searches used

### DIFF
--- a/.claude/plans/feature-utilisation-metrics.md
+++ b/.claude/plans/feature-utilisation-metrics.md
@@ -1,0 +1,67 @@
+# Feature utilisation metrics
+
+A "Feature Utilisation" row on the Planner Metrics dashboard: for each planner feature, how many
+synced plans use it, how many of their factories use it, and the rate, now and over time. Plus a
+count of searches that were actually used to jump somewhere.
+
+Cloud plans only, decided 2026-09-13. Local plans are invisible to the server and stay that way:
+nothing is added to the anonymous heartbeat, and the privacy wording in `docs/telemetry.md` is
+untouched. The 110-odd synced plans are the sample of the people who use the planner most, and
+the rates over them are exact for that population. Aggregate only, never per plan.
+
+## Tasks
+
+- Add a pure `featureUsage(tab)` function in `common` that says, for one plan, which features
+  it uses and how many of its factories use each. Defensive against malformed factories, since
+  `Room.factories` is Mixed and old documents are not schema-checked.
+- Sum it over live rooms in the metrics slow loader, over a lean projection of the fields it
+  needs, in Node rather than in a Mongo pipeline.
+- Export `sf_room_feature_plans{feature}` and `sf_room_feature_factories{feature}`, every
+  feature label seeded at zero from the enum.
+- Add `USAGE_ACTIONS` to `common` with `search_jump`, and an optional `usage` list on the
+  `POST /events` report; `events` becomes optional too, with at least one of the two required.
+- Export `sf_usage_total{action}` from `EventCountersService`, seeded at zero.
+- Give the events store a second buffer for usage, flushed on the same tick and cleared on the
+  same acknowledgement rules; count `search_jump` when a search result is activated.
+- Retitle "Plans Ever Created" to "Plans Created From Scratch" and show adopted and imported
+  beside it, so the three account for the synced-plan total.
+- Add the Feature Utilisation row to `docs/grafana/generate.py`, regenerate, apply both
+  dashboards after the API deploys.
+- Update `docs/telemetry.md` for the usage list and both allowed-field specs.
+
+## Which features, and what counts as "using" it
+
+Every one is derivable from the plan as stored. Nothing new is written on edit.
+
+| Feature | A factory uses it when | A plan uses it when |
+| --- | --- | --- |
+| AWESOME Sink | any `partDisposal[*].sinks > 0` | any factory does |
+| Dimensional Depot | any `partDisposal[*].depots > 0` | any factory does |
+| Power target | n/a | `powerTarget > 0` on the room |
+| Groups | `group` is set | `groups` is non-empty |
+| Checklist | `checklistEnabled` | any factory does |
+| Notes | `notes` is non-blank after trimming | any factory does |
+| Tasks | `tasks` is non-empty | any factory does |
+| Somersloops | any building group, under a product or a power producer, with `somersloops > 0` | any factory does |
+| Overclocking | any building group, under a product or a power producer, with `overclockPercent` a finite number other than 100 | any factory does |
+| Custom buildings | `customBuildings` is non-empty | any factory does |
+| Power producers | `powerProducers` is non-empty | any factory does |
+
+Missing, null or wrong-typed fields read as "not used". A factory that is not an object is
+skipped. One bad room must never fail the reload.
+
+Rates on the dashboard are `sf_room_feature_plans / sf_rooms_total` and
+`sf_room_feature_factories / sf_room_factories_total`, both already exported.
+
+## Search
+
+Counted when a result is activated, not when the query changes: a jump is somebody who found what
+they wanted. Buffered in the events store beside the fault buffer and flushed on the same minute
+tick; the report carries `usage: [{ action, count }]` with the action from a closed enum, so a
+client cannot invent a label. Unauthenticated and indicative, like every client counter, and the
+panel says so.
+
+## Out of scope
+
+Feature usage from local plans; per-plan rankings; anything that needs a new write on the edit
+path.

--- a/backend/src/event-counters/event-counters.service.ts
+++ b/backend/src/event-counters/event-counters.service.ts
@@ -1,7 +1,7 @@
 import { Counter, Registry } from 'prom-client'
-import { EVENT_REASONS, EVENT_SOURCES } from 'common'
+import { EVENT_REASONS, EVENT_SOURCES, USAGE_ACTIONS } from 'common'
 import { Injectable } from '@nestjs/common'
-import type { EventReason, EventSource } from 'common'
+import type { EventReason, EventSource, UsageAction } from 'common'
 
 /**
  * The error counters, and nothing else.
@@ -37,6 +37,7 @@ export class EventCountersService {
   private readonly events: Counter<'source' | 'reason'>
   private readonly httpErrors: Counter<'status'>
   private readonly backoffs: Counter<'endpoint' | 'reason'>
+  private readonly usage: Counter<'action'>
 
   constructor () {
     this.events = new Counter({
@@ -60,6 +61,13 @@ export class EventCountersService {
       registers: [this.registry],
     })
 
+    this.usage = new Counter({
+      name: 'sf_usage_total',
+      help: 'Things people did in the planner, by action. Arrives over POST /events like the client faults, so it is indicative rather than authoritative: the endpoint is unauthenticated and anonymous.',
+      labelNames: ['action'],
+      registers: [this.registry],
+    })
+
     // Every series starts at zero rather than appearing on first use. Without this a reason
     // that has never fired is absent, and absent reads as "no data" on a panel rather than as
     // the good news it actually is.
@@ -67,6 +75,13 @@ export class EventCountersService {
       for (const reason of EVENT_REASONS) this.events.inc({ source, reason }, 0)
     }
     for (const [endpoint, reason] of BACKOFFS) this.backoffs.inc({ endpoint, reason }, 0)
+    for (const action of USAGE_ACTIONS) this.usage.inc({ action }, 0)
+  }
+
+  recordUsage (action: UsageAction, count = 1): void {
+    try {
+      this.usage.inc({ action }, count)
+    } catch { /* as above */ }
   }
 
   /** Never throws: a metric must not be able to break what it is measuring. */

--- a/backend/src/metrics/events.controller.ts
+++ b/backend/src/metrics/events.controller.ts
@@ -54,8 +54,11 @@ export class EventsController {
       throw new BackoffException('events', 'too_soon', 'Too many event reports.')
     }
 
-    for (const { reason, count } of parsed.data.events) {
+    for (const { reason, count } of parsed.data.events ?? []) {
       this.counters.record('client', reason, count)
+    }
+    for (const { action, count } of parsed.data.usage ?? []) {
+      this.counters.recordUsage(action, count)
     }
   }
 }

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -1,4 +1,6 @@
 import { Gauge, Registry, collectDefaultMetrics } from 'prom-client'
+import { PLAN_FEATURES, emptyFeatureCounts, planFeatureUsage } from 'common'
+import type { FeatureCounts } from 'common'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { Types } from 'mongoose'
@@ -57,6 +59,9 @@ interface SlowStats {
   topShares: ShareTotal[]
   newRooms: Array<readonly [string, number]>
   newMemberships: Array<readonly [string, number]>
+  /** Live synced plans using each feature, and factories across them using each. */
+  featurePlans: FeatureCounts
+  featureFactories: FeatureCounts
 }
 
 /**
@@ -153,6 +158,8 @@ export class MetricsService {
   private readonly roomFactories: Gauge<'room_id' | 'name' | 'owner'>
   private readonly roomCollaborators: Gauge<'room_id' | 'name' | 'owner'>
   private readonly roomEdits: Gauge<'room_id' | 'name' | 'owner'>
+  private readonly roomFeaturePlans: Gauge<'feature'>
+  private readonly roomFeatureFactories: Gauge<'feature'>
   private readonly userEdits: Gauge<'username'>
   private readonly userFactories: Gauge<'username'>
   private readonly userRooms: Gauge<'username'>
@@ -290,6 +297,18 @@ export class MetricsService {
       name: 'sf_room_edits',
       help: `The ${METRICS_TOP_N} most-edited synced tabs, by accepted edits still on the plan.`,
       labelNames: ['room_id', 'name', 'owner'],
+      registers,
+    })
+    this.roomFeaturePlans = new Gauge({
+      name: 'sf_room_feature_plans',
+      help: 'Live synced tabs using each planner feature. Divide by sf_rooms_total for the rate. Synced plans only; local plans never reach the server.',
+      labelNames: ['feature'],
+      registers,
+    })
+    this.roomFeatureFactories = new Gauge({
+      name: 'sf_room_feature_factories',
+      help: 'Factories across live synced tabs using each planner feature. Divide by sf_room_factories_total for the rate.',
+      labelNames: ['feature'],
       registers,
     })
     this.userEdits = new Gauge({
@@ -504,6 +523,11 @@ export class MetricsService {
     for (const [window, memberships] of stats.newMemberships) {
       this.newMemberships.set({ window }, memberships)
     }
+    // Every feature is written each time, so a never-used one reads zero rather than absent.
+    for (const feature of PLAN_FEATURES) {
+      this.roomFeaturePlans.set({ feature }, stats.featurePlans[feature])
+      this.roomFeatureFactories.set({ feature }, stats.featureFactories[feature])
+    }
   }
 
   private async loadCheap (): Promise<CheapCounts> {
@@ -531,7 +555,7 @@ export class MetricsService {
     const now = this.clock.now()
     const [
       activeAccounts, newAccounts, signedInAccounts, topRooms, topCollaborated, topEdited, topEditors, topOwners,
-      topRoomOwners, newShares, topShares, newRooms, newMemberships,
+      topRoomOwners, newShares, topShares, newRooms, newMemberships, features,
     ] =
       await Promise.all([
         this.countByWindow(now, since => this.users.countDocuments({ lastActiveAt: { $gt: since } })),
@@ -550,12 +574,48 @@ export class MetricsService {
         // would report every new room as an invite somebody accepted.
         this.countByWindow(now, since =>
           this.memberships.countDocuments({ role: 'member', joinedAt: { $gt: since } })),
+        this.sumFeatureUsage(),
       ])
 
     return {
       activeAccounts, newAccounts, signedInAccounts, topRooms, topCollaborated, topEdited, topEditors, topOwners,
-      topRoomOwners, newShares, topShares, newRooms, newMemberships,
+      topRoomOwners, newShares, topShares, newRooms, newMemberships, ...features,
     }
+  }
+
+  /**
+   * Feature usage summed over live rooms, derived in Node rather than in a pipeline:
+   * `factories` is Mixed, so an aggregate over its innards can fail the whole reload on one
+   * malformed document, where `planFeatureUsage` reads junk as "not used" and carries on.
+   * The projection keeps the read to the fields that decide it.
+   */
+  private async sumFeatureUsage (): Promise<{ featurePlans: FeatureCounts, featureFactories: FeatureCounts }> {
+    const featurePlans = emptyFeatureCounts()
+    const featureFactories = emptyFeatureCounts()
+    const cursor = this.rooms
+      .find({ deletedAt: null }, {
+        powerTarget: 1,
+        groups: 1,
+        'factories.partDisposal': 1,
+        'factories.group': 1,
+        'factories.checklistEnabled': 1,
+        'factories.notes': 1,
+        'factories.tasks': 1,
+        'factories.customBuildings': 1,
+        'factories.powerProducers.buildingGroups': 1,
+        'factories.products.buildingGroups': 1,
+      })
+      .lean()
+      .cursor()
+
+    for await (const room of cursor) {
+      const usage = planFeatureUsage(room)
+      for (const feature of PLAN_FEATURES) {
+        if (usage.plan[feature]) featurePlans[feature]++
+        featureFactories[feature] += usage.factories[feature]
+      }
+    }
+    return { featurePlans, featureFactories }
   }
 
   /** Factories and accepted edits in one pass, since both are sums over the same documents. */

--- a/backend/test/events.spec.ts
+++ b/backend/test/events.spec.ts
@@ -101,6 +101,42 @@ describe('POST /events', () => {
     })
   })
 
+  describe('usage', () => {
+    const usage = (body: string, action: string) => sample(body, 'sf_usage_total', `action="${action}"`)
+
+    it('starts every action at zero rather than absent', async () => {
+      expect(usage(await scrape(), 'search_jump')).toBe(0)
+    })
+
+    it('counts a usage-only report, with no fault in it', async () => {
+      const body = report({ usage: [{ action: 'search_jump', count: 4 }] })
+      delete (body as Record<string, unknown>).events
+
+      expect((await post(body)).status).toBe(204)
+      expect(usage(await scrape(), 'search_jump')).toBe(4)
+    })
+
+    it('counts usage beside faults from the same batch, and never mixes them', async () => {
+      const before = await scrape()
+      await post(report({
+        events: [{ reason: 'api_network_error', count: 2 }],
+        usage: [{ action: 'search_jump', count: 3 }],
+      }))
+
+      const body = await scrape()
+      expect(usage(body, 'search_jump')).toBe((usage(before, 'search_jump') ?? 0) + 3)
+      expect(events(body, 'api_network_error')).toBe((events(before, 'api_network_error') ?? 0) + 2)
+      expect(sample(body, 'sf_events_total', 'source="client",reason="search_jump"')).toBeUndefined()
+    })
+
+    it('refuses an action it does not know', async () => {
+      const body = report({ usage: [{ action: 'search_typed', count: 1 }] })
+      delete (body as Record<string, unknown>).events
+
+      expect((await post(body)).status).toBe(400)
+    })
+  })
+
   describe('what it refuses', () => {
     // The whole cardinality design: a client cannot invent a label.
     it.each(['not_a_reason', 'plan_repair_made_up', '../../etc', ''])(

--- a/backend/test/metrics-usage.spec.ts
+++ b/backend/test/metrics-usage.spec.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { getModelToken } from '@nestjs/mongoose'
 import type { Model } from 'mongoose'
 
+import { PLAN_FEATURES } from 'common'
 import {
   ACTIVE_ACCOUNT_WINDOWS,
   DELETED_OWNER,
@@ -663,6 +664,79 @@ describe('the database-backed usage metrics', () => {
       }
 
       expect(labelValues(await scrape(), 'sf_room_collaborators', 'room_id').length).toBe(METRICS_TOP_N)
+    })
+  })
+
+  describe('feature utilisation over synced plans', () => {
+    const plans = (body: string, feature: string) => sample(body, 'sf_room_feature_plans', `feature="${feature}"`)
+    const factories = (body: string, feature: string) => sample(body, 'sf_room_feature_factories', `feature="${feature}"`)
+
+    it('starts every feature at zero rather than absent', async () => {
+      const body = await scrape()
+
+      for (const feature of PLAN_FEATURES) {
+        expect(plans(body, feature)).toBe(0)
+        expect(factories(body, feature)).toBe(0)
+      }
+    })
+
+    it('counts plans and factories using each feature across live rooms', async () => {
+      await rooms().create({
+        roomId: randomUUID(),
+        name: 'Sinks',
+        createdBy: 'someone',
+        powerTarget: 300,
+        factories: [
+          { id: 1, partDisposal: { IronIngot: { sinks: 1, depots: 0 } }, checklistEnabled: true },
+          { id: 2, partDisposal: { Copper: { sinks: 2, depots: 0 } }, notes: 'x' },
+          { id: 3 },
+        ],
+      })
+      await rooms().create({
+        roomId: randomUUID(),
+        name: 'Clocked',
+        createdBy: 'someone',
+        factories: [
+          { id: 1, products: [{ id: 'IronIngot', buildingGroups: [{ id: 1, overclockPercent: 200, somersloops: 1 }] }] },
+          { id: 2, powerProducers: [{ id: 'g', buildingGroups: [{ id: 1, overclockPercent: 100 }] }] },
+        ],
+      })
+      await rooms().create({ roomId: randomUUID(), name: 'Gone', createdBy: 'someone', deletedAt: new Date(), factories: [{ id: 1, notes: 'deleted' }] })
+
+      const body = await scrape()
+
+      expect(plans(body, 'sink')).toBe(1)
+      expect(factories(body, 'sink')).toBe(2)
+      expect(plans(body, 'power_target')).toBe(1)
+      expect(factories(body, 'power_target')).toBe(0)
+      expect(plans(body, 'checklist')).toBe(1)
+      expect(plans(body, 'notes')).toBe(1)
+      expect(factories(body, 'notes')).toBe(1)
+      expect(plans(body, 'overclocking')).toBe(1)
+      expect(factories(body, 'overclocking')).toBe(1)
+      expect(plans(body, 'somersloops')).toBe(1)
+      expect(plans(body, 'power_producers')).toBe(1)
+      expect(plans(body, 'depot')).toBe(0)
+      expect(sample(body, 'sf_rooms_total', 'shared="false"')).toBe(2)
+    })
+
+    // `factories` is Mixed, so nothing in Mongo checks what an old document holds inside it.
+    it('survives a room whose factories are not what the type says', async () => {
+      await rooms().collection.insertOne({
+        roomId: randomUUID(),
+        name: 'Worse',
+        createdBy: 'someone',
+        deletedAt: null,
+        powerTarget: 'lots',
+        factories: [null, 5, { id: 1, partDisposal: [1, 2], tasks: 'none', notes: 'kept' }],
+      })
+
+      const body = await scrape()
+
+      expect(sample(body, 'sf_metrics_database_up')).toBe(1)
+      expect(plans(body, 'notes')).toBe(1)
+      expect(plans(body, 'sink')).toBe(0)
+      expect(plans(body, 'power_target')).toBe(0)
     })
   })
 

--- a/common/src/feature-usage.spec.ts
+++ b/common/src/feature-usage.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+import { PLAN_FEATURES, emptyFeatureCounts, factoryFeatures, planFeatureUsage } from './feature-usage'
+
+const bare = () => ({ id: 1, name: 'Bare', products: [], powerProducers: [] })
+
+const none = () => Object.fromEntries(PLAN_FEATURES.map(feature => [feature, false]))
+
+describe('factoryFeatures', () => {
+  it('reads a bare factory as using nothing', () => {
+    expect(factoryFeatures(bare())).toEqual(none())
+  })
+
+  it('returns null for anything that is not an object', () => {
+    for (const junk of [null, undefined, 3, 'factory', [bare()]]) expect(factoryFeatures(junk)).toBeNull()
+  })
+
+  it.each([
+    ['sink', { partDisposal: { IronIngot: { sinks: 2, depots: 0 } } }],
+    ['depot', { partDisposal: { IronIngot: { sinks: 0, depots: 1 } } }],
+    ['groups', { group: { id: 'g', name: 'Steel', color: '#fff', order: 0 } }],
+    ['checklist', { checklistEnabled: true }],
+    ['notes', { notes: 'remember the belts' }],
+    ['tasks', { tasks: [{ title: 'build it', completed: false }] }],
+    ['custom_buildings', { customBuildings: [{ id: 'p', building: 'portal', amount: 1 }] }],
+    ['power_producers', { powerProducers: [{ id: 'g', building: 'generatorcoal' }] }],
+    ['somersloops', { products: [{ id: 'IronIngot', buildingGroups: [{ id: 1, somersloops: 2 }] }] }],
+    ['overclocking', { products: [{ id: 'IronIngot', buildingGroups: [{ id: 1, overclockPercent: 150 }] }] }],
+    ['overclocking', { products: [{ id: 'IronIngot', buildingGroups: [{ id: 1, overclockPercent: 50 }] }] }],
+  ])('detects %s', (feature, extra) => {
+    expect(factoryFeatures({ ...bare(), ...extra })).toEqual({ ...none(), [feature]: true })
+  })
+
+  it('finds somersloops and overclocking under power producers as well as products', () => {
+    const factory = { ...bare(), powerProducers: [{ id: 'g', buildingGroups: [{ id: 1, somersloops: 1, overclockPercent: 250 }] }] }
+
+    expect(factoryFeatures(factory)).toEqual({ ...none(), somersloops: true, overclocking: true, power_producers: true })
+  })
+
+  it.each([
+    ['blank notes', { notes: '   \n' }],
+    ['a zero sink count', { partDisposal: { IronIngot: { sinks: 0, depots: 0 } } }],
+    ['a negative depot count', { partDisposal: { IronIngot: { sinks: 0, depots: -1 } } }],
+    ['a 100% clock', { products: [{ id: 'x', buildingGroups: [{ id: 1, overclockPercent: 100 }] }] }],
+    ['a NaN clock', { products: [{ id: 'x', buildingGroups: [{ id: 1, overclockPercent: NaN }] }] }],
+    ['a clock stored as a string', { products: [{ id: 'x', buildingGroups: [{ id: 1, overclockPercent: '150' }] }] }],
+    ['an empty task list', { tasks: [] }],
+    ['a group that is not an object', { group: 'steel' }],
+    ['checklistEnabled as a string', { checklistEnabled: 'true' }],
+    ['a partDisposal that is an array', { partDisposal: [{ sinks: 3 }] }],
+    ['building groups that are not objects', { products: [{ id: 'x', buildingGroups: [3, null, 'x'] }] }],
+  ])('reads %s as not used', (_label, extra) => {
+    expect(factoryFeatures({ ...bare(), ...extra })).toEqual(none())
+  })
+})
+
+describe('planFeatureUsage', () => {
+  it('counts factories per feature and marks the plan for any of them', () => {
+    const usage = planFeatureUsage({
+      factories: [
+        { ...bare(), checklistEnabled: true, notes: 'a' },
+        { ...bare(), checklistEnabled: true },
+        bare(),
+      ],
+    })
+
+    expect(usage.factoryCount).toBe(3)
+    expect(usage.factories).toEqual({ ...emptyFeatureCounts(), checklist: 2, notes: 1 })
+    expect(usage.plan).toEqual({ ...none(), checklist: true, notes: true })
+  })
+
+  it('reads the power target and groups off the plan itself', () => {
+    const usage = planFeatureUsage({ powerTarget: 500, groups: [{ id: 'g', name: 'A', color: '#000', order: 0 }], factories: [] })
+
+    expect(usage.plan.power_target).toBe(true)
+    expect(usage.plan.groups).toBe(true)
+    expect(usage.factories.power_target).toBe(0)
+  })
+
+  it.each([0, -5, NaN, '500', null, undefined])('does not count a power target of %s', target => {
+    expect(planFeatureUsage({ powerTarget: target, factories: [] }).plan.power_target).toBe(false)
+  })
+
+  it('skips factories that are not objects and never throws on junk', () => {
+    const usage = planFeatureUsage({ factories: [null, 4, 'x', bare(), { ...bare(), notes: 'n' }] })
+
+    expect(usage.factoryCount).toBe(2)
+    expect(usage.factories.notes).toBe(1)
+  })
+
+  it.each([null, undefined, 'plan', [], { factories: 'nope' }, { factories: null }])('reads %s as an empty plan', plan => {
+    const usage = planFeatureUsage(plan)
+
+    expect(usage.factoryCount).toBe(0)
+    expect(usage.factories).toEqual(emptyFeatureCounts())
+    expect(Object.values(usage.plan).every(used => !used)).toBe(true)
+  })
+})

--- a/common/src/feature-usage.ts
+++ b/common/src/feature-usage.ts
@@ -1,0 +1,116 @@
+/**
+ * Which planner features a plan uses, for the utilisation gauges.
+ *
+ * Read off the plan as stored and never written on edit. Defensive throughout: `Room.factories`
+ * is a Mixed field, so an old or hand-edited document can hold anything, and one bad plan must
+ * never fail the reload that feeds every gauge. Anything missing, null or wrong-typed reads as
+ * "not used", and a factory that is not an object is skipped.
+ */
+export const PLAN_FEATURES = [
+  'sink',
+  'depot',
+  'power_target',
+  'groups',
+  'checklist',
+  'notes',
+  'tasks',
+  'somersloops',
+  'overclocking',
+  'custom_buildings',
+  'power_producers',
+] as const
+
+export type PlanFeature = typeof PLAN_FEATURES[number]
+
+export type FeatureCounts = Record<PlanFeature, number>
+
+export interface PlanFeatureUsage {
+  /** Whether the plan uses each feature at all. */
+  plan: Record<PlanFeature, boolean>
+  /** How many of the plan's factories use each. Plan-level features count zero here. */
+  factories: FeatureCounts
+  /** Factories that were objects and therefore inspected. */
+  factoryCount: number
+}
+
+export const emptyFeatureCounts = (): FeatureCounts =>
+  Object.fromEntries(PLAN_FEATURES.map(feature => [feature, 0])) as FeatureCounts
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const nonEmptyArray = (value: unknown): value is unknown[] => Array.isArray(value) && value.length > 0
+
+const positive = (value: unknown): boolean => typeof value === 'number' && Number.isFinite(value) && value > 0
+
+/** Building groups sit under products and under power producers; both are searched. */
+const buildingGroups = (factory: Record<string, unknown>): Record<string, unknown>[] => {
+  const groups: Record<string, unknown>[] = []
+  for (const key of ['products', 'powerProducers']) {
+    const owners = factory[key]
+    if (!Array.isArray(owners)) continue
+    for (const owner of owners) {
+      if (!isObject(owner) || !Array.isArray(owner.buildingGroups)) continue
+      for (const group of owner.buildingGroups) if (isObject(group)) groups.push(group)
+    }
+  }
+  return groups
+}
+
+const disposes = (factory: Record<string, unknown>, field: 'sinks' | 'depots'): boolean => {
+  if (!isObject(factory.partDisposal)) return false
+  return Object.values(factory.partDisposal).some(entry => isObject(entry) && positive(entry[field]))
+}
+
+/** Per-factory features. The plan-level ones (`power_target`, `groups`) are decided by the caller. */
+export const factoryFeatures = (factory: unknown): Record<PlanFeature, boolean> | null => {
+  if (!isObject(factory)) return null
+  const groups = buildingGroups(factory)
+
+  return {
+    sink: disposes(factory, 'sinks'),
+    depot: disposes(factory, 'depots'),
+    power_target: false,
+    groups: isObject(factory.group),
+    checklist: factory.checklistEnabled === true,
+    notes: typeof factory.notes === 'string' && factory.notes.trim().length > 0,
+    tasks: nonEmptyArray(factory.tasks),
+    somersloops: groups.some(group => positive(group.somersloops)),
+    overclocking: groups.some(group =>
+      typeof group.overclockPercent === 'number' &&
+      Number.isFinite(group.overclockPercent) &&
+      group.overclockPercent !== 100),
+    custom_buildings: nonEmptyArray(factory.customBuildings),
+    power_producers: nonEmptyArray(factory.powerProducers),
+  }
+}
+
+/**
+ * One plan's usage. `plan` is the shape a room or a tab shares: its factories, its power
+ * target and its groups; nothing else is read.
+ */
+export const planFeatureUsage = (plan: unknown): PlanFeatureUsage => {
+  const factories = emptyFeatureCounts()
+  const usage: PlanFeatureUsage = {
+    plan: Object.fromEntries(PLAN_FEATURES.map(feature => [feature, false])) as Record<PlanFeature, boolean>,
+    factories,
+    factoryCount: 0,
+  }
+  if (!isObject(plan)) return usage
+
+  usage.plan.power_target = positive(plan.powerTarget)
+  usage.plan.groups = nonEmptyArray(plan.groups)
+
+  if (!Array.isArray(plan.factories)) return usage
+  for (const factory of plan.factories) {
+    const features = factoryFeatures(factory)
+    if (features === null) continue
+    usage.factoryCount++
+    for (const feature of PLAN_FEATURES) {
+      if (!features[feature]) continue
+      factories[feature]++
+      usage.plan[feature] = true
+    }
+  }
+  return usage
+}

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,5 +1,6 @@
 export * from './caps'
 export * from './truncate'
+export * from './feature-usage'
 export * from './types/api'
 export * from './types/factory'
 export * from './types/protocol'

--- a/common/src/schemas/events.spec.ts
+++ b/common/src/schemas/events.spec.ts
@@ -4,7 +4,9 @@ import {
   EVENT_CAPS,
   EVENT_REASONS,
   EVENT_SOURCES,
+  USAGE_ACTIONS,
   isEventReason,
+  isUsageAction,
   parseEventReport,
 } from './events'
 
@@ -71,6 +73,7 @@ describe('eventReportSchema', () => {
 
   it('rejects an empty batch and one past the entry cap', () => {
     expect(parseEventReport(report({ events: [] })).success).toBe(false)
+    expect(parseEventReport(report({ events: undefined })).success).toBe(false)
 
     const tooMany = Array.from(
       { length: EVENT_CAPS.entries + 1 },
@@ -122,5 +125,46 @@ describe('the reason enum', () => {
     expect(isEventReason('sync_op_reject_stale')).toBe(false)
     expect(isEventReason('sync_op_reject_duplicate')).toBe(false)
     expect(isEventReason('sync_op_reject_forbidden')).toBe(true)
+  })
+})
+
+describe('the usage list', () => {
+  const usageOnly = (overrides: Record<string, unknown> = {}) => {
+    const body = report({ usage: [{ action: 'search_jump', count: 3 }], ...overrides })
+    delete (body as Record<string, unknown>).events
+    return body
+  }
+
+  it('accepts a report carrying only usage', () => {
+    expect(parseEventReport(usageOnly()).success).toBe(true)
+  })
+
+  it('accepts usage beside events', () => {
+    expect(parseEventReport(report({ usage: [{ action: 'search_jump', count: 1 }] })).success).toBe(true)
+  })
+
+  it('rejects a report with neither events nor usage, however it is spelled', () => {
+    expect(parseEventReport(usageOnly({ usage: [] })).success).toBe(false)
+    expect(parseEventReport(usageOnly({ usage: undefined })).success).toBe(false)
+    expect(parseEventReport(report({ events: [], usage: [] })).success).toBe(false)
+  })
+
+  it('rejects an action the server has never heard of', () => {
+    expect(parseEventReport(usageOnly({ usage: [{ action: 'typed_a_letter', count: 1 }] })).success).toBe(false)
+  })
+
+  it('rejects an entry with anything beyond action and count', () => {
+    expect(parseEventReport(usageOnly({ usage: [{ action: 'search_jump', count: 1, query: 'copper' }] })).success).toBe(false)
+  })
+
+  it('bounds the count the same way as an event', () => {
+    expect(parseEventReport(usageOnly({ usage: [{ action: 'search_jump', count: 0 }] })).success).toBe(false)
+    expect(parseEventReport(usageOnly({ usage: [{ action: 'search_jump', count: EVENT_CAPS.count + 1 }] })).success).toBe(false)
+  })
+
+  it('knows its own actions', () => {
+    expect(USAGE_ACTIONS).toContain('search_jump')
+    expect(isUsageAction('search_jump')).toBe(true)
+    expect(isUsageAction('search_typed')).toBe(false)
   })
 })

--- a/common/src/schemas/events.ts
+++ b/common/src/schemas/events.ts
@@ -107,6 +107,23 @@ const eventEntrySchema = z.strictObject({
 })
 
 /**
+ * Things people did, as opposed to things that went wrong. Counted the same way and carried on
+ * the same report, kept apart so the fault panels stay faults. Closed list: a client cannot
+ * invent an action, so the series count is bounded by this file.
+ */
+export const USAGE_ACTIONS = [
+  /** A search result was activated: somebody found what they were looking for. Keystrokes are not counted. */
+  'search_jump',
+] as const
+
+export type UsageAction = typeof USAGE_ACTIONS[number]
+
+const usageEntrySchema = z.strictObject({
+  action: z.enum(USAGE_ACTIONS),
+  count: z.number().int().min(1).max(EVENT_CAPS.count),
+})
+
+/**
  * A batch of counts, posted to `POST /events`.
  *
  * Batched rather than one request per event, because one request per occurrence is a request
@@ -121,12 +138,20 @@ export const eventReportSchema = z.strictObject({
   instanceId: z.uuid(),
   appVersion: z.string().min(1).max(32),
   gitSha: z.string().max(40).optional(),
-  events: z.array(eventEntrySchema).min(1).max(EVENT_CAPS.entries),
-})
+  events: z.array(eventEntrySchema).max(EVENT_CAPS.entries).optional(),
+  usage: z.array(usageEntrySchema).max(USAGE_ACTIONS.length).optional(),
+}).refine(
+  report => (report.events?.length ?? 0) + (report.usage?.length ?? 0) > 0,
+  { message: 'A report carries at least one event or one usage entry.' },
+)
 
 export type EventReport = z.infer<typeof eventReportSchema>
 
 export const parseEventReport = (input: unknown) => eventReportSchema.safeParse(input)
+
+/** True when a value is an action the server would accept. Used to bound the client buffer. */
+export const isUsageAction = (value: unknown): value is UsageAction =>
+  typeof value === 'string' && (USAGE_ACTIONS as readonly string[]).includes(value)
 
 /** True when a value is a reason the server would accept. Used to bound the client buffer. */
 export const isEventReason = (value: unknown): value is EventReason =>

--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -166,12 +166,14 @@ def timeseries(unit="short", fill=15, stack="none", steps=None, decimals=None,
     }
 
 
-def bargauge(display_name=None, unit="short"):
+def bargauge(display_name=None, unit="short", minmax=None):
     defaults = {
         "unit": unit,
         "thresholds": {"mode": "absolute", "steps": [{"value": 0, "color": "green"}]},
         "color": {"mode": "palette-classic"},
     }
+    if minmax:
+        defaults["min"], defaults["max"] = minmax
     if display_name:
         defaults["displayName"] = display_name
     return {
@@ -539,10 +541,12 @@ add(87, "Of Those Who Signed In, How Many Edited",
 # is the opposite — a stored tally that only ever rises, so a plan made and then deleted
 # still counts. It starts at zero when this shipped, because the activity log it would
 # otherwise be read from is trimmed to 200 rows a plan and deleted with the plan.
-add(110, "Plans Ever Created",
-    "Synced plans made, all time. Unlike Synced Plans above, deleting a plan does not take it back off this number. Counts from when this metric shipped.",
-    [query('sum(sf_room_actions_total%s)' % sel('action="created"'), "Created")],
-    stat(BLUE, graph="area", color_mode="background_solid"))
+add(110, "How Synced Plans Arrived",
+    "Every way a synced plan comes to exist, all time since this tally shipped: made from scratch while signed in, a local tab adopted into the account at sign-in, or the old cloud sync restored. Deleting a plan does not take it back off, so these minus Plans Ever Deleted is roughly Synced Plans.",
+    [query('sum(sf_room_actions_total%s)' % sel('action="created"'), "From scratch", "A"),
+     query('sum(sf_room_actions_total%s)' % sel('action="adopted"'), "Adopted", "B"),
+     query('sum(sf_room_actions_total%s)' % sel('action="imported"'), "Imported", "C")],
+    stat(BLUE, color_mode="value", text_mode="value_and_name"))
 
 add(111, "Plans Ever Shared",
     "Times somebody turned a plan into a collaborative one by allocating an invite link. A plan shared, unshared and shared again counts twice, because that is two decisions to share.",
@@ -590,6 +594,64 @@ add(116, "Plan Lifecycle Over Time",
     [query('sum(sf_room_actions_total%s)' % sel('action="%s"' % action), legend, "ABCDEFGH"[index])
      for index, (action, legend) in enumerate(LIFECYCLE_ACTIONS)],
     timeseries(fill=8))
+
+# ---------------------------------------------------------- feature utilisation
+# Synced plans only. Local plans never reach the server and are not counted anywhere here;
+# these rates are over the plans the service can see, which are the people who use it most.
+FEATURES = [
+    ("sink", "AWESOME Sink"),
+    ("depot", "Dimensional Depot"),
+    ("power_target", "Power target"),
+    ("groups", "Groups"),
+    ("checklist", "Checklist"),
+    ("notes", "Notes"),
+    ("tasks", "Tasks"),
+    ("somersloops", "Somersloops"),
+    ("overclocking", "Overclocking"),
+    ("custom_buildings", "Custom buildings"),
+    ("power_producers", "Power producers"),
+]
+
+
+def feature_queries(metric, total):
+    return [
+        query("sum(%s%s) / sum(%s%s)" % (metric, sel('feature="%s"' % feature), total, J), legend,
+              "ABCDEFGHIJK"[index])
+        for index, (feature, legend) in enumerate(FEATURES)
+    ]
+
+
+add(130, "Plans Using Each Feature",
+    "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target and groups are plan-level settings; everything else is any factory in the plan.",
+    [query("sort_desc(sum by (feature) (sf_room_feature_plans%s) / ignoring(feature) group_left sum(sf_rooms_total%s))" % (J, J), "{{feature}}", instant=True)],
+    bargauge(display_name="${__field.labels.feature}", unit="percentunit", minmax=(0, 1)))
+
+add(131, "Factories Using Each Feature",
+    "Share of factories across live synced plans using each feature. Plan-level settings read zero here by design.",
+    [query("sort_desc(sum by (feature) (sf_room_feature_factories%s) / ignoring(feature) group_left sum(sf_room_factories_total%s))" % (J, J), "{{feature}}", instant=True)],
+    bargauge(display_name="${__field.labels.feature}", unit="percentunit", minmax=(0, 1)))
+
+add(132, "Plan Utilisation Over Time",
+    "The same plan-level rates, plotted. A line rising is a feature being picked up.",
+    feature_queries("sf_room_feature_plans", "sf_rooms_total"),
+    timeseries(unit="percentunit", fill=0, minmax=(0, 1)))
+
+add(133, "Factory Utilisation Over Time",
+    "The same factory-level rates, plotted.",
+    feature_queries("sf_room_feature_factories", "sf_room_factories_total"),
+    timeseries(unit="percentunit", fill=0, minmax=(0, 1)))
+
+add(134, "Searches Used",
+    "Search results somebody activated to jump to a factory; typing is not counted. Arrives over the same anonymous endpoint as the fault counts, so it is indicative rather than exact.",
+    [query("round(sum(increase(sf_usage_total%s[24h])))" % sel('action="search_jump"'), "24 hours", "A"),
+     query("round(sum(increase(sf_usage_total%s[7d])))" % sel('action="search_jump"'), "7 days", "B"),
+     query("sum(sf_usage_total%s)" % sel('action="search_jump"'), "Since deploy", "C")],
+    stat(GREEN, color_mode="value", text_mode="value_and_name"))
+
+add(135, "Searches Used Over Time",
+    "Per hour. Indicative, as above.",
+    [query("round(sum(increase(sf_usage_total%s[1h])))" % sel('action="search_jump"'), "Searches used")],
+    timeseries(fill=15))
 
 # ----------------------------------------------------------------- share links
 # Snapshot links, the "copy a link to this plan" feature. Every number here comes from the
@@ -764,6 +826,11 @@ rows = [
         item(12, 0, 6, 4, 112), item(18, 0, 6, 4, 113),
         item(0, 4, 12, 4, 114), item(12, 4, 12, 4, 115),
         item(0, 8, 24, 8, 116),
+    ]),
+    row("🧰 Feature Utilisation · from the database, synced plans only", [
+        item(0, 0, 12, 10, 130), item(12, 0, 12, 10, 131),
+        item(0, 10, 12, 8, 132), item(12, 10, 12, 8, 133),
+        item(0, 18, 8, 4, 134), item(8, 18, 16, 4, 135),
     ]),
     row("🔗 Share Links · from the database", [
         item(0, 0, 5, 4, 100), item(5, 0, 5, 4, 101), item(10, 0, 4, 4, 102),

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -5663,8 +5663,8 @@
         "kind": "Panel",
         "spec": {
           "id": 110,
-          "title": "Plans Ever Created",
-          "description": "Synced plans made, all time. Unlike Synced Plans above, deleting a plan does not take it back off this number. Counts from when this metric shipped.",
+          "title": "How Synced Plans Arrived",
+          "description": "Every way a synced plan comes to exist, all time since this tally shipped: made from scratch while signed in, a local tab adopted into the account at sign-in, or the old cloud sync restored. Deleting a plan does not take it back off, so these minus Plans Ever Deleted is roughly Synced Plans.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -5683,11 +5683,53 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories-preview\",action=\"created\"})",
-                        "legendFormat": "Created",
+                        "legendFormat": "From scratch",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories-preview\",action=\"adopted\"})",
+                        "legendFormat": "Adopted",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories-preview\",action=\"imported\"})",
+                        "legendFormat": "Imported",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
                     "hidden": false
                   }
                 }
@@ -5702,8 +5744,8 @@
             "version": "13.0.2",
             "spec": {
               "options": {
-                "colorMode": "background_solid",
-                "graphMode": "area",
+                "colorMode": "value",
+                "graphMode": "none",
                 "justifyMode": "auto",
                 "orientation": "auto",
                 "percentChangeColorMode": "standard",
@@ -5715,7 +5757,7 @@
                   "values": false
                 },
                 "showPercentChange": false,
-                "textMode": "auto",
+                "textMode": "value_and_name",
                 "wideLayout": true
               },
               "fieldConfig": {
@@ -6464,6 +6506,1082 @@
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
                     "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-130": {
+        "kind": "Panel",
+        "spec": {
+          "id": 130,
+          "title": "Plans Using Each Feature",
+          "description": "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target and groups are plan-level settings; everything else is any factory in the plan.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sum by (feature) (sf_room_feature_plans{job=\"satisfactory-factories-preview\"}) / ignoring(feature) group_left sum(sf_rooms_total{job=\"satisfactory-factories-preview\"}))",
+                        "legendFormat": "{{feature}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "min": 0,
+                  "max": 1,
+                  "displayName": "${__field.labels.feature}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-131": {
+        "kind": "Panel",
+        "spec": {
+          "id": 131,
+          "title": "Factories Using Each Feature",
+          "description": "Share of factories across live synced plans using each feature. Plan-level settings read zero here by design.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sum by (feature) (sf_room_feature_factories{job=\"satisfactory-factories-preview\"}) / ignoring(feature) group_left sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"}))",
+                        "legendFormat": "{{feature}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "min": 0,
+                  "max": 1,
+                  "displayName": "${__field.labels.feature}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-132": {
+        "kind": "Panel",
+        "spec": {
+          "id": 132,
+          "title": "Plan Utilisation Over Time",
+          "description": "The same plan-level rates, plotted. A line rising is a feature being picked up.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"sink\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "AWESOME Sink",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"depot\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Dimensional Depot",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"power_target\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Power target",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"groups\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Groups",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"checklist\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Checklist",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"notes\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Notes",
+                        "range": true
+                      }
+                    },
+                    "refId": "F",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"tasks\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Tasks",
+                        "range": true
+                      }
+                    },
+                    "refId": "G",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"somersloops\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Somersloops",
+                        "range": true
+                      }
+                    },
+                    "refId": "H",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"overclocking\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Overclocking",
+                        "range": true
+                      }
+                    },
+                    "refId": "I",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"custom_buildings\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Custom buildings",
+                        "range": true
+                      }
+                    },
+                    "refId": "J",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"power_producers\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Power producers",
+                        "range": true
+                      }
+                    },
+                    "refId": "K",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-133": {
+        "kind": "Panel",
+        "spec": {
+          "id": 133,
+          "title": "Factory Utilisation Over Time",
+          "description": "The same factory-level rates, plotted.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"sink\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "AWESOME Sink",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"depot\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Dimensional Depot",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"power_target\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Power target",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"groups\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Groups",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"checklist\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Checklist",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"notes\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Notes",
+                        "range": true
+                      }
+                    },
+                    "refId": "F",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"tasks\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Tasks",
+                        "range": true
+                      }
+                    },
+                    "refId": "G",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"somersloops\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Somersloops",
+                        "range": true
+                      }
+                    },
+                    "refId": "H",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"overclocking\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Overclocking",
+                        "range": true
+                      }
+                    },
+                    "refId": "I",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"custom_buildings\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Custom buildings",
+                        "range": true
+                      }
+                    },
+                    "refId": "J",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"power_producers\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Power producers",
+                        "range": true
+                      }
+                    },
+                    "refId": "K",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-134": {
+        "kind": "Panel",
+        "spec": {
+          "id": 134,
+          "title": "Searches Used",
+          "description": "Search results somebody activated to jump to a factory; typing is not counted. Arrives over the same anonymous endpoint as the fault counts, so it is indicative rather than exact.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "round(sum(increase(sf_usage_total{job=\"satisfactory-factories-preview\",action=\"search_jump\"}[24h])))",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "round(sum(increase(sf_usage_total{job=\"satisfactory-factories-preview\",action=\"search_jump\"}[7d])))",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_usage_total{job=\"satisfactory-factories-preview\",action=\"search_jump\"})",
+                        "legendFormat": "Since deploy",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-135": {
+        "kind": "Panel",
+        "spec": {
+          "id": 135,
+          "title": "Searches Used Over Time",
+          "description": "Per hour. Indicative, as above.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "round(sum(increase(sf_usage_total{job=\"satisfactory-factories-preview\",action=\"search_jump\"}[1h])))",
+                        "legendFormat": "Searches used",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 15,
                     "gradientMode": "opacity",
                     "hideFrom": {
                       "legend": false,
@@ -9351,6 +10469,98 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-116"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🧰 Feature Utilisation · from the database, synced plans only",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-130"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-131"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 10,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-132"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 10,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-133"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 18,
+                        "width": 8,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-134"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 8,
+                        "y": 18,
+                        "width": 16,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-135"
                         }
                       }
                     }

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -5663,8 +5663,8 @@
         "kind": "Panel",
         "spec": {
           "id": 110,
-          "title": "Plans Ever Created",
-          "description": "Synced plans made, all time. Unlike Synced Plans above, deleting a plan does not take it back off this number. Counts from when this metric shipped.",
+          "title": "How Synced Plans Arrived",
+          "description": "Every way a synced plan comes to exist, all time since this tally shipped: made from scratch while signed in, a local tab adopted into the account at sign-in, or the old cloud sync restored. Deleting a plan does not take it back off, so these minus Plans Ever Deleted is roughly Synced Plans.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -5683,11 +5683,53 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories\",action=\"created\"})",
-                        "legendFormat": "Created",
+                        "legendFormat": "From scratch",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories\",action=\"adopted\"})",
+                        "legendFormat": "Adopted",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories\",action=\"imported\"})",
+                        "legendFormat": "Imported",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
                     "hidden": false
                   }
                 }
@@ -5702,8 +5744,8 @@
             "version": "13.0.2",
             "spec": {
               "options": {
-                "colorMode": "background_solid",
-                "graphMode": "area",
+                "colorMode": "value",
+                "graphMode": "none",
                 "justifyMode": "auto",
                 "orientation": "auto",
                 "percentChangeColorMode": "standard",
@@ -5715,7 +5757,7 @@
                   "values": false
                 },
                 "showPercentChange": false,
-                "textMode": "auto",
+                "textMode": "value_and_name",
                 "wideLayout": true
               },
               "fieldConfig": {
@@ -6464,6 +6506,1082 @@
                     "barWidthFactor": 0.6,
                     "drawStyle": "line",
                     "fillOpacity": 8,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-130": {
+        "kind": "Panel",
+        "spec": {
+          "id": 130,
+          "title": "Plans Using Each Feature",
+          "description": "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target and groups are plan-level settings; everything else is any factory in the plan.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sum by (feature) (sf_room_feature_plans{job=\"satisfactory-factories\"}) / ignoring(feature) group_left sum(sf_rooms_total{job=\"satisfactory-factories\"}))",
+                        "legendFormat": "{{feature}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "min": 0,
+                  "max": 1,
+                  "displayName": "${__field.labels.feature}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-131": {
+        "kind": "Panel",
+        "spec": {
+          "id": 131,
+          "title": "Factories Using Each Feature",
+          "description": "Share of factories across live synced plans using each feature. Plan-level settings read zero here by design.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sort_desc(sum by (feature) (sf_room_feature_factories{job=\"satisfactory-factories\"}) / ignoring(feature) group_left sum(sf_room_factories_total{job=\"satisfactory-factories\"}))",
+                        "legendFormat": "{{feature}}",
+                        "instant": true,
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 0,
+                "namePlacement": "left",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "min": 0,
+                  "max": 1,
+                  "displayName": "${__field.labels.feature}"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-132": {
+        "kind": "Panel",
+        "spec": {
+          "id": 132,
+          "title": "Plan Utilisation Over Time",
+          "description": "The same plan-level rates, plotted. A line rising is a feature being picked up.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"sink\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "AWESOME Sink",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"depot\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Dimensional Depot",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"power_target\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Power target",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"groups\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Groups",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"checklist\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Checklist",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"notes\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Notes",
+                        "range": true
+                      }
+                    },
+                    "refId": "F",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"tasks\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Tasks",
+                        "range": true
+                      }
+                    },
+                    "refId": "G",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"somersloops\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Somersloops",
+                        "range": true
+                      }
+                    },
+                    "refId": "H",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"overclocking\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Overclocking",
+                        "range": true
+                      }
+                    },
+                    "refId": "I",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"custom_buildings\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Custom buildings",
+                        "range": true
+                      }
+                    },
+                    "refId": "J",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"power_producers\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Power producers",
+                        "range": true
+                      }
+                    },
+                    "refId": "K",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-133": {
+        "kind": "Panel",
+        "spec": {
+          "id": 133,
+          "title": "Factory Utilisation Over Time",
+          "description": "The same factory-level rates, plotted.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"sink\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "AWESOME Sink",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"depot\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Dimensional Depot",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"power_target\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Power target",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"groups\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Groups",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"checklist\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Checklist",
+                        "range": true
+                      }
+                    },
+                    "refId": "E",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"notes\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Notes",
+                        "range": true
+                      }
+                    },
+                    "refId": "F",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"tasks\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Tasks",
+                        "range": true
+                      }
+                    },
+                    "refId": "G",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"somersloops\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Somersloops",
+                        "range": true
+                      }
+                    },
+                    "refId": "H",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"overclocking\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Overclocking",
+                        "range": true
+                      }
+                    },
+                    "refId": "I",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"custom_buildings\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Custom buildings",
+                        "range": true
+                      }
+                    },
+                    "refId": "J",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"power_producers\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Power producers",
+                        "range": true
+                      }
+                    },
+                    "refId": "K",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-134": {
+        "kind": "Panel",
+        "spec": {
+          "id": 134,
+          "title": "Searches Used",
+          "description": "Search results somebody activated to jump to a factory; typing is not counted. Arrives over the same anonymous endpoint as the fault counts, so it is indicative rather than exact.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "round(sum(increase(sf_usage_total{job=\"satisfactory-factories\",action=\"search_jump\"}[24h])))",
+                        "legendFormat": "24 hours",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "round(sum(increase(sf_usage_total{job=\"satisfactory-factories\",action=\"search_jump\"}[7d])))",
+                        "legendFormat": "7 days",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_usage_total{job=\"satisfactory-factories\",action=\"search_jump\"})",
+                        "legendFormat": "Since deploy",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value_and_name",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-135": {
+        "kind": "Panel",
+        "spec": {
+          "id": 135,
+          "title": "Searches Used Over Time",
+          "description": "Per hour. Indicative, as above.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "round(sum(increase(sf_usage_total{job=\"satisfactory-factories\",action=\"search_jump\"}[1h])))",
+                        "legendFormat": "Searches used",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.2",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 15,
                     "gradientMode": "opacity",
                     "hideFrom": {
                       "legend": false,
@@ -9351,6 +10469,98 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-116"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "🧰 Feature Utilisation · from the database, synced plans only",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-130"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 10,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-131"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 10,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-132"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 10,
+                        "width": 12,
+                        "height": 8,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-133"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 18,
+                        "width": 8,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-134"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 8,
+                        "y": 18,
+                        "width": 16,
+                        "height": 4,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-135"
                         }
                       }
                     }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -39,14 +39,15 @@ Counts, two flags and two build identifiers. That is the whole payload.
 There is one other thing the planner sends, `POST /events`, and it carries even less.
 
 When the app corrects a broken plan on load, or shows you an error it had to admit defeat
-over, it counts that. Once a minute, if and only if it has anything to report, it sends the
-counts:
+over, it counts that. It also counts one thing you did: using a search result to jump to a
+factory. Once a minute, if and only if it has anything to report, it sends the counts:
 
 | Field | What it is |
 | --- | --- |
 | `instanceId` | The same random browser identifier as above |
 | `appVersion`, `gitSha` | The same build identifiers as above |
 | `events` | A list of `{ reason, count }` |
+| `usage` | A list of `{ action, count }`. The only action today is `search_jump`. What you searched for is never sent. |
 
 **`reason` is one of a fixed list written into the code.** The app cannot invent one, and the
 server refuses anything not on the list. A reason is a short slug like
@@ -65,8 +66,9 @@ Offline mode stops this too.
 No names of any kind: not your username, not plan names, not tab names, not factory names.
 No account id, no email address, no token, no room id or invite link. No IP address is
 stored (the request has one, as every request does, and nothing writes it down). No page
-addresses, no clicks, no timings, no recipes, no plan contents. No error messages and no
-stack traces. Nothing that is not in the two tables above.
+addresses, no timings, no recipes, no plan contents. No clicks, beyond the one count of
+search results used described above. No error messages and no stack traces. Nothing that is
+not in the two tables above.
 
 ## The instance id
 

--- a/web/src/components/planner/PlannerSearch.spec.ts
+++ b/web/src/components/planner/PlannerSearch.spec.ts
@@ -10,6 +10,7 @@ import { addProductToFactory } from '@/utils/factory-management/products'
 import { addInputToFactory } from '@/utils/factory-management/inputs'
 import { gameData } from '@/utils/gameData'
 import eventBus from '@/utils/eventBus'
+import { useEventsStore } from '@/stores/events-store'
 
 // The route is only read to decide whether the planner is on screen to receive the jump; the
 // component is mounted on its own here, so there is no router to ask.
@@ -151,6 +152,17 @@ describe('PlannerSearch', () => {
       targets: ['1-products-item-IronIngot'],
       fallback: '1-products',
     })
+  })
+
+  it('counts a jump as a search used, and typing as nothing', async () => {
+    await search('iron ingot')
+    // After the render, which is what installs this test's Pinia.
+    const events = useEventsStore()
+    expect(events.pendingUsage()).toEqual({})
+
+    await fireEvent.click(rows().find(row => row.textContent?.includes('Ingot Smelter'))!)
+
+    expect(events.pendingUsage()).toEqual({ search_jump: 1 })
   })
 
   it('jumps to the import row when an import result is clicked', async () => {

--- a/web/src/components/planner/PlannerSearch.vue
+++ b/web/src/components/planner/PlannerSearch.vue
@@ -180,6 +180,7 @@
   } from '@/utils/factory-search'
   import { formatNumber } from '@/utils/numberFormatter'
   import eventBus from '@/utils/eventBus'
+  import { recordUsage } from '@/utils/record-event'
 
   const props = defineProps<{ factories: Factory[] }>()
 
@@ -306,6 +307,8 @@
 
   const jump = (factoryId: number, targets: string[] = [], fallback?: string) => {
     open.value = false
+    // Counted here and not on the query: a jump is somebody who found what they wanted.
+    recordUsage('search_jump')
 
     // The tab bar is also up on the graph page, where there is no planner listening and nothing
     // to scroll. Hand the jump to the planner the way the Parts page does and go there.

--- a/web/src/stores/events-store.spec.ts
+++ b/web/src/stores/events-store.spec.ts
@@ -165,6 +165,67 @@ describe('events-store', () => {
     })
   })
 
+  describe('usage', () => {
+    it('sends a usage-only report, with no events list at all', async () => {
+      store.recordUsage('search_jump', 3)
+
+      await store.flush()
+
+      expect(sent()).not.toHaveProperty('events')
+      expect(sent()?.usage).toEqual([{ action: 'search_jump', count: 3 }])
+      expect(eventReportSchema.safeParse(sent()).success).toBe(true)
+      expect(store.pendingUsage()).toEqual({})
+    })
+
+    it('sends usage beside faults in one report', async () => {
+      store.record('api_network_error')
+      store.recordUsage('search_jump')
+
+      await store.flush()
+
+      expect(Object.keys(sent() ?? {}).sort()).toEqual(['appVersion', 'events', 'instanceId', 'usage'])
+      expect(api.sendEventReport).toHaveBeenCalledTimes(1)
+    })
+
+    it('refuses an action the server would not accept', () => {
+      store.recordUsage('search_typed' as never)
+      store.recordUsage('search_jump', 0)
+
+      expect(store.pendingUsage()).toEqual({})
+    })
+
+    it('saturates at the cap', () => {
+      store.recordUsage('search_jump', EVENT_CAPS.count)
+      store.recordUsage('search_jump', 5)
+
+      expect(store.pendingUsage()).toEqual({ search_jump: EVENT_CAPS.count })
+    })
+
+    it('keeps usage when the send is deferred and drops it when refused outright', async () => {
+      vi.mocked(api.sendEventReport).mockResolvedValue('deferred')
+      store.recordUsage('search_jump', 2)
+      await store.flush()
+      expect(store.pendingUsage()).toEqual({ search_jump: 2 })
+
+      vi.mocked(api.sendEventReport).mockResolvedValue('rejected')
+      await store.flush()
+      expect(store.pendingUsage()).toEqual({})
+    })
+
+    it('keeps usage recorded while the flush was in flight', async () => {
+      let release: (outcome: 'accepted') => void = () => undefined
+      vi.mocked(api.sendEventReport).mockReturnValue(new Promise(resolve => { release = resolve }))
+      store.recordUsage('search_jump', 2)
+
+      const flushing = store.flush()
+      store.recordUsage('search_jump', 1)
+      release('accepted')
+      await flushing
+
+      expect(store.pendingUsage()).toEqual({ search_jump: 1 })
+    })
+  })
+
   describe('offline mode', () => {
     it('sends nothing while offline mode is on', async () => {
       roomSync.enterOffline()

--- a/web/src/stores/events-store.ts
+++ b/web/src/stores/events-store.ts
@@ -1,6 +1,6 @@
-import { EVENT_CAPS, isEventReason } from 'common'
+import { EVENT_CAPS, isEventReason, isUsageAction } from 'common'
 import { defineStore } from 'pinia'
-import type { EventReason, EventReport } from 'common'
+import type { EventReason, EventReport, UsageAction } from 'common'
 import { config } from '@/config/config'
 import { readInstanceId } from '@/stores/telemetry-store'
 import { sendEventReport } from '@/api/client'
@@ -10,7 +10,7 @@ import { useRoomSyncStore } from '@/stores/room-sync-store'
 export const UNKNOWN_VERSION = 'unknown'
 
 /**
- * Counts faults and flushes them to `POST /events`.
+ * Counts faults, and things people did, and flushes both to `POST /events`.
  *
  * **A batch, never one request per fault.** One request per occurrence is a request storm at
  * exactly the moment something is already looping, which is how a telemetry endpoint becomes
@@ -28,7 +28,24 @@ export const useEventsStore = defineStore('events', () => {
   const roomSync = useRoomSyncStore()
 
   const buffer = new Map<EventReason, number>()
+  // Usage rides on the same report in its own list, so the fault counters stay faults.
+  const usage = new Map<UsageAction, number>()
   let timer: ReturnType<typeof setInterval> | undefined
+
+  const bump = <K>(counts: Map<K, number>, key: K, count: number): void => {
+    const next = (counts.get(key) ?? 0) + count
+    // Saturate rather than accumulate: past the cap the exact number stopped mattering, and
+    // a retained batch must not grow without limit while the endpoint is refusing it.
+    counts.set(key, Math.min(next, EVENT_CAPS.count))
+  }
+
+  const settle = <K>(counts: Map<K, number>, sent: Array<{ key: K, count: number }>): void => {
+    for (const { key, count } of sent) {
+      const remaining = (counts.get(key) ?? 0) - count
+      if (remaining > 0) counts.set(key, remaining)
+      else counts.delete(key)
+    }
+  }
 
   /**
    * Rejecting an unknown reason here is what actually bounds the buffer: the enum has a few
@@ -38,12 +55,19 @@ export const useEventsStore = defineStore('events', () => {
   const record = (reason: EventReason, count = 1): void => {
     try {
       if (!isEventReason(reason) || count < 1) return
-      const next = (buffer.get(reason) ?? 0) + count
-      // Saturate rather than accumulate: past the cap the exact number stopped mattering, and
-      // a retained batch must not grow without limit while the endpoint is refusing it.
-      buffer.set(reason, Math.min(next, EVENT_CAPS.count))
+      bump(buffer, reason, count)
     } catch {
       // A counter that cannot count must not break the repair it was counting.
+    }
+  }
+
+  /** Same bound as `record`: only an action the server knows can occupy a slot. */
+  const recordUsage = (action: UsageAction, count = 1): void => {
+    try {
+      if (!isUsageAction(action) || count < 1) return
+      bump(usage, action, count)
+    } catch {
+      // As above; a search that cannot be counted still jumps.
     }
   }
 
@@ -51,7 +75,8 @@ export const useEventsStore = defineStore('events', () => {
     instanceId: readInstanceId(),
     appVersion: config.appVersion || UNKNOWN_VERSION,
     ...(config.gitSha ? { gitSha: config.gitSha } : {}),
-    events: [...buffer].map(([reason, count]) => ({ reason, count })),
+    ...(buffer.size > 0 ? { events: [...buffer].map(([reason, count]) => ({ reason, count })) } : {}),
+    ...(usage.size > 0 ? { usage: [...usage].map(([action, count]) => ({ action, count })) } : {}),
   })
 
   /**
@@ -64,12 +89,13 @@ export const useEventsStore = defineStore('events', () => {
    */
   const flush = async (options: { unloading?: boolean } = {}): Promise<void> => {
     try {
-      if (roomSync.isSuppressed || buffer.size === 0) return
+      if (roomSync.isSuppressed || (buffer.size === 0 && usage.size === 0)) return
 
       const sent = payload()
       if (options.unloading) {
         void sendEventReport(sent).catch(() => undefined)
         buffer.clear()
+        usage.clear()
         return
       }
 
@@ -78,11 +104,8 @@ export const useEventsStore = defineStore('events', () => {
       // 400 and 413 will never succeed, so retrying forever would be a loop. Anything else,
       // including a 429 and a transport failure, is worth keeping for the next tick.
       if (outcome === 'accepted' || outcome === 'rejected') {
-        for (const { reason, count } of sent.events) {
-          const remaining = (buffer.get(reason) ?? 0) - count
-          if (remaining > 0) buffer.set(reason, remaining)
-          else buffer.delete(reason)
-        }
+        settle(buffer, (sent.events ?? []).map(({ reason, count }) => ({ key: reason, count })))
+        settle(usage, (sent.usage ?? []).map(({ action, count }) => ({ key: action, count })))
       }
     } catch {
       // As above. A flush that fails is not the reader's problem and says nothing in console.
@@ -108,6 +131,7 @@ export const useEventsStore = defineStore('events', () => {
 
   /** The buffered counts, for the specs and for nothing else. */
   const pending = (): Record<string, number> => Object.fromEntries(buffer)
+  const pendingUsage = (): Record<string, number> => Object.fromEntries(usage)
 
-  return { record, flush, start, stop, pending, dispose: stop }
+  return { record, recordUsage, flush, start, stop, pending, pendingUsage, dispose: stop }
 })

--- a/web/src/utils/record-event.ts
+++ b/web/src/utils/record-event.ts
@@ -1,4 +1,4 @@
-import type { EventReason } from 'common'
+import type { EventReason, UsageAction } from 'common'
 import { useEventsStore } from '@/stores/events-store'
 
 /**
@@ -18,5 +18,14 @@ export const recordEvent = (reason: EventReason, count = 1): void => {
   } catch {
     // No active Pinia, or a store that would not construct. Losing a count is the correct
     // trade against interrupting a recovery path.
+  }
+}
+
+/** Count something somebody did, with the same guarantees: a search that cannot be counted still jumps. */
+export const recordUsage = (action: UsageAction, count = 1): void => {
+  try {
+    useEventsStore().recordUsage(action, count)
+  } catch {
+    // As above.
   }
 }


### PR DESCRIPTION
## Manual steps

None. Both Grafana dashboards are already regenerated and applied; the new row reads "No data" until this deploys to the API.

## What changes

**Feature utilisation, synced plans only.** `sf_room_feature_plans{feature}` and `sf_room_feature_factories{feature}` count how many live synced plans, and how many of their factories, use each feature: AWESOME Sink, Dimensional Depot, power target, groups, checklist, notes, tasks, somersloops, overclocking, custom buildings, power producers. Aggregate counts only, never per plan. Derived in Node from a lean projection through `planFeatureUsage()` in `common`, which reads anything missing, null or wrong-typed as "not used" and skips factories that are not objects, because `Room.factories` is Mixed and one bad document must not fail the reload that feeds every gauge. Building groups are searched under products and under power producers. Nothing is added to the anonymous heartbeat; local plans stay invisible and the privacy wording is unchanged on that front.

**Searches used.** `POST /events` gains an optional `usage: [{ action, count }]` list beside `events` (now also optional; a report needs at least one of the two), with `search_jump` the single action in a closed enum. The planner counts it when a search result is activated, never on typing, buffered and flushed with the fault counts. Exported as `sf_usage_total{action}`, seeded at zero. `docs/telemetry.md` lists the field and amends "no clicks" to say this one count exists.

**Dashboard.** New row "Feature Utilisation · from the database, synced plans only": two bar gauges (share of plans, share of factories), two over-time graphs, searches used over 24h/7d/all and per hour. "Plans Ever Created" is now "How Synced Plans Arrived" showing from-scratch, adopted and imported side by side, since most synced plans were adopted or imported rather than created and the old single number read as if 39 plans existed when 110 do.

Plan: `.claude/plans/feature-utilisation-metrics.md`. Codex plan review (gpt-5.6-sol) returned RETHINK on the original heartbeat-based design; it was reworked to database-only in response.

## Validation

- `common`: 319/319, including 40 new specs for `planFeatureUsage` (each feature, each junk shape, both building-group homes).
- `backend`: 619/619, including the feature gauges over seeded rooms, a junk room leaving `sf_metrics_database_up` at 1, and usage-only, mixed and unknown-action reports.
- `web`: 3566 passed, 1 skipped; the search spec asserts a jump counts and typing does not; `vue-tsc --noEmit` clean.
- `pnpm lint-check` clean on the packages touched.
- All 164 generated PromQL expressions validated against production Prometheus; the applied dashboards re-fetched and match the generator key-for-key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)