### PR TITLE
docs(grafana): percent-stack the rollout and active-vs-idle panels

### DIFF
--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -253,10 +253,10 @@ add(10, "Browsers Over Time, Signed In vs Out",
     timeseries(fill=25, stack="normal"))
 
 add(13, "Browsers Over Time, Active vs Idle",
-    "Stacked. Idle is thirty minutes without a click, key press, scroll or touch; a tab left open in the background lands here.",
+    "Stacked to 100%, so it reads as the share of open browsers somebody is actually using. Idle is thirty minutes without a click, key press, scroll or touch; a tab left open in the background lands here.",
     [query('sum(sf_active_clients%s)' % sel('state="active"'), "Active", "A"),
      query('sum(sf_active_clients%s)' % sel('state="idle"'), "Idle", "B")],
-    timeseries(fill=25, stack="normal"))
+    timeseries(fill=25, stack="percent"))
 
 add(11, "Live Sockets Over Time",
     "Realtime connections held open.",

--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -754,7 +754,7 @@ add(40, "Browsers by Build",
 add(41, "Planner Version Over Time",
     "Stacked. After a release, watch the old band drain. While it is still wide, a breaking change will hurt.",
     [query("sum by (version) (sf_clients_by_version%s)" % J, "{{version}}")],
-    timeseries(fill=25, stack="normal"))
+    timeseries(fill=25, stack="percent"))
 
 add(43, "Browsers by Commit",
     "Active browsers by the commit their bundle was built from. A build that reported no commit, such as a local one, counts under \"unknown\". Capped to the busiest 25 commits.",
@@ -764,7 +764,7 @@ add(43, "Browsers by Commit",
 add(44, "Commit Rollout Over Time",
     "Stacked. After a deploy, watch the previous commit drain. This is the panel that says whether a rollout has actually reached people, which a version number cannot: several commits ship under one version.",
     [query("sum by (sha) (sf_clients_by_sha%s)" % J, "{{sha}}")],
-    timeseries(fill=25, stack="normal"))
+    timeseries(fill=25, stack="percent"))
 
 add(45, "Browsers on an Unknown Commit",
     "Builds reporting no usable commit. Expect this to be non-zero only for local development builds.",

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -773,7 +773,7 @@
         "spec": {
           "id": 13,
           "title": "Browsers Over Time, Active vs Idle",
-          "description": "Stacked. Idle is thirty minutes without a click, key press, scroll or touch; a tab left open in the background lands here.",
+          "description": "Stacked to 100%, so it reads as the share of open browsers somebody is actually using. Idle is thirty minutes without a click, key press, scroll or touch; a tab left open in the background lands here.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -891,7 +891,7 @@
                     "spanNulls": false,
                     "stacking": {
                       "group": "A",
-                      "mode": "normal"
+                      "mode": "percent"
                     },
                     "thresholdsStyle": {
                       "mode": "off"

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -9529,7 +9529,7 @@
                     "spanNulls": false,
                     "stacking": {
                       "group": "A",
-                      "mode": "normal"
+                      "mode": "percent"
                     },
                     "thresholdsStyle": {
                       "mode": "off"
@@ -9734,7 +9734,7 @@
                     "spanNulls": false,
                     "stacking": {
                       "group": "A",
-                      "mode": "normal"
+                      "mode": "percent"
                     },
                     "thresholdsStyle": {
                       "mode": "off"

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -773,7 +773,7 @@
         "spec": {
           "id": 13,
           "title": "Browsers Over Time, Active vs Idle",
-          "description": "Stacked. Idle is thirty minutes without a click, key press, scroll or touch; a tab left open in the background lands here.",
+          "description": "Stacked to 100%, so it reads as the share of open browsers somebody is actually using. Idle is thirty minutes without a click, key press, scroll or touch; a tab left open in the background lands here.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -891,7 +891,7 @@
                     "spanNulls": false,
                     "stacking": {
                       "group": "A",
-                      "mode": "normal"
+                      "mode": "percent"
                     },
                     "thresholdsStyle": {
                       "mode": "off"

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -9529,7 +9529,7 @@
                     "spanNulls": false,
                     "stacking": {
                       "group": "A",
-                      "mode": "normal"
+                      "mode": "percent"
                     },
                     "thresholdsStyle": {
                       "mode": "off"
@@ -9734,7 +9734,7 @@
                     "spanNulls": false,
                     "stacking": {
                       "group": "A",
-                      "mode": "normal"
+                      "mode": "percent"
                     },
                     "thresholdsStyle": {
                       "mode": "off"


### PR DESCRIPTION
No manual steps. Both dashboards are already re-applied from the generator.

Planner Version Over Time and Commit Rollout Over Time were set to percent stacking by hand on the live dashboard on 2026-09-11 and lost when the generator was applied over them in #696; they are now percent-stacked in `generate.py` so the next regeneration keeps it. Browsers Over Time, Active vs Idle gets the same treatment, since the share is what that panel is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)