### PR TITLE
chore(repo): skip the required checks when a PR touches nothing they cover

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -8,9 +8,10 @@ name: Backend Checks
 # Backend Deploy instead, so keeping one would run the same checks twice on the
 # same commit.
 #
-# The pull_request trigger is deliberately not path-filtered. A required status
-# check that never triggers sits pending forever rather than passing, so a filter
-# here would block every PR that does not touch the backend.
+# The pull_request trigger cannot be path-filtered: this is a required status check
+# and one that never triggers sits pending forever. It always triggers and the
+# `changes` gate decides whether the real job runs (see changed-paths.yml). Under
+# workflow_call the gate does not run at all, so a deploy is never gated.
 on:
   pull_request:
     branches:
@@ -18,13 +19,35 @@ on:
       # The v0.7.0 integration line: sync work lands here for beta testing first.
       - beta7
   workflow_call:
+    inputs:
+      # Absent on a plain pull_request trigger, which is how the gate below tells a
+      # PR run from a deploy calling it. A deploy must never be gated out.
+      called:
+        type: boolean
+        default: true
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    if: ${{ !inputs.called }}
+    uses: ./.github/workflows/changed-paths.yml
+    with:
+      patterns: |
+        backend/*
+        common/*
+        package.json
+        pnpm-workspace.yaml
+        pnpm-lock.yaml
+        .github/workflows/build-backend.yml
+        .github/workflows/changed-paths.yml
+
   build-backend:
     name: Build Backend
+    needs: changes
+    # `!cancelled()` because a skipped gate would otherwise skip this too.
+    if: ${{ !cancelled() && (inputs.called || needs.changes.outputs.matched == 'true') }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/build-parsing.yml
+++ b/.github/workflows/build-parsing.yml
@@ -1,8 +1,9 @@
 name: Parsing Checks
 
-# The push trigger stays path-filtered, the pull_request one does not. A required
-# status check that never triggers sits pending forever rather than passing, so a
-# path filter here would block every PR that does not touch parsing/.
+# The push trigger is path-filtered; the pull_request one cannot be, because this is
+# a required status check and one that never triggers sits pending forever. It
+# always triggers and the `changes` gate decides whether the real job runs: see
+# changed-paths.yml.
 on:
   push:
     branches:
@@ -19,8 +20,21 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    uses: ./.github/workflows/changed-paths.yml
+    with:
+      patterns: |
+        parsing/*
+        package.json
+        pnpm-workspace.yaml
+        pnpm-lock.yaml
+        .github/workflows/build-parsing.yml
+        .github/workflows/changed-paths.yml
+
   build-parsing:
     name: Build Parsing
+    needs: changes
+    if: needs.changes.outputs.matched == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -1,8 +1,9 @@
 name: Web Checks
 
-# The push trigger stays path-filtered, the pull_request one does not. A required
-# status check that never triggers sits pending forever rather than passing, so a
-# path filter here would block every PR that does not touch web/.
+# The push trigger is path-filtered; the pull_request one cannot be, because this is
+# a required status check and one that never triggers sits pending forever. So it
+# always triggers and the `changes` gate decides whether the real job runs: see
+# changed-paths.yml. A docs-only PR passes in seconds with the job skipped.
 on:
   push:
     branches:
@@ -11,12 +12,6 @@ on:
       - beta7
     paths:
       - 'web/**'
-  # Deliberately NOT path-filtered, unlike the push trigger above. This job is a
-  # required status check on main, and a required check that never runs sits
-  # pending forever rather than passing — so a path filter here would block every
-  # PR that does not touch web/ (a backend bump, a docs change, a config edit)
-  # with no way to satisfy it. Running the web suite on those PRs costs a couple
-  # of minutes and is the price of it being required.
   pull_request:
     branches:
       - main
@@ -24,8 +19,24 @@ on:
 permissions:
   contents: read
 jobs:
+  changes:
+    uses: ./.github/workflows/changed-paths.yml
+    with:
+      # The API is in here on purpose: web's e2e and typed client follow its shapes.
+      patterns: |
+        web/*
+        backend/*
+        common/*
+        package.json
+        pnpm-workspace.yaml
+        pnpm-lock.yaml
+        .github/workflows/build-web.yml
+        .github/workflows/changed-paths.yml
+
   build-web:
     name: Build & Test Web
+    needs: changes
+    if: needs.changes.outputs.matched == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/changed-paths.yml
+++ b/.github/workflows/changed-paths.yml
@@ -1,0 +1,71 @@
+name: Changed Paths
+
+# The gate in front of the required checks. Those checks cannot be path-filtered at
+# the trigger: a required status check that never triggers sits pending forever, so
+# a docs-only PR could never merge. Instead each check workflow always triggers,
+# asks this for whether the PR touches anything it cares about, and skips its real
+# job if not. A job skipped by `if:` reports "skipped", which branch protection
+# counts as satisfied, so the check stays required and a docs PR passes in seconds.
+#
+# Reads the PR's file list from the API rather than diffing the checkout, so it is
+# exactly the set GitHub shows on the Files tab, however far main has moved since
+# the branch was cut. On any event other than pull_request (a push to main, a
+# workflow_call from a deploy) everything matches: those runs are not the ones
+# being saved.
+on:
+  workflow_call:
+    inputs:
+      patterns:
+        description: >-
+          One bash pattern per line, matched against each changed path with `[[ == ]]`.
+          `*` crosses directory separators, so `web/*` is everything under web/.
+        required: true
+        type: string
+    outputs:
+      matched:
+        description: '"true" when any changed path matches any pattern, or the event is not a pull_request.'
+        value: ${{ jobs.changes.outputs.matched }}
+
+# No permissions block: a called workflow inherits the caller's, and the file list
+# of a public repository's PR needs nothing beyond the caller's `contents: read`.
+jobs:
+  changes:
+    name: Changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      matched: ${{ steps.filter.outputs.matched }}
+    steps:
+      - name: Match the PR's files against the patterns
+        id: filter
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PATTERNS: ${{ inputs.patterns }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+            echo "Not a pull request (${GITHUB_EVENT_NAME}): running everything." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          mapfile -t files < <(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          mapfile -t patterns < <(printf '%s\n' "$PATTERNS" | sed '/^[[:space:]]*$/d')
+
+          matched=false
+          for file in "${files[@]}"; do
+            for pattern in "${patterns[@]}"; do
+              # shellcheck disable=SC2053
+              if [[ "$file" == $pattern ]]; then
+                echo "Running: \`$file\` matches \`$pattern\`." >> "$GITHUB_STEP_SUMMARY"
+                matched=true
+                break 2
+              fi
+            done
+          done
+
+          if [ "$matched" = "false" ]; then
+            echo "Skipped: none of the ${#files[@]} changed file(s) match. Patterns:" >> "$GITHUB_STEP_SUMMARY"
+            printf -- '- `%s`\n' "${patterns[@]}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "matched=$matched" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,12 +4,11 @@ name: E2E Checks
 # production build of the client, real WebSockets and two browser contexts per
 # test. `web/e2e/README.md` covers what it proves and why the ports are fixed.
 #
-# Unlike its sibling check workflows, this one IS path-filtered on pull_request.
-# Those three are required status checks on main, and a required check that never
-# triggers sits pending forever rather than passing — so they cannot filter. This
-# one is not required, which is what buys the filter. Making it required later
-# means deleting both paths blocks first, or a PR that touches only docs can
-# never be merged.
+# Path-filtered at the trigger, which it can be because it is not a required status
+# check. The three required ones cannot (a required check that never triggers sits
+# pending forever) and gate inside the workflow instead, via changed-paths.yml.
+# Making this one required later means moving to that gate first, or a PR that
+# touches only docs can never be merged.
 #
 # The two lists are duplicated rather than shared: the workflow parser does not
 # accept YAML anchors, which is why deploy-backend.yml and pr-docker-backend.yml


### PR DESCRIPTION
No manual steps. The check names are unchanged, so the ruleset's required checks need no edit.

## Why

#698 touched only `docs/grafana/` and still ran Build & Test Web (5m41s), Backend Checks and Parsing Checks. The E2E workflow is already path-filtered and did not run; those three are the required status checks, and a required check that never triggers sits pending forever, which is why they were deliberately unfiltered.

## What changes

A reusable `changed-paths.yml` reads the PR's file list from the API (exactly what the Files tab shows, however far main has moved) and matches it against a per-workflow pattern list. Each required workflow still triggers on every PR, runs that gate first, and runs its real job only on a match. A job skipped by `if:` reports "skipped", which branch protection counts as satisfied. On any event other than `pull_request` the gate matches everything.

- **Web Checks** runs for `web/`, `backend/`, `common/`, the root package files and its own workflow. The API is included on purpose: the typed client and e2e follow its shapes.
- **Backend Checks** runs for `backend/`, `common/`, the root package files and its own workflow. Under `workflow_call` (the production and preview deploys) the gate is skipped entirely via a `called` input that defaults true and is absent on a plain PR trigger, so a deploy is never gated out.
- **Parsing Checks** runs for `parsing/`, the root package files and its own workflow.

Each gate writes why it ran or skipped to the job summary.

## Validation

- All workflow files parse as YAML.
- This PR touches only `.github/workflows/`, which every pattern list includes, so all three checks run here; the gate summaries should read "Running: `.github/workflows/...` matches". The skip path gets its first exercise on the next docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)