### PR TITLE
feat(backend): count depot settings as a feature

### DIFF
--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -595,6 +595,8 @@ export class MetricsService {
     const cursor = this.rooms
       .find({ deletedAt: null }, {
         powerTarget: 1,
+        depotUploadTier: 1,
+        depotExpansionTier: 1,
         groups: 1,
         'factories.partDisposal': 1,
         'factories.group': 1,

--- a/backend/test/metrics-usage.spec.ts
+++ b/backend/test/metrics-usage.spec.ts
@@ -696,6 +696,7 @@ describe('the database-backed usage metrics', () => {
         roomId: randomUUID(),
         name: 'Clocked',
         createdBy: 'someone',
+        depotExpansionTier: 4,
         factories: [
           { id: 1, products: [{ id: 'IronIngot', buildingGroups: [{ id: 1, overclockPercent: 200, somersloops: 1 }] }] },
           { id: 2, powerProducers: [{ id: 'g', buildingGroups: [{ id: 1, overclockPercent: 100 }] }] },
@@ -717,6 +718,7 @@ describe('the database-backed usage metrics', () => {
       expect(plans(body, 'somersloops')).toBe(1)
       expect(plans(body, 'power_producers')).toBe(1)
       expect(plans(body, 'depot')).toBe(0)
+      expect(plans(body, 'depot_settings')).toBe(1)
       expect(sample(body, 'sf_rooms_total', 'shared="false"')).toBe(2)
     })
 

--- a/backend/test/metrics-usage.spec.ts
+++ b/backend/test/metrics-usage.spec.ts
@@ -3,8 +3,8 @@ import { randomUUID } from 'node:crypto'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { getModelToken } from '@nestjs/mongoose'
 import type { Model } from 'mongoose'
-
 import { PLAN_FEATURES } from 'common'
+
 import {
   ACTIVE_ACCOUNT_WINDOWS,
   DELETED_OWNER,

--- a/common/src/feature-usage.spec.ts
+++ b/common/src/feature-usage.spec.ts
@@ -77,6 +77,26 @@ describe('planFeatureUsage', () => {
     expect(usage.factories.power_target).toBe(0)
   })
 
+  it.each([
+    ['the upload tier', { depotUploadTier: 2 }],
+    ['the expansion tier', { depotExpansionTier: 0 }],
+    ['both at the maximum', { depotUploadTier: 4, depotExpansionTier: 4 }],
+  ])('counts depot settings once %s has been set', (_label, tiers) => {
+    const usage = planFeatureUsage({ ...tiers, factories: [bare()] })
+
+    expect(usage.plan.depot_settings).toBe(true)
+    expect(usage.factories.depot_settings).toBe(0)
+  })
+
+  it.each([
+    ['nothing set', {}],
+    ['a tier that is not a number', { depotUploadTier: '3' }],
+    ['a NaN tier', { depotExpansionTier: NaN }],
+    ['null tiers', { depotUploadTier: null, depotExpansionTier: null }],
+  ])('does not count depot settings with %s', (_label, tiers) => {
+    expect(planFeatureUsage({ ...tiers, factories: [] }).plan.depot_settings).toBe(false)
+  })
+
   it.each([0, -5, NaN, '500', null, undefined])('does not count a power target of %s', target => {
     expect(planFeatureUsage({ powerTarget: target, factories: [] }).plan.power_target).toBe(false)
   })

--- a/common/src/feature-usage.ts
+++ b/common/src/feature-usage.ts
@@ -9,6 +9,7 @@
 export const PLAN_FEATURES = [
   'sink',
   'depot',
+  'depot_settings',
   'power_target',
   'groups',
   'checklist',
@@ -41,6 +42,8 @@ const isObject = (value: unknown): value is Record<string, unknown> =>
 
 const nonEmptyArray = (value: unknown): value is unknown[] => Array.isArray(value) && value.length > 0
 
+const isTier = (value: unknown): boolean => typeof value === 'number' && Number.isFinite(value)
+
 const positive = (value: unknown): boolean => typeof value === 'number' && Number.isFinite(value) && value > 0
 
 /** Building groups sit under products and under power producers; both are searched. */
@@ -70,6 +73,7 @@ export const factoryFeatures = (factory: unknown): Record<PlanFeature, boolean> 
   return {
     sink: disposes(factory, 'sinks'),
     depot: disposes(factory, 'depots'),
+    depot_settings: false,
     power_target: false,
     groups: isObject(factory.group),
     checklist: factory.checklistEnabled === true,
@@ -87,7 +91,7 @@ export const factoryFeatures = (factory: unknown): Record<PlanFeature, boolean> 
 
 /**
  * One plan's usage. `plan` is the shape a room or a tab shares: its factories, its power
- * target and its groups; nothing else is read.
+ * target, its depot tiers and its groups; nothing else is read.
  */
 export const planFeatureUsage = (plan: unknown): PlanFeatureUsage => {
   const factories = emptyFeatureCounts()
@@ -99,6 +103,9 @@ export const planFeatureUsage = (plan: unknown): PlanFeatureUsage => {
   if (!isObject(plan)) return usage
 
   usage.plan.power_target = positive(plan.powerTarget)
+  // Absent means "fully researched" and nobody touched it; any number, tier 4 included,
+  // means somebody opened the depot settings and answered.
+  usage.plan.depot_settings = isTier(plan.depotUploadTier) || isTier(plan.depotExpansionTier)
   usage.plan.groups = nonEmptyArray(plan.groups)
 
   if (!Array.isArray(plan.factories)) return usage

--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -601,6 +601,7 @@ add(116, "Plan Lifecycle Over Time",
 FEATURES = [
     ("sink", "AWESOME Sink"),
     ("depot", "Dimensional Depot"),
+    ("depot_settings", "Depot settings"),
     ("power_target", "Power target"),
     ("groups", "Groups"),
     ("checklist", "Checklist"),
@@ -616,13 +617,13 @@ FEATURES = [
 def feature_queries(metric, total):
     return [
         query("sum(%s%s) / sum(%s%s)" % (metric, sel('feature="%s"' % feature), total, J), legend,
-              "ABCDEFGHIJK"[index])
+              "ABCDEFGHIJKL"[index])
         for index, (feature, legend) in enumerate(FEATURES)
     ]
 
 
 add(130, "Plans Using Each Feature",
-    "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target and groups are plan-level settings; everything else is any factory in the plan.",
+    "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target, depot settings and groups are plan-level; everything else is any factory in the plan. Depot settings means somebody answered the MAM research tiers, at any tier; unset reads as fully researched and is not counted.",
     [query("sort_desc(sum by (feature) (sf_room_feature_plans%s) / ignoring(feature) group_left sum(sf_rooms_total%s))" % (J, J), "{{feature}}", instant=True)],
     bargauge(display_name="${__field.labels.feature}", unit="percentunit", minmax=(0, 1)))
 

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -6542,7 +6542,7 @@
         "spec": {
           "id": 130,
           "title": "Plans Using Each Feature",
-          "description": "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target and groups are plan-level settings; everything else is any factory in the plan.",
+          "description": "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target, depot settings and groups are plan-level; everything else is any factory in the plan. Depot settings means somebody answered the MAM research tiers, at any tier; unset reads as fully researched and is not counted.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -6786,12 +6786,33 @@
                       },
                       "spec": {
                         "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"depot_settings\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Depot settings",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
                         "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"power_target\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
                         "legendFormat": "Power target",
                         "range": true
                       }
                     },
-                    "refId": "C",
+                    "refId": "D",
                     "hidden": false
                   }
                 },
@@ -6812,7 +6833,7 @@
                         "range": true
                       }
                     },
-                    "refId": "D",
+                    "refId": "E",
                     "hidden": false
                   }
                 },
@@ -6833,7 +6854,7 @@
                         "range": true
                       }
                     },
-                    "refId": "E",
+                    "refId": "F",
                     "hidden": false
                   }
                 },
@@ -6854,7 +6875,7 @@
                         "range": true
                       }
                     },
-                    "refId": "F",
+                    "refId": "G",
                     "hidden": false
                   }
                 },
@@ -6875,7 +6896,7 @@
                         "range": true
                       }
                     },
-                    "refId": "G",
+                    "refId": "H",
                     "hidden": false
                   }
                 },
@@ -6896,7 +6917,7 @@
                         "range": true
                       }
                     },
-                    "refId": "H",
+                    "refId": "I",
                     "hidden": false
                   }
                 },
@@ -6917,7 +6938,7 @@
                         "range": true
                       }
                     },
-                    "refId": "I",
+                    "refId": "J",
                     "hidden": false
                   }
                 },
@@ -6938,7 +6959,7 @@
                         "range": true
                       }
                     },
-                    "refId": "J",
+                    "refId": "K",
                     "hidden": false
                   }
                 },
@@ -6959,7 +6980,7 @@
                         "range": true
                       }
                     },
-                    "refId": "K",
+                    "refId": "L",
                     "hidden": false
                   }
                 }
@@ -7113,12 +7134,33 @@
                       },
                       "spec": {
                         "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"depot_settings\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Depot settings",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
                         "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"power_target\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
                         "legendFormat": "Power target",
                         "range": true
                       }
                     },
-                    "refId": "C",
+                    "refId": "D",
                     "hidden": false
                   }
                 },
@@ -7139,7 +7181,7 @@
                         "range": true
                       }
                     },
-                    "refId": "D",
+                    "refId": "E",
                     "hidden": false
                   }
                 },
@@ -7160,7 +7202,7 @@
                         "range": true
                       }
                     },
-                    "refId": "E",
+                    "refId": "F",
                     "hidden": false
                   }
                 },
@@ -7181,7 +7223,7 @@
                         "range": true
                       }
                     },
-                    "refId": "F",
+                    "refId": "G",
                     "hidden": false
                   }
                 },
@@ -7202,7 +7244,7 @@
                         "range": true
                       }
                     },
-                    "refId": "G",
+                    "refId": "H",
                     "hidden": false
                   }
                 },
@@ -7223,7 +7265,7 @@
                         "range": true
                       }
                     },
-                    "refId": "H",
+                    "refId": "I",
                     "hidden": false
                   }
                 },
@@ -7244,7 +7286,7 @@
                         "range": true
                       }
                     },
-                    "refId": "I",
+                    "refId": "J",
                     "hidden": false
                   }
                 },
@@ -7265,7 +7307,7 @@
                         "range": true
                       }
                     },
-                    "refId": "J",
+                    "refId": "K",
                     "hidden": false
                   }
                 },
@@ -7286,7 +7328,7 @@
                         "range": true
                       }
                     },
-                    "refId": "K",
+                    "refId": "L",
                     "hidden": false
                   }
                 }

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -6542,7 +6542,7 @@
         "spec": {
           "id": 130,
           "title": "Plans Using Each Feature",
-          "description": "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target and groups are plan-level settings; everything else is any factory in the plan.",
+          "description": "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target, depot settings and groups are plan-level; everything else is any factory in the plan. Depot settings means somebody answered the MAM research tiers, at any tier; unset reads as fully researched and is not counted.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -6786,12 +6786,33 @@
                       },
                       "spec": {
                         "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"depot_settings\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Depot settings",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
                         "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"power_target\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
                         "legendFormat": "Power target",
                         "range": true
                       }
                     },
-                    "refId": "C",
+                    "refId": "D",
                     "hidden": false
                   }
                 },
@@ -6812,7 +6833,7 @@
                         "range": true
                       }
                     },
-                    "refId": "D",
+                    "refId": "E",
                     "hidden": false
                   }
                 },
@@ -6833,7 +6854,7 @@
                         "range": true
                       }
                     },
-                    "refId": "E",
+                    "refId": "F",
                     "hidden": false
                   }
                 },
@@ -6854,7 +6875,7 @@
                         "range": true
                       }
                     },
-                    "refId": "F",
+                    "refId": "G",
                     "hidden": false
                   }
                 },
@@ -6875,7 +6896,7 @@
                         "range": true
                       }
                     },
-                    "refId": "G",
+                    "refId": "H",
                     "hidden": false
                   }
                 },
@@ -6896,7 +6917,7 @@
                         "range": true
                       }
                     },
-                    "refId": "H",
+                    "refId": "I",
                     "hidden": false
                   }
                 },
@@ -6917,7 +6938,7 @@
                         "range": true
                       }
                     },
-                    "refId": "I",
+                    "refId": "J",
                     "hidden": false
                   }
                 },
@@ -6938,7 +6959,7 @@
                         "range": true
                       }
                     },
-                    "refId": "J",
+                    "refId": "K",
                     "hidden": false
                   }
                 },
@@ -6959,7 +6980,7 @@
                         "range": true
                       }
                     },
-                    "refId": "K",
+                    "refId": "L",
                     "hidden": false
                   }
                 }
@@ -7113,12 +7134,33 @@
                       },
                       "spec": {
                         "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"depot_settings\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Depot settings",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
                         "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"power_target\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
                         "legendFormat": "Power target",
                         "range": true
                       }
                     },
-                    "refId": "C",
+                    "refId": "D",
                     "hidden": false
                   }
                 },
@@ -7139,7 +7181,7 @@
                         "range": true
                       }
                     },
-                    "refId": "D",
+                    "refId": "E",
                     "hidden": false
                   }
                 },
@@ -7160,7 +7202,7 @@
                         "range": true
                       }
                     },
-                    "refId": "E",
+                    "refId": "F",
                     "hidden": false
                   }
                 },
@@ -7181,7 +7223,7 @@
                         "range": true
                       }
                     },
-                    "refId": "F",
+                    "refId": "G",
                     "hidden": false
                   }
                 },
@@ -7202,7 +7244,7 @@
                         "range": true
                       }
                     },
-                    "refId": "G",
+                    "refId": "H",
                     "hidden": false
                   }
                 },
@@ -7223,7 +7265,7 @@
                         "range": true
                       }
                     },
-                    "refId": "H",
+                    "refId": "I",
                     "hidden": false
                   }
                 },
@@ -7244,7 +7286,7 @@
                         "range": true
                       }
                     },
-                    "refId": "I",
+                    "refId": "J",
                     "hidden": false
                   }
                 },
@@ -7265,7 +7307,7 @@
                         "range": true
                       }
                     },
-                    "refId": "J",
+                    "refId": "K",
                     "hidden": false
                   }
                 },
@@ -7286,7 +7328,7 @@
                         "range": true
                       }
                     },
-                    "refId": "K",
+                    "refId": "L",
                     "hidden": false
                   }
                 }


### PR DESCRIPTION
No manual steps. Both dashboards are already re-applied; the new bar reads "No data" until this deploys.

Adds `depot_settings` to the feature utilisation gauges: a synced plan counts when either `depotUploadTier` or `depotExpansionTier` is a number, at any tier including 4. Absent means "fully researched" and nobody has opened the setting, so it is not counted. Plan-level only, like power target and groups. The two tier fields join the metrics projection; `planFeatureUsage` and its specs cover set, unset, string, NaN and null tiers.

Validation: common 47/47 on the feature specs, backend metrics-usage 82/82, lint clean, dashboards regenerated and applied from the generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)