### PR TITLE
feat(backend): count building groups and game sync as features

### DIFF
--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -604,6 +604,7 @@ export class MetricsService {
         'factories.notes': 1,
         'factories.tasks': 1,
         'factories.customBuildings': 1,
+        'factories.inSync': 1,
         'factories.powerProducers.buildingGroups': 1,
         'factories.products.buildingGroups': 1,
       })

--- a/backend/test/metrics-usage.spec.ts
+++ b/backend/test/metrics-usage.spec.ts
@@ -688,8 +688,8 @@ describe('the database-backed usage metrics', () => {
         powerTarget: 300,
         factories: [
           { id: 1, partDisposal: { IronIngot: { sinks: 1, depots: 0 } }, checklistEnabled: true },
-          { id: 2, partDisposal: { Copper: { sinks: 2, depots: 0 } }, notes: 'x' },
-          { id: 3 },
+          { id: 2, partDisposal: { Copper: { sinks: 2, depots: 0 } }, notes: 'x', inSync: false },
+          { id: 3, inSync: null },
         ],
       })
       await rooms().create({
@@ -699,7 +699,7 @@ describe('the database-backed usage metrics', () => {
         depotExpansionTier: 4,
         factories: [
           { id: 1, products: [{ id: 'IronIngot', buildingGroups: [{ id: 1, overclockPercent: 200, somersloops: 1 }] }] },
-          { id: 2, powerProducers: [{ id: 'g', buildingGroups: [{ id: 1, overclockPercent: 100 }] }] },
+          { id: 2, powerProducers: [{ id: 'g', buildingGroups: [{ id: 1, overclockPercent: 100 }, { id: 2 }] }] },
         ],
       })
       await rooms().create({ roomId: randomUUID(), name: 'Gone', createdBy: 'someone', deletedAt: new Date(), factories: [{ id: 1, notes: 'deleted' }] })
@@ -719,6 +719,10 @@ describe('the database-backed usage metrics', () => {
       expect(plans(body, 'power_producers')).toBe(1)
       expect(plans(body, 'depot')).toBe(0)
       expect(plans(body, 'depot_settings')).toBe(1)
+      expect(plans(body, 'building_groups')).toBe(1)
+      expect(plans(body, 'game_sync')).toBe(1)
+      expect(factories(body, 'game_sync')).toBe(1)
+      expect(factories(body, 'building_groups')).toBe(1)
       expect(sample(body, 'sf_rooms_total', 'shared="false"')).toBe(2)
     })
 

--- a/common/src/feature-usage.spec.ts
+++ b/common/src/feature-usage.spec.ts
@@ -23,12 +23,24 @@ describe('factoryFeatures', () => {
     ['notes', { notes: 'remember the belts' }],
     ['tasks', { tasks: [{ title: 'build it', completed: false }] }],
     ['custom_buildings', { customBuildings: [{ id: 'p', building: 'portal', amount: 1 }] }],
+    ['game_sync', { inSync: true }],
+    ['game_sync', { inSync: false }],
     ['power_producers', { powerProducers: [{ id: 'g', building: 'generatorcoal' }] }],
     ['somersloops', { products: [{ id: 'IronIngot', buildingGroups: [{ id: 1, somersloops: 2 }] }] }],
     ['overclocking', { products: [{ id: 'IronIngot', buildingGroups: [{ id: 1, overclockPercent: 150 }] }] }],
     ['overclocking', { products: [{ id: 'IronIngot', buildingGroups: [{ id: 1, overclockPercent: 50 }] }] }],
   ])('detects %s', (feature, extra) => {
     expect(factoryFeatures({ ...bare(), ...extra })).toEqual({ ...none(), [feature]: true })
+  })
+
+  it('counts building groups only once a product has been split into more than one', () => {
+    const one = { ...bare(), products: [{ id: 'a', buildingGroups: [{ id: 1 }] }, { id: 'b', buildingGroups: [{ id: 2 }] }] }
+    const split = { ...bare(), products: [{ id: 'a', buildingGroups: [{ id: 1 }, { id: 2 }] }] }
+    const splitGenerator = { ...bare(), powerProducers: [{ id: 'g', buildingGroups: [{ id: 1 }, { id: 2 }] }] }
+
+    expect(factoryFeatures(one)?.building_groups).toBe(false)
+    expect(factoryFeatures(split)?.building_groups).toBe(true)
+    expect(factoryFeatures(splitGenerator)?.building_groups).toBe(true)
   })
 
   it('finds somersloops and overclocking under power producers as well as products', () => {
@@ -47,6 +59,8 @@ describe('factoryFeatures', () => {
     ['an empty task list', { tasks: [] }],
     ['a group that is not an object', { group: 'steel' }],
     ['checklistEnabled as a string', { checklistEnabled: 'true' }],
+    ['a factory never marked in sync', { inSync: null }],
+    ['inSync as a string', { inSync: 'true' }],
     ['a partDisposal that is an array', { partDisposal: [{ sinks: 3 }] }],
     ['building groups that are not objects', { products: [{ id: 'x', buildingGroups: [3, null, 'x'] }] }],
   ])('reads %s as not used', (_label, extra) => {

--- a/common/src/feature-usage.ts
+++ b/common/src/feature-usage.ts
@@ -17,6 +17,8 @@ export const PLAN_FEATURES = [
   'tasks',
   'somersloops',
   'overclocking',
+  'building_groups',
+  'game_sync',
   'custom_buildings',
   'power_producers',
 ] as const
@@ -46,18 +48,22 @@ const isTier = (value: unknown): boolean => typeof value === 'number' && Number.
 
 const positive = (value: unknown): boolean => typeof value === 'number' && Number.isFinite(value) && value > 0
 
-/** Building groups sit under products and under power producers; both are searched. */
-const buildingGroups = (factory: Record<string, unknown>): Record<string, unknown>[] => {
-  const groups: Record<string, unknown>[] = []
+/**
+ * Building groups sit under products and under power producers; both are searched. Kept per
+ * owner, because "split into groups" is a property of one product's buildings: every product
+ * starts with a single group, so only a second one on the same owner means somebody split it.
+ */
+const buildingGroupsByOwner = (factory: Record<string, unknown>): Record<string, unknown>[][] => {
+  const owners: Record<string, unknown>[][] = []
   for (const key of ['products', 'powerProducers']) {
-    const owners = factory[key]
-    if (!Array.isArray(owners)) continue
-    for (const owner of owners) {
+    const candidates = factory[key]
+    if (!Array.isArray(candidates)) continue
+    for (const owner of candidates) {
       if (!isObject(owner) || !Array.isArray(owner.buildingGroups)) continue
-      for (const group of owner.buildingGroups) if (isObject(group)) groups.push(group)
+      owners.push(owner.buildingGroups.filter(isObject))
     }
   }
-  return groups
+  return owners
 }
 
 const disposes = (factory: Record<string, unknown>, field: 'sinks' | 'depots'): boolean => {
@@ -68,7 +74,8 @@ const disposes = (factory: Record<string, unknown>, field: 'sinks' | 'depots'): 
 /** Per-factory features. The plan-level ones (`power_target`, `groups`) are decided by the caller. */
 export const factoryFeatures = (factory: unknown): Record<PlanFeature, boolean> | null => {
   if (!isObject(factory)) return null
-  const groups = buildingGroups(factory)
+  const owners = buildingGroupsByOwner(factory)
+  const groups = owners.flat()
 
   return {
     sink: disposes(factory, 'sinks'),
@@ -84,6 +91,9 @@ export const factoryFeatures = (factory: unknown): Record<PlanFeature, boolean> 
       typeof group.overclockPercent === 'number' &&
       Number.isFinite(group.overclockPercent) &&
       group.overclockPercent !== 100),
+    building_groups: owners.some(groups => groups.length > 1),
+    // null means never marked; true or false means somebody has used "in sync with the game".
+    game_sync: typeof factory.inSync === 'boolean',
     custom_buildings: nonEmptyArray(factory.customBuildings),
     power_producers: nonEmptyArray(factory.powerProducers),
   }

--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -609,6 +609,8 @@ FEATURES = [
     ("tasks", "Tasks"),
     ("somersloops", "Somersloops"),
     ("overclocking", "Overclocking"),
+    ("building_groups", "Building groups"),
+    ("game_sync", "Game sync"),
     ("custom_buildings", "Custom buildings"),
     ("power_producers", "Power producers"),
 ]
@@ -617,13 +619,13 @@ FEATURES = [
 def feature_queries(metric, total):
     return [
         query("sum(%s%s) / sum(%s%s)" % (metric, sel('feature="%s"' % feature), total, J), legend,
-              "ABCDEFGHIJKL"[index])
+              "ABCDEFGHIJKLMN"[index])
         for index, (feature, legend) in enumerate(FEATURES)
     ]
 
 
 add(130, "Plans Using Each Feature",
-    "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target, depot settings and groups are plan-level; everything else is any factory in the plan. Depot settings means somebody answered the MAM research tiers, at any tier; unset reads as fully researched and is not counted.",
+    "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target, depot settings and groups are plan-level; everything else is any factory in the plan. Depot settings means somebody answered the MAM research tiers, at any tier; unset reads as fully researched and is not counted. Building groups means a product's buildings split into more than one group. Game sync means a factory has been marked in sync with the game at some point.",
     [query("sort_desc(sum by (feature) (sf_room_feature_plans%s) / ignoring(feature) group_left sum(sf_rooms_total%s))" % (J, J), "{{feature}}", instant=True)],
     bargauge(display_name="${__field.labels.feature}", unit="percentunit", minmax=(0, 1)))
 

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -6542,7 +6542,7 @@
         "spec": {
           "id": 130,
           "title": "Plans Using Each Feature",
-          "description": "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target, depot settings and groups are plan-level; everything else is any factory in the plan. Depot settings means somebody answered the MAM research tiers, at any tier; unset reads as fully researched and is not counted.",
+          "description": "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target, depot settings and groups are plan-level; everything else is any factory in the plan. Depot settings means somebody answered the MAM research tiers, at any tier; unset reads as fully researched and is not counted. Building groups means a product's buildings split into more than one group. Game sync means a factory has been marked in sync with the game at some point.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -6954,12 +6954,54 @@
                       },
                       "spec": {
                         "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"building_groups\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Building groups",
+                        "range": true
+                      }
+                    },
+                    "refId": "K",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"game_sync\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Game sync",
+                        "range": true
+                      }
+                    },
+                    "refId": "L",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
                         "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories-preview\",feature=\"custom_buildings\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
                         "legendFormat": "Custom buildings",
                         "range": true
                       }
                     },
-                    "refId": "K",
+                    "refId": "M",
                     "hidden": false
                   }
                 },
@@ -6980,7 +7022,7 @@
                         "range": true
                       }
                     },
-                    "refId": "L",
+                    "refId": "N",
                     "hidden": false
                   }
                 }
@@ -7302,12 +7344,54 @@
                       },
                       "spec": {
                         "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"building_groups\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Building groups",
+                        "range": true
+                      }
+                    },
+                    "refId": "K",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"game_sync\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
+                        "legendFormat": "Game sync",
+                        "range": true
+                      }
+                    },
+                    "refId": "L",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
                         "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories-preview\",feature=\"custom_buildings\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories-preview\"})",
                         "legendFormat": "Custom buildings",
                         "range": true
                       }
                     },
-                    "refId": "K",
+                    "refId": "M",
                     "hidden": false
                   }
                 },
@@ -7328,7 +7412,7 @@
                         "range": true
                       }
                     },
-                    "refId": "L",
+                    "refId": "N",
                     "hidden": false
                   }
                 }

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -6542,7 +6542,7 @@
         "spec": {
           "id": 130,
           "title": "Plans Using Each Feature",
-          "description": "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target, depot settings and groups are plan-level; everything else is any factory in the plan. Depot settings means somebody answered the MAM research tiers, at any tier; unset reads as fully researched and is not counted.",
+          "description": "Share of live synced plans using each feature at all. A plan counts once however many of its factories use it. Power target, depot settings and groups are plan-level; everything else is any factory in the plan. Depot settings means somebody answered the MAM research tiers, at any tier; unset reads as fully researched and is not counted. Building groups means a product's buildings split into more than one group. Game sync means a factory has been marked in sync with the game at some point.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -6954,12 +6954,54 @@
                       },
                       "spec": {
                         "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"building_groups\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Building groups",
+                        "range": true
+                      }
+                    },
+                    "refId": "K",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"game_sync\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Game sync",
+                        "range": true
+                      }
+                    },
+                    "refId": "L",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
                         "expr": "sum(sf_room_feature_plans{job=\"satisfactory-factories\",feature=\"custom_buildings\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
                         "legendFormat": "Custom buildings",
                         "range": true
                       }
                     },
-                    "refId": "K",
+                    "refId": "M",
                     "hidden": false
                   }
                 },
@@ -6980,7 +7022,7 @@
                         "range": true
                       }
                     },
-                    "refId": "L",
+                    "refId": "N",
                     "hidden": false
                   }
                 }
@@ -7302,12 +7344,54 @@
                       },
                       "spec": {
                         "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"building_groups\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Building groups",
+                        "range": true
+                      }
+                    },
+                    "refId": "K",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"game_sync\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
+                        "legendFormat": "Game sync",
+                        "range": true
+                      }
+                    },
+                    "refId": "L",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
                         "expr": "sum(sf_room_feature_factories{job=\"satisfactory-factories\",feature=\"custom_buildings\"}) / sum(sf_room_factories_total{job=\"satisfactory-factories\"})",
                         "legendFormat": "Custom buildings",
                         "range": true
                       }
                     },
-                    "refId": "K",
+                    "refId": "M",
                     "hidden": false
                   }
                 },
@@ -7328,7 +7412,7 @@
                         "range": true
                       }
                     },
-                    "refId": "L",
+                    "refId": "N",
                     "hidden": false
                   }
                 }


### PR DESCRIPTION
No manual steps. Both dashboards are already re-applied; the two new bars read "No data" until this deploys.

Two more features in the utilisation gauges:

- **Building groups**: a factory counts once any single product or power producer has more than one building group. Every product starts with exactly one, so a factory with several products each on their default group is not a use; only a split is. Checked under products and under power producers.
- **Game sync**: a factory counts when `inSync` is a boolean. `null` means the "in sync with the game" feature was never used on it; `true` or `false` means it was, whether or not it is still in sync.

`inSync` joins the metrics projection. Specs cover the single-group default, a split product, a split generator, `inSync` at null/true/false and as a string.

Validation: common feature specs 52/52, backend metrics-usage 82/82, lint clean, dashboards regenerated and applied from the generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)