### PR TITLE
docs(grafana): say collaboration where the dashboard said shared

### DIFF
--- a/docs/grafana/generate.py
+++ b/docs/grafana/generate.py
@@ -218,7 +218,7 @@ add(1, "Browsers",
     stat([{"value": 0, "color": "#6a6a6a"}, {"value": 1, "color": "green"}], color_mode="value", text_mode="value_and_name"))
 
 add(6, "Browsers and Sockets",
-    "Every browser with the planner open, by whether somebody is at it, against the realtime sockets held open. Sockets are only opened by signed-in users and shared-link visitors, so the gap is local-only planning.",
+    "Every browser with the planner open, by whether somebody is at it, against the realtime sockets held open. Sockets are only opened by signed-in users and invite-link visitors, so the gap is local-only planning.",
     [query('sum(sf_active_clients%s)' % sel('state="active"'), "Active browsers", "A"),
      query('sum(sf_active_clients%s)' % sel('state="idle"'), "Idle browsers", "B"),
      query("sum(sf_ws_connections%s)" % J, "Sockets", "C")],
@@ -321,14 +321,14 @@ add(31, "Synced Plans",
     [query("sum(sf_rooms_total%s)" % J, "Synced plans")],
     stat(BLUE))
 
-add(32, "Shared Plans",
-    "Synced plans that have an invite link allocated.",
-    [query('sum(sf_rooms_total%s)' % sel('shared="true"'), "Shared")],
+add(32, "Collaborative Plans",
+    "Synced plans that have an invite link allocated, so other accounts can join and edit. Not share links, which are snapshots.",
+    [query('sum(sf_rooms_total%s)' % sel('shared="true"'), "Collaborative")],
     stat([{"value": 0, "color": "blue"}]))
 
-add(33, "Share Rate",
-    "What fraction of synced plans have been shared with somebody.",
-    [query("sum(sf_rooms_total%s) / sum(sf_rooms_total%s)" % (sel('shared="true"'), J), "Shared")],
+add(33, "Collaboration Rate",
+    "What fraction of synced plans have been opened up to collaborators.",
+    [query("sum(sf_rooms_total%s) / sum(sf_rooms_total%s)" % (sel('shared="true"'), J), "Collaborative")],
     stat([{"value": 0, "color": "blue"}, {"value": 0.1, "color": "green"}],
          unit="percentunit", minmax=(0, 1)))
 
@@ -359,8 +359,9 @@ add(109, "Factories per Synced Plan Over Time",
     timeseries(fill=10, decimals=1))
 
 add(36, "Synced Plans Over Time",
-    "Stacked by whether the plan has an invite link.",
-    [query("sum by (shared) (sf_rooms_total%s)" % J, "{{shared}}")],
+    "Stacked by whether the plan has an invite link for collaborators.",
+    [query('sum(sf_rooms_total%s)' % sel('shared="true"'), "Collaborative", "A"),
+     query('sum(sf_rooms_total%s)' % sel('shared="false"'), "Private", "B")],
     timeseries(fill=25, stack="normal"))
 
 add(37, "Accounts, Plans and Collaborators Over Time",
@@ -548,9 +549,9 @@ add(110, "How Synced Plans Arrived",
      query('sum(sf_room_actions_total%s)' % sel('action="imported"'), "Imported", "C")],
     stat(BLUE, color_mode="value", text_mode="value_and_name"))
 
-add(111, "Plans Ever Shared",
-    "Times somebody turned a plan into a collaborative one by allocating an invite link. A plan shared, unshared and shared again counts twice, because that is two decisions to share.",
-    [query('sum(sf_room_actions_total%s)' % sel('action="shared"'), "Shared")],
+add(111, "Plans Ever Collaborated",
+    "Times somebody turned a plan into a collaborative one by allocating an invite link. A plan opened, closed and opened again counts twice, because that is two decisions to collaborate.",
+    [query('sum(sf_room_actions_total%s)' % sel('action="shared"'), "Collaborated")],
     stat(GREEN, graph="area", color_mode="background_solid"))
 
 add(112, "Invites Accepted",
@@ -572,7 +573,7 @@ add(114, "New Plans",
     stat(BLUE, color_mode="value", text_mode="value_and_name"))
 
 add(115, "Invites Accepted Recently",
-    "Invites accepted inside each rolling window, counted off the membership rows. Same caveat as New Plans: somebody who joined and then left, or who was dropped when the owner unshared, is not in it.",
+    "Invites accepted inside each rolling window, counted off the membership rows. Same caveat as New Plans: somebody who joined and then left, or who was dropped when the owner closed collaboration, is not in it.",
     [query('sum(sf_new_memberships%s)' % sel('window="24h"'), "24 hours", "A"),
      query('sum(sf_new_memberships%s)' % sel('window="7d"'), "7 days", "B"),
      query('sum(sf_new_memberships%s)' % sel('window="30d"'), "30 days", "C")],
@@ -582,8 +583,8 @@ LIFECYCLE_ACTIONS = [
     ("created", "Created"),
     ("adopted", "Adopted (local tab upgraded to cloud)"),
     ("imported", "Imported (old cloud sync restored)"),
-    ("shared", "Shared"),
-    ("unshared", "Unshared"),
+    ("shared", "Collaboration opened"),
+    ("unshared", "Collaboration closed"),
     ("joined", "Invite accepted"),
     ("left", "Left"),
     ("deleted", "Deleted"),

--- a/docs/grafana/satisfactory-factories-preview.json
+++ b/docs/grafana/satisfactory-factories-preview.json
@@ -142,7 +142,7 @@
         "spec": {
           "id": 6,
           "title": "Browsers and Sockets",
-          "description": "Every browser with the planner open, by whether somebody is at it, against the realtime sockets held open. Sockets are only opened by signed-in users and shared-link visitors, so the gap is local-only planning.",
+          "description": "Every browser with the planner open, by whether somebody is at it, against the realtime sockets held open. Sockets are only opened by signed-in users and invite-link visitors, so the gap is local-only planning.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -2020,8 +2020,8 @@
         "kind": "Panel",
         "spec": {
           "id": 32,
-          "title": "Shared Plans",
-          "description": "Synced plans that have an invite link allocated.",
+          "title": "Collaborative Plans",
+          "description": "Synced plans that have an invite link allocated, so other accounts can join and edit. Not share links, which are snapshots.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -2040,7 +2040,7 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_rooms_total{job=\"satisfactory-factories-preview\",shared=\"true\"})",
-                        "legendFormat": "Shared",
+                        "legendFormat": "Collaborative",
                         "range": true
                       }
                     },
@@ -2101,8 +2101,8 @@
         "kind": "Panel",
         "spec": {
           "id": 33,
-          "title": "Share Rate",
-          "description": "What fraction of synced plans have been shared with somebody.",
+          "title": "Collaboration Rate",
+          "description": "What fraction of synced plans have been opened up to collaborators.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -2121,7 +2121,7 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_rooms_total{job=\"satisfactory-factories-preview\",shared=\"true\"}) / sum(sf_rooms_total{job=\"satisfactory-factories-preview\"})",
-                        "legendFormat": "Shared",
+                        "legendFormat": "Collaborative",
                         "range": true
                       }
                     },
@@ -2689,7 +2689,7 @@
         "spec": {
           "id": 36,
           "title": "Synced Plans Over Time",
-          "description": "Stacked by whether the plan has an invite link.",
+          "description": "Stacked by whether the plan has an invite link for collaborators.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -2707,12 +2707,33 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (shared) (sf_rooms_total{job=\"satisfactory-factories-preview\"})",
-                        "legendFormat": "{{shared}}",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories-preview\",shared=\"true\"})",
+                        "legendFormat": "Collaborative",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories-preview\",shared=\"false\"})",
+                        "legendFormat": "Private",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
                     "hidden": false
                   }
                 }
@@ -5786,8 +5807,8 @@
         "kind": "Panel",
         "spec": {
           "id": 111,
-          "title": "Plans Ever Shared",
-          "description": "Times somebody turned a plan into a collaborative one by allocating an invite link. A plan shared, unshared and shared again counts twice, because that is two decisions to share.",
+          "title": "Plans Ever Collaborated",
+          "description": "Times somebody turned a plan into a collaborative one by allocating an invite link. A plan opened, closed and opened again counts twice, because that is two decisions to collaborate.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -5806,7 +5827,7 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories-preview\",action=\"shared\"})",
-                        "legendFormat": "Shared",
+                        "legendFormat": "Collaborated",
                         "range": true
                       }
                     },
@@ -6157,7 +6178,7 @@
         "spec": {
           "id": 115,
           "title": "Invites Accepted Recently",
-          "description": "Invites accepted inside each rolling window, counted off the membership rows. Same caveat as New Plans: somebody who joined and then left, or who was dropped when the owner unshared, is not in it.",
+          "description": "Invites accepted inside each rolling window, counted off the membership rows. Same caveat as New Plans: somebody who joined and then left, or who was dropped when the owner closed collaboration, is not in it.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -6362,7 +6383,7 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories-preview\",action=\"shared\"})",
-                        "legendFormat": "Shared",
+                        "legendFormat": "Collaboration opened",
                         "range": true
                       }
                     },
@@ -6383,7 +6404,7 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories-preview\",action=\"unshared\"})",
-                        "legendFormat": "Unshared",
+                        "legendFormat": "Collaboration closed",
                         "range": true
                       }
                     },

--- a/docs/grafana/satisfactory-factories.json
+++ b/docs/grafana/satisfactory-factories.json
@@ -142,7 +142,7 @@
         "spec": {
           "id": 6,
           "title": "Browsers and Sockets",
-          "description": "Every browser with the planner open, by whether somebody is at it, against the realtime sockets held open. Sockets are only opened by signed-in users and shared-link visitors, so the gap is local-only planning.",
+          "description": "Every browser with the planner open, by whether somebody is at it, against the realtime sockets held open. Sockets are only opened by signed-in users and invite-link visitors, so the gap is local-only planning.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -2020,8 +2020,8 @@
         "kind": "Panel",
         "spec": {
           "id": 32,
-          "title": "Shared Plans",
-          "description": "Synced plans that have an invite link allocated.",
+          "title": "Collaborative Plans",
+          "description": "Synced plans that have an invite link allocated, so other accounts can join and edit. Not share links, which are snapshots.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -2040,7 +2040,7 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_rooms_total{job=\"satisfactory-factories\",shared=\"true\"})",
-                        "legendFormat": "Shared",
+                        "legendFormat": "Collaborative",
                         "range": true
                       }
                     },
@@ -2101,8 +2101,8 @@
         "kind": "Panel",
         "spec": {
           "id": 33,
-          "title": "Share Rate",
-          "description": "What fraction of synced plans have been shared with somebody.",
+          "title": "Collaboration Rate",
+          "description": "What fraction of synced plans have been opened up to collaborators.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -2121,7 +2121,7 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_rooms_total{job=\"satisfactory-factories\",shared=\"true\"}) / sum(sf_rooms_total{job=\"satisfactory-factories\"})",
-                        "legendFormat": "Shared",
+                        "legendFormat": "Collaborative",
                         "range": true
                       }
                     },
@@ -2689,7 +2689,7 @@
         "spec": {
           "id": 36,
           "title": "Synced Plans Over Time",
-          "description": "Stacked by whether the plan has an invite link.",
+          "description": "Stacked by whether the plan has an invite link for collaborators.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -2707,12 +2707,33 @@
                       },
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum by (shared) (sf_rooms_total{job=\"satisfactory-factories\"})",
-                        "legendFormat": "{{shared}}",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories\",shared=\"true\"})",
+                        "legendFormat": "Collaborative",
                         "range": true
                       }
                     },
                     "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "prometheus"
+                      },
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sf_rooms_total{job=\"satisfactory-factories\",shared=\"false\"})",
+                        "legendFormat": "Private",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
                     "hidden": false
                   }
                 }
@@ -5786,8 +5807,8 @@
         "kind": "Panel",
         "spec": {
           "id": 111,
-          "title": "Plans Ever Shared",
-          "description": "Times somebody turned a plan into a collaborative one by allocating an invite link. A plan shared, unshared and shared again counts twice, because that is two decisions to share.",
+          "title": "Plans Ever Collaborated",
+          "description": "Times somebody turned a plan into a collaborative one by allocating an invite link. A plan opened, closed and opened again counts twice, because that is two decisions to collaborate.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -5806,7 +5827,7 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories\",action=\"shared\"})",
-                        "legendFormat": "Shared",
+                        "legendFormat": "Collaborated",
                         "range": true
                       }
                     },
@@ -6157,7 +6178,7 @@
         "spec": {
           "id": 115,
           "title": "Invites Accepted Recently",
-          "description": "Invites accepted inside each rolling window, counted off the membership rows. Same caveat as New Plans: somebody who joined and then left, or who was dropped when the owner unshared, is not in it.",
+          "description": "Invites accepted inside each rolling window, counted off the membership rows. Same caveat as New Plans: somebody who joined and then left, or who was dropped when the owner closed collaboration, is not in it.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -6362,7 +6383,7 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories\",action=\"shared\"})",
-                        "legendFormat": "Shared",
+                        "legendFormat": "Collaboration opened",
                         "range": true
                       }
                     },
@@ -6383,7 +6404,7 @@
                       "spec": {
                         "editorMode": "code",
                         "expr": "sum(sf_room_actions_total{job=\"satisfactory-factories\",action=\"unshared\"})",
-                        "legendFormat": "Unshared",
+                        "legendFormat": "Collaboration closed",
                         "range": true
                       }
                     },


### PR DESCRIPTION
No manual steps. Both dashboards are already re-applied from the generator.

The dashboard used "shared" for two different things: a plan with an invite link (collaboration) and a share link (a snapshot). Everything about the former now says collaboration, so it no longer reads as sharing:

- Shared Plans → Collaborative Plans; Share Rate → Collaboration Rate
- Synced Plans Over Time stacks Collaborative / Private rather than `true` / `false`
- Plans Ever Shared → Plans Ever Collaborated
- Plan Lifecycle legends: Collaboration opened / Collaboration closed
- Descriptions that said "unshared" or "shared-link visitors"

The Share Links row, `sf_shares_total` and `sf_share_opens` are unchanged: those really are share links. Metric names and labels are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)